### PR TITLE
Implement multi-tenant OAuth2 routing and management UI

### DIFF
--- a/src/main/java/com/stucray/limen/identity/AuthUserDetailsService.java
+++ b/src/main/java/com/stucray/limen/identity/AuthUserDetailsService.java
@@ -1,5 +1,6 @@
 package com.stucray.limen.identity;
 
+import com.stucray.limen.tenant.TenantRepository;
 import com.stucray.limen.user.UserRepository;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
@@ -10,18 +11,28 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+/**
+ * UserDetailsService for the OAuth2 authorization code flow login page.
+ * Scoped to the system tenant until per-tenant OAuth2 routing is wired up in a later slice.
+ */
 @Service
 public class AuthUserDetailsService implements UserDetailsService {
 
+    private final TenantRepository tenantRepository;
     private final UserRepository userRepository;
 
-    public AuthUserDetailsService(UserRepository userRepository) {
+    public AuthUserDetailsService(TenantRepository tenantRepository, UserRepository userRepository) {
+        this.tenantRepository = tenantRepository;
         this.userRepository = userRepository;
     }
 
     @Override
     public UserDetails loadUserByUsername(String username) {
-        return userRepository.findByUsername(username)
+        Long systemTenantId = tenantRepository.findBySlug(UserBootstrap.SYSTEM_SLUG)
+            .orElseThrow(() -> new UsernameNotFoundException(username))
+            .id();
+
+        return userRepository.findByUsernameAndTenantId(username, systemTenantId)
             .map(user -> new User(
                 user.username(),
                 user.passwordHash(),

--- a/src/main/java/com/stucray/limen/identity/UserBootstrap.java
+++ b/src/main/java/com/stucray/limen/identity/UserBootstrap.java
@@ -1,42 +1,61 @@
 package com.stucray.limen.identity;
 
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.tenant.TenantStatus;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
 @Component
 public class UserBootstrap implements CommandLineRunner {
 
+    static final String SYSTEM_SLUG = "system";
+    static final String SYSTEM_DISPLAY_NAME = "System";
+
     private final String adminUsername;
     private final String adminPassword;
+    private final TenantRepository tenantRepository;
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
     public UserBootstrap(
-        @Value("${OVERROUND_ADMIN_USERNAME:#{null}}") String adminUsername,
-        @Value("${OVERROUND_ADMIN_PASSWORD:#{null}}") String adminPassword,
+        @Value("${LIMEN_ADMIN_USERNAME:#{null}}") String adminUsername,
+        @Value("${LIMEN_ADMIN_PASSWORD:#{null}}") String adminPassword,
+        TenantRepository tenantRepository,
         UserRepository userRepository,
         PasswordEncoder passwordEncoder
     ) {
         this.adminUsername = adminUsername;
         this.adminPassword = adminPassword;
+        this.tenantRepository = tenantRepository;
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
     }
 
     @Override
+    @Transactional
     public void run(String... args) {
+        Tenant systemTenant = tenantRepository.findBySlug(SYSTEM_SLUG)
+            .orElseGet(() -> tenantRepository.save(
+                new Tenant(null, SYSTEM_SLUG, SYSTEM_DISPLAY_NAME, TenantStatus.ACTIVE, LocalDateTime.now())
+            ));
+
         if (adminUsername == null || adminPassword == null) return;
 
         String hash = passwordEncoder.encode(adminPassword);
-        userRepository.findByUsername(adminUsername).ifPresentOrElse(
-            existing -> userRepository.save(existing.withPasswordHash(hash)),
-            () -> userRepository.save(new User(null, adminUsername, hash, true, LocalDateTime.now()))
-        );
+        userRepository.findByUsernameAndTenantId(adminUsername, systemTenant.id())
+            .ifPresentOrElse(
+                existing -> userRepository.save(existing.withPasswordHash(hash).withMustChangePassword(false)),
+                () -> userRepository.save(
+                    new User(null, systemTenant.id(), adminUsername, hash, true, false, false, LocalDateTime.now())
+                )
+            );
     }
 }

--- a/src/main/java/com/stucray/limen/management/applications/Application.java
+++ b/src/main/java/com/stucray/limen/management/applications/Application.java
@@ -1,0 +1,23 @@
+package com.stucray.limen.management.applications;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+
+@Table("applications")
+public record Application(
+    @Id Long id,
+    Long tenantId,
+    String name,
+    String description,
+    LocalDateTime createdAt
+) {
+    public Application withName(String newName) {
+        return new Application(id, tenantId, newName, description, createdAt);
+    }
+
+    public Application withDescription(String newDescription) {
+        return new Application(id, tenantId, name, newDescription, createdAt);
+    }
+}

--- a/src/main/java/com/stucray/limen/management/applications/ApplicationController.java
+++ b/src/main/java/com/stucray/limen/management/applications/ApplicationController.java
@@ -1,0 +1,97 @@
+package com.stucray.limen.management.applications;
+
+import com.stucray.limen.management.auth.TenantUserDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+@Controller
+@RequestMapping("/manage/t/{slug}/applications")
+public class ApplicationController {
+
+    private final ApplicationService applicationService;
+
+    public ApplicationController(ApplicationService applicationService) {
+        this.applicationService = applicationService;
+    }
+
+    @GetMapping
+    public String list(
+        @PathVariable String slug,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        Model model
+    ) {
+        model.addAttribute("slug", slug);
+        model.addAttribute("applications", applicationService.listApplications(principal.tenantId()));
+        return "manage/applications/list";
+    }
+
+    @GetMapping("/new")
+    public String newForm(@PathVariable String slug, Model model) {
+        model.addAttribute("slug", slug);
+        return "manage/applications/new";
+    }
+
+    @PostMapping
+    public String create(
+        @PathVariable String slug,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        @RequestParam String name,
+        @RequestParam(required = false) String description,
+        Model model
+    ) {
+        try {
+            applicationService.createApplication(principal.tenantId(), name, description);
+            return "redirect:/manage/t/" + slug + "/applications";
+        } catch (IllegalArgumentException e) {
+            model.addAttribute("slug", slug);
+            model.addAttribute("errorMessage", e.getMessage());
+            model.addAttribute("name", name);
+            model.addAttribute("description", description);
+            return "manage/applications/new";
+        }
+    }
+
+    @GetMapping("/{appId}/edit")
+    public String editForm(
+        @PathVariable String slug,
+        @PathVariable Long appId,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        Model model
+    ) {
+        model.addAttribute("slug", slug);
+        model.addAttribute("application", applicationService.getApplication(appId, principal.tenantId()));
+        return "manage/applications/edit";
+    }
+
+    @PostMapping("/{appId}/edit")
+    public String update(
+        @PathVariable String slug,
+        @PathVariable Long appId,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        @RequestParam String name,
+        @RequestParam(required = false) String description
+    ) {
+        applicationService.updateApplication(appId, principal.tenantId(), name, description);
+        return "redirect:/manage/t/" + slug + "/applications";
+    }
+
+    @PostMapping("/{appId}/delete")
+    public String delete(
+        @PathVariable String slug,
+        @PathVariable Long appId,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        Model model
+    ) {
+        try {
+            applicationService.deleteApplication(appId, principal.tenantId());
+            return "redirect:/manage/t/" + slug + "/applications";
+        } catch (IllegalStateException e) {
+            model.addAttribute("slug", slug);
+            model.addAttribute("applications", applicationService.listApplications(principal.tenantId()));
+            model.addAttribute("errorMessage", e.getMessage());
+            return "manage/applications/list";
+        }
+    }
+}

--- a/src/main/java/com/stucray/limen/management/applications/ApplicationRepository.java
+++ b/src/main/java/com/stucray/limen/management/applications/ApplicationRepository.java
@@ -1,0 +1,12 @@
+package com.stucray.limen.management.applications;
+
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ApplicationRepository extends CrudRepository<Application, Long> {
+    List<Application> findAllByTenantId(Long tenantId);
+    Optional<Application> findByIdAndTenantId(Long id, Long tenantId);
+    boolean existsByNameAndTenantId(String name, Long tenantId);
+}

--- a/src/main/java/com/stucray/limen/management/applications/ApplicationService.java
+++ b/src/main/java/com/stucray/limen/management/applications/ApplicationService.java
@@ -1,0 +1,54 @@
+package com.stucray.limen.management.applications;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class ApplicationService {
+
+    private final ApplicationRepository applicationRepository;
+    private final JdbcTemplate jdbcTemplate;
+
+    public ApplicationService(ApplicationRepository applicationRepository, JdbcTemplate jdbcTemplate) {
+        this.applicationRepository = applicationRepository;
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public List<Application> listApplications(Long tenantId) {
+        return applicationRepository.findAllByTenantId(tenantId);
+    }
+
+    public Application getApplication(Long appId, Long tenantId) {
+        return applicationRepository.findByIdAndTenantId(appId, tenantId)
+            .orElseThrow(() -> new IllegalArgumentException("Application not found"));
+    }
+
+    public Application createApplication(Long tenantId, String name, String description) {
+        if (applicationRepository.existsByNameAndTenantId(name, tenantId)) {
+            throw new IllegalArgumentException("An application named '" + name + "' already exists in this tenant");
+        }
+        return applicationRepository.save(
+            new Application(null, tenantId, name, description, LocalDateTime.now())
+        );
+    }
+
+    public void updateApplication(Long appId, Long tenantId, String name, String description) {
+        Application app = getApplication(appId, tenantId);
+        applicationRepository.save(app.withName(name).withDescription(description));
+    }
+
+    public void deleteApplication(Long appId, Long tenantId) {
+        Application app = getApplication(appId, tenantId);
+        Integer clientCount = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM oauth2_registered_client WHERE application_id = ?",
+            Integer.class, appId
+        );
+        if (clientCount != null && clientCount > 0) {
+            throw new IllegalStateException("Cannot delete application with attached Clients");
+        }
+        applicationRepository.delete(app);
+    }
+}

--- a/src/main/java/com/stucray/limen/management/auth/ManagementSecurityConfig.java
+++ b/src/main/java/com/stucray/limen/management/auth/ManagementSecurityConfig.java
@@ -1,0 +1,73 @@
+package com.stucray.limen.management.auth;
+
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.user.UserRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
+
+@Configuration
+@Order(2)
+public class ManagementSecurityConfig {
+
+    private final TenantRepository tenantRepository;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public ManagementSecurityConfig(
+        TenantRepository tenantRepository,
+        UserRepository userRepository,
+        PasswordEncoder passwordEncoder
+    ) {
+        this.tenantRepository = tenantRepository;
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Bean
+    public SecurityFilterChain managementFilterChain(HttpSecurity http) throws Exception {
+        TenantAuthProvider provider = new TenantAuthProvider(tenantRepository, userRepository, passwordEncoder);
+        TenantAuthFilter authFilter = new TenantAuthFilter(new ProviderManager(provider));
+        authFilter.setSecurityContextRepository(new HttpSessionSecurityContextRepository());
+
+        http
+            .securityMatcher("/manage/**", "/signup")
+            // /manage/system/** is for System Admins; @PreAuthorize enforces role check
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/signup").permitAll()
+                .requestMatchers("/manage/t/*/login").permitAll()
+                .anyRequest().authenticated()
+            )
+            .addFilterAt(authFilter, UsernamePasswordAuthenticationFilter.class)
+            .exceptionHandling(ex -> ex.authenticationEntryPoint(new TenantAuthEntryPoint()))
+            .logout(logout -> logout
+                .logoutUrl("/manage/logout")
+                .logoutSuccessHandler((req, res, auth) -> {
+                    String referer = req.getHeader("Referer");
+                    String redirectUrl = "/manage/t/system/login";
+                    if (referer != null) {
+                        java.util.regex.Matcher m = java.util.regex.Pattern
+                            .compile(".*/manage/t/([^/]+)/.*").matcher(referer);
+                        if (m.matches()) redirectUrl = "/manage/t/" + m.group(1) + "/login";
+                    }
+                    res.sendRedirect(redirectUrl);
+                })
+                .deleteCookies("JSESSIONID")
+                .invalidateHttpSession(true)
+            )
+            .csrf(csrf -> csrf
+                .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                .csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler())
+            );
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/stucray/limen/management/auth/TenantAuthEntryPoint.java
+++ b/src/main/java/com/stucray/limen/management/auth/TenantAuthEntryPoint.java
@@ -1,0 +1,27 @@
+package com.stucray.limen.management.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class TenantAuthEntryPoint implements AuthenticationEntryPoint {
+
+    private static final Pattern SLUG_PATTERN = Pattern.compile("/manage/t/([^/]+)/.*");
+
+    @Override
+    public void commence(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        AuthenticationException authException
+    ) throws IOException {
+        String uri = request.getRequestURI();
+        Matcher matcher = SLUG_PATTERN.matcher(uri);
+        String slug = matcher.matches() ? matcher.group(1) : "system";
+        response.sendRedirect(request.getContextPath() + "/manage/t/" + slug + "/login");
+    }
+}

--- a/src/main/java/com/stucray/limen/management/auth/TenantAuthFilter.java
+++ b/src/main/java/com/stucray/limen/management/auth/TenantAuthFilter.java
@@ -1,0 +1,45 @@
+package com.stucray.limen.management.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
+
+import java.io.IOException;
+
+public class TenantAuthFilter extends AbstractAuthenticationProcessingFilter {
+
+    public TenantAuthFilter(AuthenticationManager authenticationManager) {
+        super(
+            PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.POST, "/manage/t/*/login"),
+            authenticationManager
+        );
+        setAuthenticationSuccessHandler((req, res, auth) -> {
+            String slug = extractSlug(req.getRequestURI());
+            res.sendRedirect(req.getContextPath() + "/manage/t/" + slug + "/");
+        });
+        setAuthenticationFailureHandler((req, res, ex) -> {
+            String slug = extractSlug(req.getRequestURI());
+            res.sendRedirect(req.getContextPath() + "/manage/t/" + slug + "/login?error");
+        });
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
+        throws AuthenticationException, IOException {
+        String slug = extractSlug(request.getRequestURI());
+        String username = request.getParameter("username");
+        String password = request.getParameter("password");
+        return getAuthenticationManager().authenticate(new TenantAuthToken(slug, username, password));
+    }
+
+    private static String extractSlug(String uri) {
+        // /manage/t/{slug}/login → parts: ["", "manage", "t", "{slug}", "login"]
+        String[] parts = uri.split("/");
+        return parts[3];
+    }
+}

--- a/src/main/java/com/stucray/limen/management/auth/TenantAuthProvider.java
+++ b/src/main/java/com/stucray/limen/management/auth/TenantAuthProvider.java
@@ -1,0 +1,64 @@
+package com.stucray.limen.management.auth;
+
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.tenant.TenantStatus;
+import com.stucray.limen.user.User;
+import com.stucray.limen.user.UserRepository;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+public class TenantAuthProvider implements AuthenticationProvider {
+
+    private final TenantRepository tenantRepository;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public TenantAuthProvider(
+        TenantRepository tenantRepository,
+        UserRepository userRepository,
+        PasswordEncoder passwordEncoder
+    ) {
+        this.tenantRepository = tenantRepository;
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        TenantAuthToken token = (TenantAuthToken) authentication;
+        String slug = token.getTenantSlug();
+        String username = (String) token.getPrincipal();
+        String rawPassword = (String) token.getCredentials();
+
+        Tenant tenant = tenantRepository.findBySlug(slug)
+            .orElseThrow(() -> new BadCredentialsException("Invalid credentials"));
+
+        if (tenant.status() == TenantStatus.SUSPENDED) {
+            throw new DisabledException("Tenant is suspended");
+        }
+
+        User user = userRepository.findByUsernameAndTenantId(username, tenant.id())
+            .orElseThrow(() -> new BadCredentialsException("Invalid credentials"));
+
+        if (!user.enabled()) {
+            throw new DisabledException("User account is disabled");
+        }
+
+        if (!passwordEncoder.matches(rawPassword, user.passwordHash())) {
+            throw new BadCredentialsException("Invalid credentials");
+        }
+
+        TenantUserDetails details = new TenantUserDetails(user, tenant);
+        return new TenantAuthToken(slug, details, details.getAuthorities());
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return TenantAuthToken.class.isAssignableFrom(authentication);
+    }
+}

--- a/src/main/java/com/stucray/limen/management/auth/TenantAuthToken.java
+++ b/src/main/java/com/stucray/limen/management/auth/TenantAuthToken.java
@@ -1,0 +1,27 @@
+package com.stucray.limen.management.auth;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+public final class TenantAuthToken extends UsernamePasswordAuthenticationToken {
+
+    private final String tenantSlug;
+
+    /** Unauthenticated — used when submitting credentials. */
+    public TenantAuthToken(String tenantSlug, String username, String password) {
+        super(username, password);
+        this.tenantSlug = tenantSlug;
+    }
+
+    /** Authenticated — returned by the AuthenticationProvider after successful verification. */
+    public TenantAuthToken(String tenantSlug, TenantUserDetails principal, Collection<? extends GrantedAuthority> authorities) {
+        super(principal, null, authorities);
+        this.tenantSlug = tenantSlug;
+    }
+
+    public String getTenantSlug() {
+        return tenantSlug;
+    }
+}

--- a/src/main/java/com/stucray/limen/management/auth/TenantUserDetails.java
+++ b/src/main/java/com/stucray/limen/management/auth/TenantUserDetails.java
@@ -1,0 +1,53 @@
+package com.stucray.limen.management.auth;
+
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.user.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+public final class TenantUserDetails implements UserDetails {
+
+    private final User user;
+    private final Tenant tenant;
+
+    public TenantUserDetails(User user, Tenant tenant) {
+        this.user = user;
+        this.tenant = tenant;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        if (tenant.isSystem()) {
+            return List.of(new SimpleGrantedAuthority("ROLE_SYSTEM_ADMIN"));
+        }
+        return List.of(new SimpleGrantedAuthority("ROLE_TENANT_OWNER"));
+    }
+
+    @Override
+    public String getPassword() {
+        return user.passwordHash();
+    }
+
+    /** Returns "{tenantSlug}:{username}" — used as the identity key in the security context. */
+    @Override
+    public String getUsername() {
+        return tenant.slug() + ":" + user.username();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return user.enabled();
+    }
+
+    public String tenantSlug() { return tenant.slug(); }
+    public Long tenantId()     { return tenant.id(); }
+    public Long userId()       { return user.id(); }
+    public String displayUsername() { return user.username(); }
+    public boolean mustChangePassword() { return user.mustChangePassword(); }
+    public Tenant tenant() { return tenant; }
+    public User user()     { return user; }
+}

--- a/src/main/java/com/stucray/limen/management/clients/ClientManagementController.java
+++ b/src/main/java/com/stucray/limen/management/clients/ClientManagementController.java
@@ -1,0 +1,123 @@
+package com.stucray.limen.management.clients;
+
+import com.stucray.limen.management.applications.ApplicationService;
+import com.stucray.limen.management.auth.TenantUserDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Controller
+@RequestMapping("/manage/t/{slug}/applications/{appId}/clients")
+public class ClientManagementController {
+
+    private final ClientManagementService clientManagementService;
+    private final ApplicationService applicationService;
+
+    public ClientManagementController(
+        ClientManagementService clientManagementService,
+        ApplicationService applicationService
+    ) {
+        this.clientManagementService = clientManagementService;
+        this.applicationService = applicationService;
+    }
+
+    @GetMapping
+    public String list(
+        @PathVariable String slug,
+        @PathVariable Long appId,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        Model model
+    ) {
+        model.addAttribute("slug", slug);
+        model.addAttribute("application", applicationService.getApplication(appId, principal.tenantId()));
+        model.addAttribute("clients", clientManagementService.listClients(appId, principal.tenantId()));
+        return "manage/clients/list";
+    }
+
+    @GetMapping("/new")
+    public String newClientForm(
+        @PathVariable String slug,
+        @PathVariable Long appId,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        Model model
+    ) {
+        model.addAttribute("slug", slug);
+        model.addAttribute("application", applicationService.getApplication(appId, principal.tenantId()));
+        return "manage/clients/new";
+    }
+
+    @PostMapping
+    public String createClient(
+        @PathVariable String slug,
+        @PathVariable Long appId,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        @RequestParam String displayName,
+        @RequestParam(required = false) String[] grantTypes,
+        @RequestParam(required = false) String redirectUris,
+        @RequestParam(required = false) String postLogoutRedirectUris,
+        @RequestParam(required = false) String scopes,
+        @RequestParam(defaultValue = "false") boolean requirePkce,
+        @RequestParam(defaultValue = "true") boolean confidential,
+        RedirectAttributes redirectAttributes
+    ) {
+        Set<AuthorizationGrantType> grants = grantTypes == null ? Set.of() :
+            Arrays.stream(grantTypes)
+                .map(AuthorizationGrantType::new)
+                .collect(Collectors.toSet());
+
+        Set<String> redirectUriSet = parseLines(redirectUris);
+        Set<String> postLogoutSet = parseLines(postLogoutRedirectUris);
+        Set<String> scopeSet = parseLines(scopes);
+
+        ClientManagementService.ClientCreationResult result = clientManagementService.createClient(
+            appId, principal.tenantId(), displayName, grants, redirectUriSet, postLogoutSet, scopeSet, requirePkce, confidential
+        );
+
+        if (result.rawSecret() != null) {
+            redirectAttributes.addFlashAttribute("clientSecret", result.rawSecret());
+            redirectAttributes.addFlashAttribute("clientId", result.client().registeredClientId());
+        }
+
+        return "redirect:/manage/t/" + slug + "/applications/" + appId + "/clients";
+    }
+
+    @PostMapping("/{registeredClientId}/delete")
+    public String deleteClient(
+        @PathVariable String slug,
+        @PathVariable Long appId,
+        @PathVariable String registeredClientId,
+        @AuthenticationPrincipal TenantUserDetails principal
+    ) {
+        clientManagementService.deleteClient(registeredClientId, principal.tenantId());
+        return "redirect:/manage/t/" + slug + "/applications/" + appId + "/clients";
+    }
+
+    @PostMapping("/{registeredClientId}/rotate-secret")
+    public String rotateSecret(
+        @PathVariable String slug,
+        @PathVariable Long appId,
+        @PathVariable String registeredClientId,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        RedirectAttributes redirectAttributes
+    ) {
+        ClientManagementService.SecretRotationResult result = clientManagementService.rotateSecret(registeredClientId, principal.tenantId());
+        redirectAttributes.addFlashAttribute("clientSecret", result.rawSecret());
+        redirectAttributes.addFlashAttribute("clientId", registeredClientId);
+        return "redirect:/manage/t/" + slug + "/applications/" + appId + "/clients";
+    }
+
+    private static Set<String> parseLines(String input) {
+        if (input == null || input.isBlank()) return Set.of();
+        return Arrays.stream(input.split("[\n,]+"))
+            .map(String::trim)
+            .filter(s -> !s.isBlank())
+            .collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/com/stucray/limen/management/clients/ClientManagementService.java
+++ b/src/main/java/com/stucray/limen/management/clients/ClientManagementService.java
@@ -1,0 +1,123 @@
+package com.stucray.limen.management.clients;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
+import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+public class ClientManagementService {
+
+    private final RegisteredClientRepository registeredClientRepository;
+    private final TenantClientRepository tenantClientRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public ClientManagementService(
+        RegisteredClientRepository registeredClientRepository,
+        TenantClientRepository tenantClientRepository,
+        PasswordEncoder passwordEncoder
+    ) {
+        this.registeredClientRepository = registeredClientRepository;
+        this.tenantClientRepository = tenantClientRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public List<TenantClient> listClients(Long applicationId, Long tenantId) {
+        return tenantClientRepository.findAllByApplicationIdAndTenantId(applicationId, tenantId);
+    }
+
+    public record ClientCreationResult(TenantClient client, String rawSecret) {}
+
+    public ClientCreationResult createClient(
+        Long applicationId, Long tenantId,
+        String clientName,
+        Set<AuthorizationGrantType> grantTypes,
+        Set<String> redirectUris,
+        Set<String> postLogoutRedirectUris,
+        Set<String> scopes,
+        boolean requirePkce,
+        boolean confidential
+    ) {
+        String rawSecret = null;
+        String hashedSecret = null;
+        if (confidential) {
+            rawSecret = generateSecret();
+            hashedSecret = passwordEncoder.encode(rawSecret);
+        }
+
+        RegisteredClient.Builder builder = RegisteredClient.withId(UUID.randomUUID().toString())
+            .clientId(UUID.randomUUID().toString())
+            .clientName(clientName)
+            .clientSettings(ClientSettings.builder()
+                .requireProofKey(requirePkce || !confidential)
+                .requireAuthorizationConsent(true)
+                .build());
+
+        if (hashedSecret != null) {
+            builder.clientSecret(hashedSecret)
+                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_POST);
+        } else {
+            builder.clientAuthenticationMethod(ClientAuthenticationMethod.NONE);
+        }
+
+        grantTypes.forEach(builder::authorizationGrantType);
+        redirectUris.stream().filter(u -> !u.isBlank()).forEach(builder::redirectUri);
+        postLogoutRedirectUris.stream().filter(u -> !u.isBlank()).forEach(builder::postLogoutRedirectUri);
+        scopes.stream().filter(s -> !s.isBlank()).forEach(builder::scope);
+
+        RegisteredClient registered = builder.build();
+        registeredClientRepository.save(registered);
+
+        TenantClient tenantClient = tenantClientRepository.save(new TenantClient(
+            null, registered.getId(), applicationId, tenantId, clientName, confidential
+        ));
+
+        return new ClientCreationResult(tenantClient, rawSecret);
+    }
+
+    public TenantClient getClient(String registeredClientId, Long tenantId) {
+        return tenantClientRepository.findByRegisteredClientIdAndTenantId(registeredClientId, tenantId)
+            .orElseThrow(() -> new IllegalArgumentException("Client not found"));
+    }
+
+    public void deleteClient(String registeredClientId, Long tenantId) {
+        TenantClient tenantClient = getClient(registeredClientId, tenantId);
+        RegisteredClient rc = registeredClientRepository.findById(registeredClientId);
+        if (rc != null) {
+            // Spring's JdbcRegisteredClientRepository has no delete method; we use the low-level approach
+            tenantClientRepository.delete(tenantClient);
+            tenantClientRepository.deleteRegisteredClient(registeredClientId);
+        }
+    }
+
+    public record SecretRotationResult(String rawSecret) {}
+
+    public SecretRotationResult rotateSecret(String registeredClientId, Long tenantId) {
+        getClient(registeredClientId, tenantId); // assert ownership
+        RegisteredClient existing = registeredClientRepository.findById(registeredClientId);
+        if (existing == null) throw new IllegalArgumentException("Client not found");
+
+        String rawSecret = generateSecret();
+        RegisteredClient updated = RegisteredClient.from(existing)
+            .clientSecret(passwordEncoder.encode(rawSecret))
+            .build();
+        registeredClientRepository.save(updated);
+        return new SecretRotationResult(rawSecret);
+    }
+
+    private static String generateSecret() {
+        byte[] bytes = new byte[32];
+        new SecureRandom().nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+}

--- a/src/main/java/com/stucray/limen/management/clients/TenantClient.java
+++ b/src/main/java/com/stucray/limen/management/clients/TenantClient.java
@@ -1,0 +1,14 @@
+package com.stucray.limen.management.clients;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table("client_metadata")
+public record TenantClient(
+    @Id Long id,
+    String registeredClientId,
+    Long applicationId,
+    Long tenantId,
+    String displayName,
+    boolean confidential
+) {}

--- a/src/main/java/com/stucray/limen/management/clients/TenantClientRepository.java
+++ b/src/main/java/com/stucray/limen/management/clients/TenantClientRepository.java
@@ -1,0 +1,18 @@
+package com.stucray.limen.management.clients;
+
+import org.springframework.data.jdbc.repository.query.Modifying;
+import org.springframework.data.jdbc.repository.query.Query;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TenantClientRepository extends CrudRepository<TenantClient, Long> {
+    List<TenantClient> findAllByApplicationIdAndTenantId(Long applicationId, Long tenantId);
+    Optional<TenantClient> findByRegisteredClientId(String registeredClientId);
+    Optional<TenantClient> findByRegisteredClientIdAndTenantId(String registeredClientId, Long tenantId);
+
+    @Modifying
+    @Query("DELETE FROM oauth2_registered_client WHERE id = :registeredClientId")
+    void deleteRegisteredClient(String registeredClientId);
+}

--- a/src/main/java/com/stucray/limen/management/signup/SignupController.java
+++ b/src/main/java/com/stucray/limen/management/signup/SignupController.java
@@ -1,0 +1,45 @@
+package com.stucray.limen.management.signup;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+public class SignupController {
+
+    private final SignupService signupService;
+
+    public SignupController(SignupService signupService) {
+        this.signupService = signupService;
+    }
+
+    @GetMapping("/signup")
+    public String signupForm(Model model) {
+        model.addAttribute("form", new SignupForm("", "", "", ""));
+        return "signup";
+    }
+
+    @PostMapping("/signup")
+    public String signup(
+        @RequestParam String organizationName,
+        @RequestParam String slug,
+        @RequestParam String username,
+        @RequestParam String password,
+        Model model
+    ) {
+        SignupForm form = new SignupForm(organizationName, slug, username, password);
+        SignupService.SignupResult result = signupService.signup(form);
+
+        if (result instanceof SignupService.SignupResult.Success success) {
+            return "redirect:/manage/t/" + success.slug() + "/login?registered";
+        }
+
+        SignupService.SignupResult.Error error = (SignupService.SignupResult.Error) result;
+        model.addAttribute("form", form);
+        model.addAttribute("errorField", error.field());
+        model.addAttribute("errorMessage", error.message());
+        return "signup";
+    }
+}

--- a/src/main/java/com/stucray/limen/management/signup/SignupForm.java
+++ b/src/main/java/com/stucray/limen/management/signup/SignupForm.java
@@ -1,0 +1,8 @@
+package com.stucray.limen.management.signup;
+
+public record SignupForm(
+    String organizationName,
+    String slug,
+    String username,
+    String password
+) {}

--- a/src/main/java/com/stucray/limen/management/signup/SignupService.java
+++ b/src/main/java/com/stucray/limen/management/signup/SignupService.java
@@ -1,0 +1,88 @@
+package com.stucray.limen.management.signup;
+
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.tenant.TenantStatus;
+import com.stucray.limen.user.User;
+import com.stucray.limen.user.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+@Service
+public class SignupService {
+
+    private static final Pattern SLUG_FORMAT = Pattern.compile("^[a-z0-9][a-z0-9-]{1,46}[a-z0-9]$");
+    private static final Set<String> RESERVED_SLUGS = Set.of(
+        "system", "admin", "manage", "api", "www", "static", "health", "limen"
+    );
+
+    private final TenantRepository tenantRepository;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public SignupService(
+        TenantRepository tenantRepository,
+        UserRepository userRepository,
+        PasswordEncoder passwordEncoder
+    ) {
+        this.tenantRepository = tenantRepository;
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public sealed interface SignupResult {
+        record Success(String slug) implements SignupResult {}
+        record Error(String field, String message) implements SignupResult {}
+    }
+
+    @Transactional
+    public SignupResult signup(SignupForm form) {
+        String slug = form.slug() == null ? "" : form.slug().trim();
+
+        if (slug.length() < 3 || slug.length() > 48) {
+            return new SignupResult.Error("slug", "Slug must be between 3 and 48 characters");
+        }
+        if (!SLUG_FORMAT.matcher(slug).matches()) {
+            return new SignupResult.Error("slug", "Slug may only contain lowercase letters, digits, and hyphens, and must start and end with a letter or digit");
+        }
+        if (RESERVED_SLUGS.contains(slug)) {
+            return new SignupResult.Error("slug", "That slug is reserved and cannot be used");
+        }
+        if (tenantRepository.existsBySlug(slug)) {
+            return new SignupResult.Error("slug", "That slug is already taken");
+        }
+
+        String orgName = form.organizationName() == null ? "" : form.organizationName().trim();
+        if (orgName.isBlank()) {
+            return new SignupResult.Error("organizationName", "Organization name is required");
+        }
+
+        String username = form.username() == null ? "" : form.username().trim();
+        if (username.isBlank()) {
+            return new SignupResult.Error("username", "Username is required");
+        }
+        if (username.length() > 100) {
+            return new SignupResult.Error("username", "Username must be 100 characters or fewer");
+        }
+
+        if (form.password() == null || form.password().length() < 8) {
+            return new SignupResult.Error("password", "Password must be at least 8 characters");
+        }
+
+        Tenant tenant = tenantRepository.save(
+            new Tenant(null, slug, orgName, TenantStatus.ACTIVE, LocalDateTime.now())
+        );
+        userRepository.save(new User(
+            null, tenant.id(), username,
+            passwordEncoder.encode(form.password()),
+            true, false, true, LocalDateTime.now()
+        ));
+
+        return new SignupResult.Success(slug);
+    }
+}

--- a/src/main/java/com/stucray/limen/management/system/SystemAdminController.java
+++ b/src/main/java/com/stucray/limen/management/system/SystemAdminController.java
@@ -1,0 +1,77 @@
+package com.stucray.limen.management.system;
+
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.tenant.TenantStatus;
+import com.stucray.limen.user.UserRepository;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@Controller
+@RequestMapping("/manage/system")
+@PreAuthorize("hasRole('SYSTEM_ADMIN')")
+public class SystemAdminController {
+
+    private final TenantRepository tenantRepository;
+    private final UserRepository userRepository;
+    private final JdbcTemplate jdbcTemplate;
+
+    public SystemAdminController(
+        TenantRepository tenantRepository,
+        UserRepository userRepository,
+        JdbcTemplate jdbcTemplate
+    ) {
+        this.tenantRepository = tenantRepository;
+        this.userRepository = userRepository;
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @GetMapping("/tenants")
+    public String listTenants(Model model) {
+        model.addAttribute("tenants", tenantRepository.findAll());
+        return "manage/system/tenants";
+    }
+
+    @PostMapping("/tenants/{tenantId}/suspend")
+    public String suspendTenant(
+        @PathVariable Long tenantId,
+        RedirectAttributes redirectAttributes
+    ) {
+        Tenant tenant = tenantRepository.findById(tenantId)
+            .orElseThrow(() -> new IllegalArgumentException("Tenant not found"));
+        if (tenant.isSystem()) {
+            redirectAttributes.addFlashAttribute("errorMessage", "The system tenant cannot be suspended");
+            return "redirect:/manage/system/tenants";
+        }
+        tenantRepository.save(tenant.withStatus(TenantStatus.SUSPENDED));
+        return "redirect:/manage/system/tenants";
+    }
+
+    @PostMapping("/tenants/{tenantId}/unsuspend")
+    public String unsuspendTenant(@PathVariable Long tenantId) {
+        Tenant tenant = tenantRepository.findById(tenantId)
+            .orElseThrow(() -> new IllegalArgumentException("Tenant not found"));
+        tenantRepository.save(tenant.withStatus(TenantStatus.ACTIVE));
+        return "redirect:/manage/system/tenants";
+    }
+
+    @PostMapping("/tenants/{tenantId}/delete")
+    public String deleteTenant(
+        @PathVariable Long tenantId,
+        RedirectAttributes redirectAttributes
+    ) {
+        Tenant tenant = tenantRepository.findById(tenantId)
+            .orElseThrow(() -> new IllegalArgumentException("Tenant not found"));
+        if (tenant.isSystem()) {
+            redirectAttributes.addFlashAttribute("errorMessage", "The system tenant cannot be deleted");
+            return "redirect:/manage/system/tenants";
+        }
+        // Cascade handled by FK ON DELETE CASCADE on users, applications, etc.
+        tenantRepository.delete(tenant);
+        return "redirect:/manage/system/tenants";
+    }
+}

--- a/src/main/java/com/stucray/limen/management/system/TenantDetailsController.java
+++ b/src/main/java/com/stucray/limen/management/system/TenantDetailsController.java
@@ -1,0 +1,40 @@
+package com.stucray.limen.management.system;
+
+import com.stucray.limen.management.auth.TenantUserDetails;
+import com.stucray.limen.tenant.TenantRepository;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+@Controller
+@RequestMapping("/manage/t/{slug}/settings")
+public class TenantDetailsController {
+
+    private final TenantRepository tenantRepository;
+
+    public TenantDetailsController(TenantRepository tenantRepository) {
+        this.tenantRepository = tenantRepository;
+    }
+
+    @GetMapping
+    public String settings(
+        @PathVariable String slug,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        Model model
+    ) {
+        model.addAttribute("slug", slug);
+        model.addAttribute("tenant", principal.tenant());
+        return "manage/settings";
+    }
+
+    @PostMapping("/display-name")
+    public String updateDisplayName(
+        @PathVariable String slug,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        @RequestParam String displayName
+    ) {
+        tenantRepository.save(principal.tenant().withDisplayName(displayName));
+        return "redirect:/manage/t/" + slug + "/settings";
+    }
+}

--- a/src/main/java/com/stucray/limen/management/users/PasswordChangeController.java
+++ b/src/main/java/com/stucray/limen/management/users/PasswordChangeController.java
@@ -1,0 +1,48 @@
+package com.stucray.limen.management.users;
+
+import com.stucray.limen.management.auth.TenantUserDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+public class PasswordChangeController {
+
+    private final UserManagementService userManagementService;
+
+    public PasswordChangeController(UserManagementService userManagementService) {
+        this.userManagementService = userManagementService;
+    }
+
+    @GetMapping("/manage/t/{slug}/change-password")
+    public String changePasswordForm(@PathVariable String slug, Model model) {
+        model.addAttribute("slug", slug);
+        return "manage/users/change-password";
+    }
+
+    @PostMapping("/manage/t/{slug}/change-password")
+    public String changePassword(
+        @PathVariable String slug,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        @RequestParam String newPassword,
+        @RequestParam String confirmPassword,
+        Model model
+    ) {
+        if (!newPassword.equals(confirmPassword)) {
+            model.addAttribute("slug", slug);
+            model.addAttribute("errorMessage", "Passwords do not match");
+            return "manage/users/change-password";
+        }
+        if (newPassword.length() < 8) {
+            model.addAttribute("slug", slug);
+            model.addAttribute("errorMessage", "Password must be at least 8 characters");
+            return "manage/users/change-password";
+        }
+        userManagementService.changePassword(principal.userId(), principal.tenantId(), newPassword);
+        return "redirect:/manage/t/" + slug + "/";
+    }
+}

--- a/src/main/java/com/stucray/limen/management/users/PasswordChangeRequiredInterceptor.java
+++ b/src/main/java/com/stucray/limen/management/users/PasswordChangeRequiredInterceptor.java
@@ -1,0 +1,32 @@
+package com.stucray.limen.management.users;
+
+import com.stucray.limen.management.auth.TenantUserDetails;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+/**
+ * Redirects users with mustChangePassword=true to the password change form
+ * before they can access any management console page.
+ */
+public class PasswordChangeRequiredInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated()) return true;
+        if (!(auth.getPrincipal() instanceof TenantUserDetails details)) return true;
+        if (!details.mustChangePassword()) return true;
+
+        String uri = request.getRequestURI();
+        String changePasswordUrl = "/manage/t/" + details.tenantSlug() + "/change-password";
+
+        // Allow access to the change-password page and logout to avoid redirect loops
+        if (uri.equals(changePasswordUrl) || uri.endsWith("/logout")) return true;
+
+        response.sendRedirect(changePasswordUrl);
+        return false;
+    }
+}

--- a/src/main/java/com/stucray/limen/management/users/UserManagementController.java
+++ b/src/main/java/com/stucray/limen/management/users/UserManagementController.java
@@ -1,0 +1,127 @@
+package com.stucray.limen.management.users;
+
+import com.stucray.limen.management.auth.TenantUserDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+@Controller
+@RequestMapping("/manage/t/{slug}/users")
+public class UserManagementController {
+
+    private final UserManagementService userManagementService;
+
+    public UserManagementController(UserManagementService userManagementService) {
+        this.userManagementService = userManagementService;
+    }
+
+    @GetMapping
+    public String list(
+        @PathVariable String slug,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        Model model
+    ) {
+        model.addAttribute("slug", slug);
+        model.addAttribute("users", userManagementService.listUsers(principal.tenantId()));
+        return "manage/users/list";
+    }
+
+    @GetMapping("/new")
+    public String newUserForm(@PathVariable String slug, Model model) {
+        model.addAttribute("slug", slug);
+        return "manage/users/new";
+    }
+
+    @PostMapping
+    public String createUser(
+        @PathVariable String slug,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        @RequestParam String username,
+        @RequestParam String temporaryPassword,
+        Model model
+    ) {
+        try {
+            userManagementService.createUser(principal.tenantId(), username, temporaryPassword);
+            return "redirect:/manage/t/" + slug + "/users";
+        } catch (IllegalArgumentException e) {
+            model.addAttribute("slug", slug);
+            model.addAttribute("errorMessage", e.getMessage());
+            model.addAttribute("username", username);
+            return "manage/users/new";
+        }
+    }
+
+    @PostMapping("/{userId}/enable")
+    public String enable(
+        @PathVariable String slug,
+        @PathVariable Long userId,
+        @AuthenticationPrincipal TenantUserDetails principal
+    ) {
+        userManagementService.setEnabled(userId, principal.tenantId(), true);
+        return "redirect:/manage/t/" + slug + "/users";
+    }
+
+    @PostMapping("/{userId}/disable")
+    public String disable(
+        @PathVariable String slug,
+        @PathVariable Long userId,
+        @AuthenticationPrincipal TenantUserDetails principal
+    ) {
+        userManagementService.setEnabled(userId, principal.tenantId(), false);
+        return "redirect:/manage/t/" + slug + "/users";
+    }
+
+    @PostMapping("/{userId}/delete")
+    public String delete(
+        @PathVariable String slug,
+        @PathVariable Long userId,
+        @AuthenticationPrincipal TenantUserDetails principal
+    ) {
+        userManagementService.deleteUser(userId, principal.tenantId());
+        return "redirect:/manage/t/" + slug + "/users";
+    }
+
+    @GetMapping("/{userId}/reset-password")
+    public String resetPasswordForm(
+        @PathVariable String slug,
+        @PathVariable Long userId,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        Model model
+    ) {
+        model.addAttribute("slug", slug);
+        model.addAttribute("user", userManagementService.getUser(userId, principal.tenantId()));
+        return "manage/users/reset-password";
+    }
+
+    @PostMapping("/{userId}/reset-password")
+    public String resetPassword(
+        @PathVariable String slug,
+        @PathVariable Long userId,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        @RequestParam String temporaryPassword
+    ) {
+        userManagementService.resetPassword(userId, principal.tenantId(), temporaryPassword);
+        return "redirect:/manage/t/" + slug + "/users";
+    }
+
+    @PostMapping("/{userId}/grant-owner")
+    public String grantOwner(
+        @PathVariable String slug,
+        @PathVariable Long userId,
+        @AuthenticationPrincipal TenantUserDetails principal
+    ) {
+        userManagementService.setTenantOwner(userId, principal.tenantId(), true);
+        return "redirect:/manage/t/" + slug + "/users";
+    }
+
+    @PostMapping("/{userId}/revoke-owner")
+    public String revokeOwner(
+        @PathVariable String slug,
+        @PathVariable Long userId,
+        @AuthenticationPrincipal TenantUserDetails principal
+    ) {
+        userManagementService.setTenantOwner(userId, principal.tenantId(), false);
+        return "redirect:/manage/t/" + slug + "/users";
+    }
+}

--- a/src/main/java/com/stucray/limen/management/users/UserManagementService.java
+++ b/src/main/java/com/stucray/limen/management/users/UserManagementService.java
@@ -1,0 +1,70 @@
+package com.stucray.limen.management.users;
+
+import com.stucray.limen.user.User;
+import com.stucray.limen.user.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class UserManagementService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public UserManagementService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public List<User> listUsers(Long tenantId) {
+        return userRepository.findAllByTenantId(tenantId);
+    }
+
+    public void createUser(Long tenantId, String username, String temporaryPassword) {
+        if (userRepository.existsByUsernameAndTenantId(username, tenantId)) {
+            throw new IllegalArgumentException("Username already exists in this tenant");
+        }
+        userRepository.save(new User(
+            null, tenantId, username,
+            passwordEncoder.encode(temporaryPassword),
+            true, true, false, LocalDateTime.now()
+        ));
+    }
+
+    public User getUser(Long userId, Long tenantId) {
+        return userRepository.findById(userId)
+            .filter(u -> u.tenantId().equals(tenantId))
+            .orElseThrow(() -> new IllegalArgumentException("User not found"));
+    }
+
+    public void setEnabled(Long userId, Long tenantId, boolean enabled) {
+        User user = getUser(userId, tenantId);
+        userRepository.save(user.withEnabled(enabled));
+    }
+
+    public void deleteUser(Long userId, Long tenantId) {
+        User user = getUser(userId, tenantId);
+        userRepository.delete(user);
+    }
+
+    public void resetPassword(Long userId, Long tenantId, String temporaryPassword) {
+        User user = getUser(userId, tenantId);
+        userRepository.save(user.withPasswordHash(passwordEncoder.encode(temporaryPassword)));
+    }
+
+    public void changePassword(Long userId, Long tenantId, String newPassword) {
+        User user = getUser(userId, tenantId);
+        userRepository.save(user
+            .withPasswordHash(passwordEncoder.encode(newPassword))
+            .withMustChangePassword(false)
+        );
+    }
+
+    public void setTenantOwner(Long userId, Long tenantId, boolean isTenantOwner) {
+        User user = getUser(userId, tenantId);
+        userRepository.save(user.withTenantOwner(isTenantOwner));
+    }
+}

--- a/src/main/java/com/stucray/limen/management/web/ManagementHomeController.java
+++ b/src/main/java/com/stucray/limen/management/web/ManagementHomeController.java
@@ -1,0 +1,25 @@
+package com.stucray.limen.management.web;
+
+import com.stucray.limen.management.auth.TenantUserDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Controller
+public class ManagementHomeController {
+
+    @GetMapping("/manage/t/{slug}/")
+    public String home(
+        @PathVariable String slug,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        Model model
+    ) {
+        model.addAttribute("slug", slug);
+        model.addAttribute("tenantName", principal.tenant().displayName());
+        model.addAttribute("username", principal.displayUsername());
+        model.addAttribute("isSystemAdmin", principal.tenant().isSystem());
+        return "manage/home";
+    }
+}

--- a/src/main/java/com/stucray/limen/management/web/ManagementLoginController.java
+++ b/src/main/java/com/stucray/limen/management/web/ManagementLoginController.java
@@ -1,0 +1,29 @@
+package com.stucray.limen.management.web;
+
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Controller
+public class ManagementLoginController {
+
+    private final TenantRepository tenantRepository;
+
+    public ManagementLoginController(TenantRepository tenantRepository) {
+        this.tenantRepository = tenantRepository;
+    }
+
+    @GetMapping("/manage/t/{slug}/login")
+    public String loginPage(@PathVariable String slug, Model model) {
+        Tenant tenant = tenantRepository.findBySlug(slug).orElse(null);
+        if (tenant == null) {
+            return "redirect:/signup";
+        }
+        model.addAttribute("slug", slug);
+        model.addAttribute("tenantName", tenant.displayName());
+        return "manage/login";
+    }
+}

--- a/src/main/java/com/stucray/limen/management/web/ManagementWebConfig.java
+++ b/src/main/java/com/stucray/limen/management/web/ManagementWebConfig.java
@@ -1,0 +1,18 @@
+package com.stucray.limen.management.web;
+
+import com.stucray.limen.management.users.PasswordChangeRequiredInterceptor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class ManagementWebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new TenantAccessInterceptor())
+            .addPathPatterns("/manage/t/**");
+        registry.addInterceptor(new PasswordChangeRequiredInterceptor())
+            .addPathPatterns("/manage/t/**");
+    }
+}

--- a/src/main/java/com/stucray/limen/management/web/TenantAccessInterceptor.java
+++ b/src/main/java/com/stucray/limen/management/web/TenantAccessInterceptor.java
@@ -1,0 +1,39 @@
+package com.stucray.limen.management.web;
+
+import com.stucray.limen.management.auth.TenantUserDetails;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Rejects requests where the URL tenant slug does not match the authenticated user's tenant.
+ * Prevents a user authenticated for tenant A from accessing tenant B's management pages.
+ */
+public class TenantAccessInterceptor implements HandlerInterceptor {
+
+    private static final Pattern SLUG_PATTERN = Pattern.compile("/manage/t/([^/]+)/.*");
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String uri = request.getRequestURI();
+        Matcher matcher = SLUG_PATTERN.matcher(uri);
+        if (!matcher.matches()) return true;
+
+        String urlSlug = matcher.group(1);
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated()) return true;
+
+        if (auth.getPrincipal() instanceof TenantUserDetails details) {
+            if (!details.tenantSlug().equals(urlSlug)) {
+                response.sendError(HttpServletResponse.SC_FORBIDDEN);
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/stucray/limen/oauth2/TenantAwareRegisteredClientRepository.java
+++ b/src/main/java/com/stucray/limen/oauth2/TenantAwareRegisteredClientRepository.java
@@ -1,0 +1,51 @@
+package com.stucray.limen.oauth2;
+
+import com.stucray.limen.management.clients.TenantClientRepository;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+
+/**
+ * Wraps JdbcRegisteredClientRepository and rejects lookups for clients that do not
+ * belong to the tenant currently set in TenantContext.
+ */
+public class TenantAwareRegisteredClientRepository implements RegisteredClientRepository {
+
+    private final RegisteredClientRepository delegate;
+    private final TenantClientRepository tenantClientRepository;
+
+    public TenantAwareRegisteredClientRepository(
+        RegisteredClientRepository delegate,
+        TenantClientRepository tenantClientRepository
+    ) {
+        this.delegate = delegate;
+        this.tenantClientRepository = tenantClientRepository;
+    }
+
+    @Override
+    public void save(RegisteredClient registeredClient) {
+        delegate.save(registeredClient);
+    }
+
+    @Override
+    public RegisteredClient findById(String id) {
+        RegisteredClient rc = delegate.findById(id);
+        return checkTenantOwnership(rc);
+    }
+
+    @Override
+    public RegisteredClient findByClientId(String clientId) {
+        RegisteredClient rc = delegate.findByClientId(clientId);
+        return checkTenantOwnership(rc);
+    }
+
+    private RegisteredClient checkTenantOwnership(RegisteredClient rc) {
+        if (rc == null) return null;
+        Long currentTenantId = TenantContext.getTenantId();
+        if (currentTenantId == null) return rc; // non-tenant context (e.g. management console)
+
+        boolean owned = tenantClientRepository
+            .findByRegisteredClientIdAndTenantId(rc.getId(), currentTenantId)
+            .isPresent();
+        return owned ? rc : null;
+    }
+}

--- a/src/main/java/com/stucray/limen/oauth2/TenantContext.java
+++ b/src/main/java/com/stucray/limen/oauth2/TenantContext.java
@@ -1,0 +1,31 @@
+package com.stucray.limen.oauth2;
+
+/**
+ * Thread-local holder for the OAuth2 tenant context set during per-tenant request routing.
+ */
+public final class TenantContext {
+
+    private record Data(String slug, Long tenantId) {}
+
+    private static final ThreadLocal<Data> HOLDER = new ThreadLocal<>();
+
+    private TenantContext() {}
+
+    public static void set(String slug, Long tenantId) {
+        HOLDER.set(new Data(slug, tenantId));
+    }
+
+    public static String getSlug() {
+        Data d = HOLDER.get();
+        return d != null ? d.slug() : null;
+    }
+
+    public static Long getTenantId() {
+        Data d = HOLDER.get();
+        return d != null ? d.tenantId() : null;
+    }
+
+    public static void clear() {
+        HOLDER.remove();
+    }
+}

--- a/src/main/java/com/stucray/limen/oauth2/TenantIssuerContextFilter.java
+++ b/src/main/java/com/stucray/limen/oauth2/TenantIssuerContextFilter.java
@@ -1,0 +1,63 @@
+package com.stucray.limen.oauth2;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.oauth2.server.authorization.context.AuthorizationServerContext;
+import org.springframework.security.oauth2.server.authorization.context.AuthorizationServerContextHolder;
+import org.springframework.security.oauth2.server.authorization.settings.AuthorizationServerSettings;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * Runs inside the SAS security filter chain, after AuthorizationServerContextFilter has
+ * populated AuthorizationServerContextHolder with the default (non-tenant) issuer. For
+ * tenant-routed requests, overwrites the context with the correct per-tenant issuer URL
+ * so that discovery documents and tokens carry the right issuer claim.
+ */
+public class TenantIssuerContextFilter extends OncePerRequestFilter {
+
+    private final AuthorizationServerSettings baseSettings;
+
+    public TenantIssuerContextFilter(AuthorizationServerSettings baseSettings) {
+        this.baseSettings = baseSettings;
+    }
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request, HttpServletResponse response, FilterChain chain
+    ) throws ServletException, IOException {
+        String slug = TenantContext.getSlug();
+        if (slug != null) {
+            String issuer = buildBaseUrl(request) + "/t/" + slug;
+            AuthorizationServerSettings tenantSettings = AuthorizationServerSettings.builder()
+                .issuer(issuer)
+                .authorizationEndpoint(baseSettings.getAuthorizationEndpoint())
+                .pushedAuthorizationRequestEndpoint(baseSettings.getPushedAuthorizationRequestEndpoint())
+                .deviceAuthorizationEndpoint(baseSettings.getDeviceAuthorizationEndpoint())
+                .deviceVerificationEndpoint(baseSettings.getDeviceVerificationEndpoint())
+                .tokenEndpoint(baseSettings.getTokenEndpoint())
+                .tokenRevocationEndpoint(baseSettings.getTokenRevocationEndpoint())
+                .tokenIntrospectionEndpoint(baseSettings.getTokenIntrospectionEndpoint())
+                .jwkSetEndpoint(baseSettings.getJwkSetEndpoint())
+                .oidcLogoutEndpoint(baseSettings.getOidcLogoutEndpoint())
+                .oidcUserInfoEndpoint(baseSettings.getOidcUserInfoEndpoint())
+                .oidcClientRegistrationEndpoint(baseSettings.getOidcClientRegistrationEndpoint())
+                .build();
+            AuthorizationServerContextHolder.setContext(new AuthorizationServerContext() {
+                @Override public String getIssuer() { return issuer; }
+                @Override public AuthorizationServerSettings getAuthorizationServerSettings() { return tenantSettings; }
+            });
+        }
+        chain.doFilter(request, response);
+    }
+
+    private static String buildBaseUrl(HttpServletRequest request) {
+        int port = request.getServerPort();
+        String scheme = request.getScheme();
+        boolean isDefault = ("http".equals(scheme) && port == 80) || ("https".equals(scheme) && port == 443);
+        return scheme + "://" + request.getServerName() + (isDefault ? "" : ":" + port) + request.getContextPath();
+    }
+}

--- a/src/main/java/com/stucray/limen/oauth2/TenantOAuth2RequestWrapper.java
+++ b/src/main/java/com/stucray/limen/oauth2/TenantOAuth2RequestWrapper.java
@@ -1,0 +1,42 @@
+package com.stucray.limen.oauth2;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+
+/**
+ * Strips the leading /t/{slug} segment from the request URI so that Spring Authorization Server
+ * sees standard endpoint paths like /oauth2/token instead of /t/acme/oauth2/token.
+ */
+public class TenantOAuth2RequestWrapper extends HttpServletRequestWrapper {
+
+    private final String strippedUri;
+    private final String strippedServletPath;
+
+    public TenantOAuth2RequestWrapper(HttpServletRequest request, String slug) {
+        super(request);
+        String prefix = "/t/" + slug;
+        String originalUri = request.getRequestURI();
+        this.strippedUri = originalUri.startsWith(prefix)
+            ? originalUri.substring(prefix.length())
+            : originalUri;
+        String originalServletPath = request.getServletPath();
+        this.strippedServletPath = originalServletPath.startsWith(prefix)
+            ? originalServletPath.substring(prefix.length())
+            : originalServletPath;
+    }
+
+    @Override
+    public String getRequestURI() {
+        return strippedUri;
+    }
+
+    @Override
+    public String getServletPath() {
+        return strippedServletPath;
+    }
+
+    @Override
+    public String getPathInfo() {
+        return null;
+    }
+}

--- a/src/main/java/com/stucray/limen/oauth2/TenantOAuth2RoutingFilter.java
+++ b/src/main/java/com/stucray/limen/oauth2/TenantOAuth2RoutingFilter.java
@@ -1,0 +1,70 @@
+package com.stucray.limen.oauth2;
+
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.tenant.TenantStatus;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Intercepts requests to /t/{slug}/oauth2/** and /t/{slug}/.well-known/**,
+ * validates and resolves the tenant, stores it in TenantContext, then strips
+ * the /t/{slug} prefix so Spring Authorization Server sees its standard endpoint
+ * paths. TenantIssuerContextFilter (registered inside the SAS security chain)
+ * then sets the per-request AuthorizationServerContext with the correct tenant
+ * issuer URL.
+ */
+@Component
+@Order(Integer.MIN_VALUE + 10)
+public class TenantOAuth2RoutingFilter extends OncePerRequestFilter {
+
+    private static final Pattern TENANT_PATH =
+        Pattern.compile("^/t/([^/]+)/(oauth2|.well-known)/.*");
+
+    private final TenantRepository tenantRepository;
+
+    public TenantOAuth2RoutingFilter(TenantRepository tenantRepository) {
+        this.tenantRepository = tenantRepository;
+    }
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request, HttpServletResponse response, FilterChain chain
+    ) throws ServletException, IOException {
+        String uri = request.getRequestURI();
+        Matcher m = TENANT_PATH.matcher(uri);
+
+        if (!m.matches()) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        String slug = m.group(1);
+        Tenant tenant = tenantRepository.findBySlug(slug).orElse(null);
+
+        if (tenant == null) {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND, "Unknown tenant: " + slug);
+            return;
+        }
+        if (tenant.status() == TenantStatus.SUSPENDED) {
+            response.sendError(HttpServletResponse.SC_FORBIDDEN, "Tenant is suspended");
+            return;
+        }
+
+        TenantContext.set(slug, tenant.id());
+        try {
+            chain.doFilter(new TenantOAuth2RequestWrapper(request, slug), response);
+        } finally {
+            TenantContext.clear();
+        }
+    }
+}

--- a/src/main/java/com/stucray/limen/security/SasConfig.java
+++ b/src/main/java/com/stucray/limen/security/SasConfig.java
@@ -1,5 +1,8 @@
 package com.stucray.limen.security;
 
+import com.stucray.limen.management.clients.TenantClientRepository;
+import com.stucray.limen.oauth2.TenantAwareRegisteredClientRepository;
+import com.stucray.limen.oauth2.TenantIssuerContextFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
@@ -8,6 +11,7 @@ import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.csrf.CsrfFilter;
 import org.springframework.security.oauth2.server.authorization.JdbcOAuth2AuthorizationConsentService;
 import org.springframework.security.oauth2.server.authorization.JdbcOAuth2AuthorizationService;
 import org.springframework.security.oauth2.server.authorization.client.JdbcRegisteredClientRepository;
@@ -40,13 +44,21 @@ public class SasConfig {
                     htmlRequestMatcher(),
                     PathPatternRequestMatcher.withDefaults().matcher("/oauth2/authorize")
                 )
-            ));
+            ))
+            .addFilterBefore(
+                new TenantIssuerContextFilter(authorizationServerSettings()),
+                CsrfFilter.class
+            );
         return http.build();
     }
 
     @Bean
-    public JdbcRegisteredClientRepository registeredClientRepository(JdbcTemplate jdbcTemplate) {
-        return new JdbcRegisteredClientRepository(jdbcTemplate);
+    public RegisteredClientRepository registeredClientRepository(
+        JdbcTemplate jdbcTemplate,
+        TenantClientRepository tenantClientRepository
+    ) {
+        JdbcRegisteredClientRepository jdbcRepo = new JdbcRegisteredClientRepository(jdbcTemplate);
+        return new TenantAwareRegisteredClientRepository(jdbcRepo, tenantClientRepository);
     }
 
     @Bean

--- a/src/main/java/com/stucray/limen/security/SecurityConfig.java
+++ b/src/main/java/com/stucray/limen/security/SecurityConfig.java
@@ -2,7 +2,9 @@ package com.stucray.limen.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.web.SecurityFilterChain;
@@ -15,6 +17,8 @@ import javax.sql.DataSource;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
+@Order(3)
 public class SecurityConfig {
 
     @Bean

--- a/src/main/java/com/stucray/limen/security/SigningKeyProvider.java
+++ b/src/main/java/com/stucray/limen/security/SigningKeyProvider.java
@@ -20,7 +20,7 @@ public class SigningKeyProvider {
 
     private final Path keyPath;
 
-    public SigningKeyProvider(@Value("${OVERROUND_SIGNING_KEY_PATH:./dev-signing-key.jwk}") String keyPath) {
+    public SigningKeyProvider(@Value("${LIMEN_SIGNING_KEY_PATH:./dev-signing-key.jwk}") String keyPath) {
         this.keyPath = Path.of(keyPath);
     }
 

--- a/src/main/java/com/stucray/limen/tenant/Tenant.java
+++ b/src/main/java/com/stucray/limen/tenant/Tenant.java
@@ -1,0 +1,27 @@
+package com.stucray.limen.tenant;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+
+@Table("tenants")
+public record Tenant(
+    @Id Long id,
+    String slug,
+    String displayName,
+    TenantStatus status,
+    LocalDateTime createdAt
+) {
+    public Tenant withDisplayName(String newDisplayName) {
+        return new Tenant(id, slug, newDisplayName, status, createdAt);
+    }
+
+    public Tenant withStatus(TenantStatus newStatus) {
+        return new Tenant(id, slug, displayName, newStatus, createdAt);
+    }
+
+    public boolean isSystem() {
+        return "system".equals(slug);
+    }
+}

--- a/src/main/java/com/stucray/limen/tenant/TenantRepository.java
+++ b/src/main/java/com/stucray/limen/tenant/TenantRepository.java
@@ -1,0 +1,10 @@
+package com.stucray.limen.tenant;
+
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+public interface TenantRepository extends CrudRepository<Tenant, Long> {
+    Optional<Tenant> findBySlug(String slug);
+    boolean existsBySlug(String slug);
+}

--- a/src/main/java/com/stucray/limen/tenant/TenantStatus.java
+++ b/src/main/java/com/stucray/limen/tenant/TenantStatus.java
@@ -1,0 +1,6 @@
+package com.stucray.limen.tenant;
+
+public enum TenantStatus {
+    ACTIVE,
+    SUSPENDED
+}

--- a/src/main/java/com/stucray/limen/user/User.java
+++ b/src/main/java/com/stucray/limen/user/User.java
@@ -8,12 +8,27 @@ import java.time.LocalDateTime;
 @Table("users")
 public record User(
     @Id Long id,
+    Long tenantId,
     String username,
     String passwordHash,
     boolean enabled,
+    boolean mustChangePassword,
+    boolean tenantOwner,
     LocalDateTime createdAt
 ) {
     public User withPasswordHash(String newHash) {
-        return new User(id, username, newHash, enabled, createdAt);
+        return new User(id, tenantId, username, newHash, enabled, true, tenantOwner, createdAt);
+    }
+
+    public User withEnabled(boolean newEnabled) {
+        return new User(id, tenantId, username, passwordHash, newEnabled, mustChangePassword, tenantOwner, createdAt);
+    }
+
+    public User withMustChangePassword(boolean value) {
+        return new User(id, tenantId, username, passwordHash, enabled, value, tenantOwner, createdAt);
+    }
+
+    public User withTenantOwner(boolean value) {
+        return new User(id, tenantId, username, passwordHash, enabled, mustChangePassword, value, createdAt);
     }
 }

--- a/src/main/java/com/stucray/limen/user/UserRepository.java
+++ b/src/main/java/com/stucray/limen/user/UserRepository.java
@@ -2,8 +2,11 @@ package com.stucray.limen.user;
 
 import org.springframework.data.repository.CrudRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends CrudRepository<User, Long> {
-    Optional<User> findByUsername(String username);
+    Optional<User> findByUsernameAndTenantId(String username, Long tenantId);
+    List<User> findAllByTenantId(Long tenantId);
+    boolean existsByUsernameAndTenantId(String username, Long tenantId);
 }

--- a/src/main/resources/db/migration/V5__multi_tenant_schema.sql
+++ b/src/main/resources/db/migration/V5__multi_tenant_schema.sql
@@ -1,0 +1,12 @@
+CREATE TABLE tenants (
+    id           bigserial    PRIMARY KEY,
+    slug         varchar(48)  NOT NULL UNIQUE,
+    display_name varchar(255) NOT NULL,
+    status       varchar(20)  NOT NULL DEFAULT 'ACTIVE',
+    created_at   timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+ALTER TABLE users ADD COLUMN tenant_id          bigint  REFERENCES tenants(id) ON DELETE CASCADE;
+ALTER TABLE users ADD COLUMN must_change_password boolean NOT NULL DEFAULT false;
+ALTER TABLE users DROP CONSTRAINT users_username_key;
+ALTER TABLE users ADD CONSTRAINT users_tenant_username_unique UNIQUE (tenant_id, username);

--- a/src/main/resources/db/migration/V6__user_tenant_owner_flag.sql
+++ b/src/main/resources/db/migration/V6__user_tenant_owner_flag.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN tenant_owner boolean NOT NULL DEFAULT false;

--- a/src/main/resources/db/migration/V7__applications.sql
+++ b/src/main/resources/db/migration/V7__applications.sql
@@ -1,0 +1,10 @@
+CREATE TABLE applications (
+    id          bigserial    PRIMARY KEY,
+    tenant_id   bigint       NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    name        varchar(255) NOT NULL,
+    description text,
+    created_at  timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT applications_tenant_name_unique UNIQUE (tenant_id, name)
+);
+
+ALTER TABLE oauth2_registered_client ADD COLUMN application_id bigint REFERENCES applications(id) ON DELETE CASCADE;

--- a/src/main/resources/db/migration/V8__client_metadata.sql
+++ b/src/main/resources/db/migration/V8__client_metadata.sql
@@ -1,0 +1,8 @@
+CREATE TABLE client_metadata (
+    id                   bigserial    PRIMARY KEY,
+    registered_client_id varchar(100) NOT NULL UNIQUE REFERENCES oauth2_registered_client(id) ON DELETE CASCADE,
+    application_id       bigint       NOT NULL REFERENCES applications(id) ON DELETE CASCADE,
+    tenant_id            bigint       NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    display_name         varchar(255) NOT NULL,
+    confidential         boolean      NOT NULL DEFAULT true
+);

--- a/src/main/resources/templates/manage/applications/edit.html
+++ b/src/main/resources/templates/manage/applications/edit.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head><title>Edit Application</title></head>
+<body>
+<h1>Edit Application</h1>
+<a th:href="@{'/manage/t/' + ${slug} + '/applications'}">← Applications</a>
+
+<form method="post" th:action="@{'/manage/t/' + ${slug} + '/applications/' + ${application.id()} + '/edit'}">
+    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+    <div><label>Name <input type="text" name="name" th:value="${application.name()}" required/></label></div>
+    <div><label>Description <textarea name="description" th:text="${application.description()}"></textarea></label></div>
+    <button type="submit">Save</button>
+</form>
+</body>
+</html>

--- a/src/main/resources/templates/manage/applications/list.html
+++ b/src/main/resources/templates/manage/applications/list.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head><title>Applications</title></head>
+<body>
+<h1>Applications</h1>
+<a th:href="@{'/manage/t/' + ${slug} + '/'}">← Home</a>
+<a th:href="@{'/manage/t/' + ${slug} + '/applications/new'}">New application</a>
+
+<div th:if="${errorMessage}" th:text="${errorMessage}"></div>
+
+<table>
+    <thead>
+        <tr><th>Name</th><th>Description</th><th>Actions</th></tr>
+    </thead>
+    <tbody>
+        <tr th:each="app : ${applications}">
+            <td th:text="${app.name()}"></td>
+            <td th:text="${app.description()}"></td>
+            <td>
+                <a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/edit'}">Edit</a>
+                <a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/clients'}">Clients</a>
+                <form method="post" th:action="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/delete'}" style="display:inline">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                    <button type="submit" onclick="return confirm('Delete this application?')">Delete</button>
+                </form>
+            </td>
+        </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/src/main/resources/templates/manage/applications/new.html
+++ b/src/main/resources/templates/manage/applications/new.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head><title>New Application</title></head>
+<body>
+<h1>New Application</h1>
+<a th:href="@{'/manage/t/' + ${slug} + '/applications'}">← Applications</a>
+
+<div th:if="${errorMessage}" th:text="${errorMessage}"></div>
+
+<form method="post" th:action="@{'/manage/t/' + ${slug} + '/applications'}">
+    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+    <div><label>Name <input type="text" name="name" th:value="${name}" autofocus required/></label></div>
+    <div><label>Description <textarea name="description" th:text="${description}"></textarea></label></div>
+    <button type="submit">Create</button>
+</form>
+</body>
+</html>

--- a/src/main/resources/templates/manage/clients/list.html
+++ b/src/main/resources/templates/manage/clients/list.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head><title>Clients</title></head>
+<body>
+<h1>Clients — <span th:text="${application.name()}"></span></h1>
+<a th:href="@{'/manage/t/' + ${slug} + '/applications'}">← Applications</a>
+<a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${application.id()} + '/clients/new'}">New client</a>
+
+<div th:if="${clientSecret}">
+    <strong>Client secret (shown once):</strong> <code th:text="${clientSecret}"></code><br/>
+    <strong>Client ID:</strong> <code th:text="${clientId}"></code>
+</div>
+
+<table>
+    <thead>
+        <tr><th>Name</th><th>Type</th><th>Actions</th></tr>
+    </thead>
+    <tbody>
+        <tr th:each="client : ${clients}">
+            <td th:text="${client.displayName()}"></td>
+            <td th:text="${client.confidential() ? 'Confidential' : 'Public'}"></td>
+            <td>
+                <form method="post" th:action="@{'/manage/t/' + ${slug} + '/applications/' + ${application.id()} + '/clients/' + ${client.registeredClientId()} + '/rotate-secret'}" style="display:inline" th:if="${client.confidential()}">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                    <button type="submit">Rotate secret</button>
+                </form>
+                <form method="post" th:action="@{'/manage/t/' + ${slug} + '/applications/' + ${application.id()} + '/clients/' + ${client.registeredClientId()} + '/delete'}" style="display:inline">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                    <button type="submit" onclick="return confirm('Delete this client?')">Delete</button>
+                </form>
+            </td>
+        </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/src/main/resources/templates/manage/clients/new.html
+++ b/src/main/resources/templates/manage/clients/new.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head><title>New Client</title></head>
+<body>
+<h1>New Client — <span th:text="${application.name()}"></span></h1>
+<a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${application.id()} + '/clients'}">← Clients</a>
+
+<form method="post" th:action="@{'/manage/t/' + ${slug} + '/applications/' + ${application.id()} + '/clients'}">
+    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+
+    <div><label>Name <input type="text" name="displayName" autofocus required/></label></div>
+
+    <fieldset>
+        <legend>Grant types</legend>
+        <label><input type="checkbox" name="grantTypes" value="authorization_code"/> Authorization code</label>
+        <label><input type="checkbox" name="grantTypes" value="client_credentials"/> Client credentials</label>
+        <label><input type="checkbox" name="grantTypes" value="refresh_token"/> Refresh token</label>
+    </fieldset>
+
+    <div><label>Redirect URIs (one per line)<br/><textarea name="redirectUris" rows="3"></textarea></label></div>
+    <div><label>Post-logout redirect URIs (one per line)<br/><textarea name="postLogoutRedirectUris" rows="2"></textarea></label></div>
+    <div><label>Scopes (space or comma separated)<br/><input type="text" name="scopes" placeholder="openid profile email"/></label></div>
+
+    <div><label><input type="checkbox" name="requirePkce"/> Require PKCE</label></div>
+    <div><label><input type="checkbox" name="confidential" value="true" checked/> Confidential (has client secret)</label></div>
+
+    <button type="submit">Create client</button>
+</form>
+</body>
+</html>

--- a/src/main/resources/templates/manage/home.html
+++ b/src/main/resources/templates/manage/home.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title th:text="|${tenantName} — Limen|">Limen</title>
+</head>
+<body>
+
+<h1 th:text="${tenantName}">Tenant</h1>
+<p>Welcome, <span th:text="${username}">user</span>.</p>
+
+<nav>
+    <ul th:if="${isSystemAdmin}">
+        <li><a th:href="@{'/manage/system/tenants'}">Tenants</a></li>
+    </ul>
+    <ul th:unless="${isSystemAdmin}">
+        <li><a th:href="@{'/manage/t/' + ${slug} + '/users'}">Users</a></li>
+        <li><a th:href="@{'/manage/t/' + ${slug} + '/applications'}">Applications</a></li>
+        <li><a th:href="@{'/manage/t/' + ${slug} + '/settings'}">Tenant Settings</a></li>
+    </ul>
+</nav>
+
+<form method="post" th:action="@{/manage/logout}">
+    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+    <button type="submit">Sign out</button>
+</form>
+
+</body>
+</html>

--- a/src/main/resources/templates/manage/login.html
+++ b/src/main/resources/templates/manage/login.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title th:text="|Sign in — ${tenantName}|">Sign in — Limen</title>
+</head>
+<body>
+
+<h1 th:text="|Sign in to ${tenantName}|">Sign in</h1>
+
+<div th:if="${param.error}">Invalid username or password.</div>
+<div th:if="${param.registered}">Account created — please sign in.</div>
+
+<form method="post" th:action="@{'/manage/t/' + ${slug} + '/login'}">
+    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+
+    <div>
+        <label>
+            Username
+            <input type="text" name="username" autofocus required/>
+        </label>
+    </div>
+
+    <div>
+        <label>
+            Password
+            <input type="password" name="password" required/>
+        </label>
+    </div>
+
+    <button type="submit">Sign in</button>
+</form>
+
+</body>
+</html>

--- a/src/main/resources/templates/manage/settings.html
+++ b/src/main/resources/templates/manage/settings.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head><title th:text="|Settings — ${tenant.displayName()}|">Settings</title></head>
+<body>
+<h1>Tenant Settings</h1>
+<a th:href="@{'/manage/t/' + ${slug} + '/'}">← Home</a>
+
+<section>
+    <h2>Details</h2>
+    <dl>
+        <dt>Slug</dt><dd th:text="${tenant.slug()}"></dd>
+        <dt>Status</dt><dd th:text="${tenant.status()}"></dd>
+        <dt>Created</dt><dd th:text="${#temporals.format(tenant.createdAt(), 'yyyy-MM-dd')}"></dd>
+    </dl>
+</section>
+
+<section>
+    <h2>Display Name</h2>
+    <form method="post" th:action="@{'/manage/t/' + ${slug} + '/settings/display-name'}">
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+        <div>
+            <label>Display name <input type="text" name="displayName" th:value="${tenant.displayName()}" required/></label>
+        </div>
+        <button type="submit">Save</button>
+    </form>
+</section>
+</body>
+</html>

--- a/src/main/resources/templates/manage/system/tenants.html
+++ b/src/main/resources/templates/manage/system/tenants.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head><title>Tenants — System Admin</title></head>
+<body>
+<h1>Tenants</h1>
+<a th:href="@{/manage/t/system/}">← Home</a>
+
+<div th:if="${errorMessage}" th:text="${errorMessage}"></div>
+<div th:if="${successMessage}" th:text="${successMessage}"></div>
+
+<table>
+    <thead>
+        <tr>
+            <th>Slug</th>
+            <th>Display Name</th>
+            <th>Status</th>
+            <th>Created</th>
+            <th>Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr th:each="tenant : ${tenants}">
+            <td th:text="${tenant.slug()}"></td>
+            <td th:text="${tenant.displayName()}"></td>
+            <td th:text="${tenant.status()}"></td>
+            <td th:text="${#temporals.format(tenant.createdAt(), 'yyyy-MM-dd')}"></td>
+            <td th:unless="${tenant.isSystem()}">
+                <form method="post" th:action="@{'/manage/system/tenants/' + ${tenant.id()} + '/suspend'}" style="display:inline" th:if="${tenant.status().name() == 'ACTIVE'}">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                    <button type="submit">Suspend</button>
+                </form>
+                <form method="post" th:action="@{'/manage/system/tenants/' + ${tenant.id()} + '/unsuspend'}" style="display:inline" th:if="${tenant.status().name() == 'SUSPENDED'}">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                    <button type="submit">Unsuspend</button>
+                </form>
+                <form method="post" th:action="@{'/manage/system/tenants/' + ${tenant.id()} + '/delete'}" style="display:inline">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                    <button type="submit" onclick="return confirm('Delete this tenant and all its data?')">Delete</button>
+                </form>
+            </td>
+            <td th:if="${tenant.isSystem()}">—</td>
+        </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/src/main/resources/templates/manage/users/change-password.html
+++ b/src/main/resources/templates/manage/users/change-password.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head><title>Change Password</title></head>
+<body>
+<h1>You must change your password before continuing</h1>
+
+<div th:if="${errorMessage}" th:text="${errorMessage}"></div>
+
+<form method="post" th:action="@{'/manage/t/' + ${slug} + '/change-password'}">
+    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+    <div>
+        <label>New password <input type="password" name="newPassword" minlength="8" autofocus required/></label>
+    </div>
+    <div>
+        <label>Confirm password <input type="password" name="confirmPassword" required/></label>
+    </div>
+    <button type="submit">Change password</button>
+</form>
+</body>
+</html>

--- a/src/main/resources/templates/manage/users/list.html
+++ b/src/main/resources/templates/manage/users/list.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head><title>Users</title></head>
+<body>
+<h1>Users</h1>
+<a th:href="@{'/manage/t/' + ${slug} + '/'}">← Home</a>
+<a th:href="@{'/manage/t/' + ${slug} + '/users/new'}">Add user</a>
+
+<table>
+    <thead>
+        <tr>
+            <th>Username</th>
+            <th>Status</th>
+            <th>Tenant Owner</th>
+            <th>Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr th:each="user : ${users}">
+            <td th:text="${user.username()}"></td>
+            <td th:text="${user.enabled() ? 'Active' : 'Disabled'}"></td>
+            <td th:text="${user.tenantOwner() ? 'Yes' : 'No'}"></td>
+            <td>
+                <form method="post" th:action="@{'/manage/t/' + ${slug} + '/users/' + ${user.id()} + '/enable'}" style="display:inline" th:if="${!user.enabled()}">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                    <button type="submit">Enable</button>
+                </form>
+                <form method="post" th:action="@{'/manage/t/' + ${slug} + '/users/' + ${user.id()} + '/disable'}" style="display:inline" th:if="${user.enabled()}">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                    <button type="submit">Disable</button>
+                </form>
+                <a th:href="@{'/manage/t/' + ${slug} + '/users/' + ${user.id()} + '/reset-password'}">Reset password</a>
+                <form method="post" th:action="@{'/manage/t/' + ${slug} + '/users/' + ${user.id()} + '/grant-owner'}" style="display:inline" th:if="${!user.tenantOwner()}">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                    <button type="submit">Grant owner</button>
+                </form>
+                <form method="post" th:action="@{'/manage/t/' + ${slug} + '/users/' + ${user.id()} + '/revoke-owner'}" style="display:inline" th:if="${user.tenantOwner()}">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                    <button type="submit">Revoke owner</button>
+                </form>
+                <form method="post" th:action="@{'/manage/t/' + ${slug} + '/users/' + ${user.id()} + '/delete'}" style="display:inline">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                    <button type="submit" onclick="return confirm('Delete this user?')">Delete</button>
+                </form>
+            </td>
+        </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/src/main/resources/templates/manage/users/new.html
+++ b/src/main/resources/templates/manage/users/new.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head><title>Add User</title></head>
+<body>
+<h1>Add User</h1>
+<a th:href="@{'/manage/t/' + ${slug} + '/users'}">← Users</a>
+
+<div th:if="${errorMessage}" th:text="${errorMessage}"></div>
+
+<form method="post" th:action="@{'/manage/t/' + ${slug} + '/users'}">
+    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+    <div>
+        <label>Username <input type="text" name="username" th:value="${username}" autofocus required/></label>
+    </div>
+    <div>
+        <label>Temporary password <input type="password" name="temporaryPassword" minlength="8" required/></label>
+    </div>
+    <button type="submit">Create user</button>
+</form>
+</body>
+</html>

--- a/src/main/resources/templates/manage/users/reset-password.html
+++ b/src/main/resources/templates/manage/users/reset-password.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head><title>Reset Password</title></head>
+<body>
+<h1>Reset Password</h1>
+<p>Resetting password for <strong th:text="${user.username()}"></strong></p>
+<a th:href="@{'/manage/t/' + ${slug} + '/users'}">← Users</a>
+
+<form method="post" th:action="@{'/manage/t/' + ${slug} + '/users/' + ${user.id()} + '/reset-password'}">
+    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+    <div>
+        <label>New temporary password <input type="password" name="temporaryPassword" minlength="8" required/></label>
+    </div>
+    <button type="submit">Reset password</button>
+</form>
+</body>
+</html>

--- a/src/main/resources/templates/signup.html
+++ b/src/main/resources/templates/signup.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Sign up — Limen</title>
+</head>
+<body>
+
+<h1>Create your Limen account</h1>
+
+<form method="post" th:action="@{/signup}">
+    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+
+    <div>
+        <label>
+            Organization name
+            <input type="text" name="organizationName" th:value="${form.organizationName()}" autofocus required/>
+        </label>
+        <span th:if="${errorField == 'organizationName'}" th:text="${errorMessage}"></span>
+    </div>
+
+    <div>
+        <label>
+            Slug (e.g. <code>acme-corp</code>)
+            <input type="text" name="slug" th:value="${form.slug()}"
+                   pattern="[a-z0-9][a-z0-9\-]{1,46}[a-z0-9]" required/>
+        </label>
+        <span th:if="${errorField == 'slug'}" th:text="${errorMessage}"></span>
+        <small>Your management URL will be <code>/manage/t/{slug}/</code></small>
+    </div>
+
+    <div>
+        <label>
+            Username
+            <input type="text" name="username" th:value="${form.username()}" required/>
+        </label>
+        <span th:if="${errorField == 'username'}" th:text="${errorMessage}"></span>
+    </div>
+
+    <div>
+        <label>
+            Password
+            <input type="password" name="password" minlength="8" required/>
+        </label>
+        <span th:if="${errorField == 'password'}" th:text="${errorMessage}"></span>
+    </div>
+
+    <button type="submit">Create account</button>
+</form>
+
+</body>
+</html>

--- a/src/test/java/com/stucray/limen/IssuerContractTest.java
+++ b/src/test/java/com/stucray/limen/IssuerContractTest.java
@@ -5,6 +5,7 @@ import com.nimbusds.jose.crypto.RSASSAVerifier;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jwt.SignedJWT;
+import com.stucray.limen.tenant.TenantRepository;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,7 +44,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest(properties = {
-    "OVERROUND_SIGNING_KEY_PATH=./target/test-signing-key.jwk"
+    "LIMEN_SIGNING_KEY_PATH=./target/test-signing-key.jwk"
 })
 @AutoConfigureMockMvc
 class IssuerContractTest {
@@ -53,6 +54,7 @@ class IssuerContractTest {
     private static final String REDIRECT_URI = "http://localhost:8091/login/oauth2/code/bff-client";
 
     @Autowired MockMvc mockMvc;
+    @Autowired TenantRepository tenantRepository;
     @Autowired UserRepository userRepository;
     @Autowired PasswordEncoder passwordEncoder;
     @Autowired RegisteredClientRepository registeredClientRepository;
@@ -61,8 +63,11 @@ class IssuerContractTest {
 
     @BeforeEach
     void setUp() {
-        userRepository.deleteAll();
-        userRepository.save(new User(null, "testuser", passwordEncoder.encode("password"), true, LocalDateTime.now()));
+        Long systemTenantId = tenantRepository.findBySlug("system").orElseThrow().id();
+        userRepository.findByUsernameAndTenantId("testuser", systemTenantId).ifPresent(u -> {});
+        if (!userRepository.existsByUsernameAndTenantId("testuser", systemTenantId)) {
+            userRepository.save(new User(null, systemTenantId, "testuser", passwordEncoder.encode("password"), true, false, false, LocalDateTime.now()));
+        }
 
         RegisteredClient existing = registeredClientRepository.findByClientId(CLIENT_ID);
         if (existing == null) {

--- a/src/test/java/com/stucray/limen/LoginIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/LoginIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.stucray.limen;
 
+import com.stucray.limen.tenant.TenantRepository;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import jakarta.servlet.http.Cookie;
@@ -25,21 +26,27 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest(properties = {
-    "OVERROUND_SIGNING_KEY_PATH=./target/test-signing-key.jwk"
+    "LIMEN_SIGNING_KEY_PATH=./target/test-signing-key.jwk"
 })
 @AutoConfigureMockMvc
 class LoginIntegrationTest {
 
     @Autowired MockMvc mockMvc;
     @Autowired UserRepository userRepository;
+    @Autowired TenantRepository tenantRepository;
     @Autowired PasswordEncoder passwordEncoder;
     @Autowired JdbcTemplate jdbcTemplate;
+
+    Long systemTenantId;
 
     @BeforeEach
     void setUp() {
         jdbcTemplate.execute("DELETE FROM persistent_logins");
-        userRepository.deleteAll();
-        userRepository.save(new User(null, "testuser", passwordEncoder.encode("password"), true, LocalDateTime.now()));
+        // Delete non-system users to avoid cross-test pollution while preserving the system tenant
+        jdbcTemplate.execute("DELETE FROM users WHERE tenant_id = (SELECT id FROM tenants WHERE slug = 'system')");
+
+        systemTenantId = tenantRepository.findBySlug("system").orElseThrow().id();
+        userRepository.save(new User(null, systemTenantId, "testuser", passwordEncoder.encode("password"), true, false, false, LocalDateTime.now()));
     }
 
     @Test
@@ -108,12 +115,9 @@ class LoginIntegrationTest {
         String tokenBefore = jdbcTemplate.queryForObject(
             "SELECT token FROM persistent_logins WHERE username = 'testuser'", String.class);
 
-        // Access a protected resource using only the remember-me cookie (no session).
-        // A redirect to /login would indicate re-authentication failed.
         MvcResult reAuthResult = mockMvc.perform(get("/login").cookie(rememberMeCookie))
             .andReturn();
 
-        // Remember-me authenticated; not redirected to /login
         assertThat(reAuthResult.getResponse().getStatus()).isNotEqualTo(302);
 
         String tokenAfter = jdbcTemplate.queryForObject(

--- a/src/test/java/com/stucray/limen/TestcontainersConfiguration.java
+++ b/src/test/java/com/stucray/limen/TestcontainersConfiguration.java
@@ -7,7 +7,7 @@ import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @TestConfiguration(proxyBeanMethods = false)
-class TestcontainersConfiguration {
+public class TestcontainersConfiguration {
 
 	@Bean
 	@ServiceConnection

--- a/src/test/java/com/stucray/limen/identity/AuthUserDetailsServiceTest.java
+++ b/src/test/java/com/stucray/limen/identity/AuthUserDetailsServiceTest.java
@@ -1,10 +1,13 @@
 package com.stucray.limen.identity;
 
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.tenant.TenantStatus;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -20,13 +23,23 @@ import static org.mockito.BDDMockito.given;
 @ExtendWith(MockitoExtension.class)
 class AuthUserDetailsServiceTest {
 
+    @Mock TenantRepository tenantRepository;
     @Mock UserRepository userRepository;
-    @InjectMocks AuthUserDetailsService service;
+
+    AuthUserDetailsService service;
+
+    private static final Tenant SYSTEM_TENANT = new Tenant(1L, "system", "System", TenantStatus.ACTIVE, LocalDateTime.now());
+
+    @BeforeEach
+    void setUp() {
+        service = new AuthUserDetailsService(tenantRepository, userRepository);
+        given(tenantRepository.findBySlug("system")).willReturn(Optional.of(SYSTEM_TENANT));
+    }
 
     @Test
-    void loadsUserByUsername() {
-        given(userRepository.findByUsername("alice")).willReturn(
-            Optional.of(new User(1L, "alice", "hash", true, LocalDateTime.now()))
+    void loadsUserByUsernameFromSystemTenant() {
+        given(userRepository.findByUsernameAndTenantId("alice", 1L)).willReturn(
+            Optional.of(new User(1L, 1L, "alice", "hash", true, false, false, LocalDateTime.now()))
         );
 
         UserDetails details = service.loadUserByUsername("alice");
@@ -38,16 +51,24 @@ class AuthUserDetailsServiceTest {
 
     @Test
     void throwsUsernameNotFoundForUnknownUser() {
-        given(userRepository.findByUsername("unknown")).willReturn(Optional.empty());
+        given(userRepository.findByUsernameAndTenantId("unknown", 1L)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.loadUserByUsername("unknown"))
             .isInstanceOf(UsernameNotFoundException.class);
     }
 
     @Test
+    void throwsUsernameNotFoundWhenSystemTenantMissing() {
+        given(tenantRepository.findBySlug("system")).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.loadUserByUsername("alice"))
+            .isInstanceOf(UsernameNotFoundException.class);
+    }
+
+    @Test
     void assignsRoleUserAuthority() {
-        given(userRepository.findByUsername("alice")).willReturn(
-            Optional.of(new User(1L, "alice", "hash", true, LocalDateTime.now()))
+        given(userRepository.findByUsernameAndTenantId("alice", 1L)).willReturn(
+            Optional.of(new User(1L, 1L, "alice", "hash", true, false, false, LocalDateTime.now()))
         );
 
         UserDetails details = service.loadUserByUsername("alice");
@@ -59,8 +80,8 @@ class AuthUserDetailsServiceTest {
 
     @Test
     void disabledUserIsNotEnabled() {
-        given(userRepository.findByUsername("bob")).willReturn(
-            Optional.of(new User(2L, "bob", "hash", false, LocalDateTime.now()))
+        given(userRepository.findByUsernameAndTenantId("bob", 1L)).willReturn(
+            Optional.of(new User(2L, 1L, "bob", "hash", false, false, false, LocalDateTime.now()))
         );
 
         UserDetails details = service.loadUserByUsername("bob");

--- a/src/test/java/com/stucray/limen/identity/UserBootstrapTest.java
+++ b/src/test/java/com/stucray/limen/identity/UserBootstrapTest.java
@@ -1,7 +1,11 @@
 package com.stucray.limen.identity;
 
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.tenant.TenantStatus;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -19,57 +23,64 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class UserBootstrapTest {
 
+    @Mock TenantRepository tenantRepository;
     @Mock UserRepository userRepository;
     @Mock PasswordEncoder passwordEncoder;
 
+    private static final Tenant SYSTEM_TENANT = new Tenant(1L, "system", "System", TenantStatus.ACTIVE, LocalDateTime.now());
+
+    @BeforeEach
+    void stubSystemTenant() {
+        given(tenantRepository.findBySlug("system")).willReturn(Optional.of(SYSTEM_TENANT));
+    }
+
     @Test
-    void doesNothingWhenUsernameUnset() throws Exception {
-        new UserBootstrap(null, "pass", userRepository, passwordEncoder).run();
+    void alwaysBootstrapsSystemTenant() throws Exception {
+        new UserBootstrap(null, null, tenantRepository, userRepository, passwordEncoder).run();
+        verify(tenantRepository).findBySlug("system");
         verifyNoInteractions(userRepository, passwordEncoder);
     }
 
     @Test
-    void doesNothingWhenPasswordUnset() throws Exception {
-        new UserBootstrap("admin", null, userRepository, passwordEncoder).run();
+    void createsSystemTenantWhenAbsent() throws Exception {
+        given(tenantRepository.findBySlug("system")).willReturn(Optional.empty());
+        given(tenantRepository.save(any())).willReturn(SYSTEM_TENANT);
+
+        new UserBootstrap(null, null, tenantRepository, userRepository, passwordEncoder).run();
+
+        verify(tenantRepository).save(argThat(t -> t.slug().equals("system")));
+    }
+
+    @Test
+    void doesNothingWithUsersWhenCredentialsUnset() throws Exception {
+        new UserBootstrap(null, "pass", tenantRepository, userRepository, passwordEncoder).run();
+        verifyNoInteractions(userRepository, passwordEncoder);
+
+        new UserBootstrap("admin", null, tenantRepository, userRepository, passwordEncoder).run();
         verifyNoInteractions(userRepository, passwordEncoder);
     }
 
     @Test
-    void createsUserWhenAbsent() throws Exception {
-        given(userRepository.findByUsername("admin")).willReturn(Optional.empty());
+    void createsAdminUserInSystemTenantWhenAbsent() throws Exception {
+        given(userRepository.findByUsernameAndTenantId("admin", 1L)).willReturn(Optional.empty());
         given(passwordEncoder.encode("pass")).willReturn("hashed");
 
-        new UserBootstrap("admin", "pass", userRepository, passwordEncoder).run();
+        new UserBootstrap("admin", "pass", tenantRepository, userRepository, passwordEncoder).run();
 
         verify(userRepository).save(argThat(u ->
-            u.username().equals("admin") && u.passwordHash().equals("hashed") && u.enabled() && u.id() == null
+            u.username().equals("admin") && u.passwordHash().equals("hashed")
+            && u.tenantId().equals(1L) && u.enabled() && !u.mustChangePassword()
         ));
     }
 
     @Test
-    void updatesPasswordHashWhenUserExists() throws Exception {
-        var existing = new User(1L, "admin", "oldhash", true, LocalDateTime.now());
-        given(userRepository.findByUsername("admin")).willReturn(Optional.of(existing));
+    void updatesPasswordHashWhenAdminUserExists() throws Exception {
+        var existing = new User(10L, 1L, "admin", "oldhash", true, false, false, LocalDateTime.now());
+        given(userRepository.findByUsernameAndTenantId("admin", 1L)).willReturn(Optional.of(existing));
         given(passwordEncoder.encode("newpass")).willReturn("newhash");
 
-        new UserBootstrap("admin", "newpass", userRepository, passwordEncoder).run();
+        new UserBootstrap("admin", "newpass", tenantRepository, userRepository, passwordEncoder).run();
 
-        verify(userRepository).save(argThat(u -> u.id().equals(1L) && u.passwordHash().equals("newhash")));
-    }
-
-    @Test
-    void isIdempotentAcrossRestarts() throws Exception {
-        given(passwordEncoder.encode("pass")).willReturn("hashed");
-        given(userRepository.findByUsername("admin")).willReturn(Optional.empty());
-
-        var bootstrap = new UserBootstrap("admin", "pass", userRepository, passwordEncoder);
-        bootstrap.run();
-
-        var created = new User(1L, "admin", "hashed", true, LocalDateTime.now());
-        given(userRepository.findByUsername("admin")).willReturn(Optional.of(created));
-
-        bootstrap.run();
-
-        verify(userRepository, times(2)).save(any());
+        verify(userRepository).save(argThat(u -> u.id().equals(10L) && u.passwordHash().equals("newhash")));
     }
 }

--- a/src/test/java/com/stucray/limen/management/ManagementLoginIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/ManagementLoginIntegrationTest.java
@@ -1,0 +1,143 @@
+package com.stucray.limen.management;
+
+import com.stucray.limen.TestcontainersConfiguration;
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.tenant.TenantStatus;
+import com.stucray.limen.user.User;
+import com.stucray.limen.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.LocalDateTime;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest(properties = {"LIMEN_SIGNING_KEY_PATH=./target/test-signing-key.jwk"})
+@AutoConfigureMockMvc
+class ManagementLoginIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired TenantRepository tenantRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired PasswordEncoder passwordEncoder;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    Tenant testTenant;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.execute("DELETE FROM oauth2_registered_client WHERE application_id IS NOT NULL");
+        jdbcTemplate.execute("DELETE FROM applications");
+        jdbcTemplate.execute("DELETE FROM users");
+        jdbcTemplate.execute("DELETE FROM tenants WHERE slug != 'system'");
+        jdbcTemplate.execute("DELETE FROM persistent_logins");
+
+        testTenant = tenantRepository.save(new Tenant(
+            null, "test-corp", "Test Corp", TenantStatus.ACTIVE, LocalDateTime.now()
+        ));
+        userRepository.save(new User(
+            null, testTenant.id(), "owner",
+            passwordEncoder.encode("password"),
+            true, false, false, LocalDateTime.now()
+        ));
+    }
+
+    @Test
+    void loginFormRendersForTenant() throws Exception {
+        mockMvc.perform(get("/manage/t/test-corp/login"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith("text/html"))
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("Test Corp")));
+    }
+
+    @Test
+    void successfulLoginRedirectsToHome() throws Exception {
+        mockMvc.perform(post("/manage/t/test-corp/login")
+                .param("username", "owner")
+                .param("password", "password")
+                .with(csrf()))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/manage/t/test-corp/"));
+    }
+
+    @Test
+    void failedLoginShowsError() throws Exception {
+        mockMvc.perform(post("/manage/t/test-corp/login")
+                .param("username", "owner")
+                .param("password", "wrong")
+                .with(csrf()))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/manage/t/test-corp/login?error"));
+    }
+
+    @Test
+    void unauthenticatedAccessToManagementPageRedirectsToLogin() throws Exception {
+        mockMvc.perform(get("/manage/t/test-corp/"))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/manage/t/test-corp/login"));
+    }
+
+    @Test
+    void authenticatedUserCanAccessManagementHome() throws Exception {
+        MvcResult loginResult = mockMvc.perform(post("/manage/t/test-corp/login")
+                .param("username", "owner")
+                .param("password", "password")
+                .with(csrf()))
+            .andReturn();
+
+        MockHttpSession session = (MockHttpSession) loginResult.getRequest().getSession(false);
+
+        mockMvc.perform(get("/manage/t/test-corp/").session(session))
+            .andExpect(status().isOk())
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("Test Corp")));
+    }
+
+    @Test
+    void systemAdminCanLoginAtSystemSlug() throws Exception {
+        Tenant systemTenant = tenantRepository.findBySlug("system").orElseThrow();
+        userRepository.save(new User(
+            null, systemTenant.id(), "sysadmin",
+            passwordEncoder.encode("syspassword"),
+            true, false, false, LocalDateTime.now()
+        ));
+
+        mockMvc.perform(post("/manage/t/system/login")
+                .param("username", "sysadmin")
+                .param("password", "syspassword")
+                .with(csrf()))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/manage/t/system/"));
+    }
+
+    @Test
+    void userCannotAccessAnotherTenantManagementPages() throws Exception {
+        MvcResult loginResult = mockMvc.perform(post("/manage/t/test-corp/login")
+                .param("username", "owner")
+                .param("password", "password")
+                .with(csrf()))
+            .andReturn();
+
+        MockHttpSession session = (MockHttpSession) loginResult.getRequest().getSession(false);
+
+        Tenant otherTenant = tenantRepository.save(new Tenant(
+            null, "other-corp", "Other Corp", TenantStatus.ACTIVE, LocalDateTime.now()
+        ));
+
+        mockMvc.perform(get("/manage/t/other-corp/").session(session))
+            .andExpect(status().isForbidden());
+    }
+}

--- a/src/test/java/com/stucray/limen/management/SignupIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/SignupIntegrationTest.java
@@ -1,0 +1,101 @@
+package com.stucray.limen.management;
+
+import com.stucray.limen.TestcontainersConfiguration;
+import com.stucray.limen.tenant.TenantRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest(properties = {"LIMEN_SIGNING_KEY_PATH=./target/test-signing-key.jwk"})
+@AutoConfigureMockMvc
+class SignupIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired TenantRepository tenantRepository;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.execute("DELETE FROM users WHERE tenant_id IN (SELECT id FROM tenants WHERE slug != 'system')");
+        jdbcTemplate.execute("DELETE FROM tenants WHERE slug != 'system'");
+    }
+
+    @Test
+    void signupFormRendersForUnauthenticatedRequest() throws Exception {
+        mockMvc.perform(get("/signup"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith("text/html"))
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("name=\"slug\"")));
+    }
+
+    @Test
+    void successfulSignupCreatesTenantAndOwner() throws Exception {
+        mockMvc.perform(post("/signup")
+                .param("organizationName", "Acme Corp")
+                .param("slug", "acme-corp")
+                .param("username", "alice")
+                .param("password", "secret123")
+                .with(csrf()))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/manage/t/acme-corp/login?registered"));
+
+        assertThat(tenantRepository.findBySlug("acme-corp")).isPresent();
+        Integer userCount = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM users u JOIN tenants t ON u.tenant_id = t.id WHERE t.slug = 'acme-corp'",
+            Integer.class);
+        assertThat(userCount).isEqualTo(1);
+    }
+
+    @Test
+    void duplicateSlugReturnsError() throws Exception {
+        jdbcTemplate.execute(
+            "INSERT INTO tenants (slug, display_name, status) VALUES ('taken-slug', 'Taken', 'ACTIVE')");
+
+        mockMvc.perform(post("/signup")
+                .param("organizationName", "Another Corp")
+                .param("slug", "taken-slug")
+                .param("username", "bob")
+                .param("password", "secret123")
+                .with(csrf()))
+            .andExpect(status().isOk())
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("already taken")));
+    }
+
+    @Test
+    void reservedSlugReturnsError() throws Exception {
+        for (String reserved : new String[]{"system", "admin", "manage", "api", "www", "static", "health", "limen"}) {
+            mockMvc.perform(post("/signup")
+                    .param("organizationName", "Test")
+                    .param("slug", reserved)
+                    .param("username", "user")
+                    .param("password", "secret123")
+                    .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("reserved")));
+        }
+    }
+
+    @Test
+    void invalidSlugFormatReturnsError() throws Exception {
+        mockMvc.perform(post("/signup")
+                .param("organizationName", "Test")
+                .param("slug", "UPPERCASE")
+                .param("username", "user")
+                .param("password", "secret123")
+                .with(csrf()))
+            .andExpect(status().isOk())
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("Slug may only contain")));
+    }
+}

--- a/src/test/java/com/stucray/limen/management/applications/ApplicationManagementIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/applications/ApplicationManagementIntegrationTest.java
@@ -1,0 +1,129 @@
+package com.stucray.limen.management.applications;
+
+import com.stucray.limen.TestcontainersConfiguration;
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.tenant.TenantStatus;
+import com.stucray.limen.user.User;
+import com.stucray.limen.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest(properties = {"LIMEN_SIGNING_KEY_PATH=./target/test-signing-key.jwk"})
+@AutoConfigureMockMvc
+class ApplicationManagementIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired TenantRepository tenantRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired ApplicationRepository applicationRepository;
+    @Autowired PasswordEncoder passwordEncoder;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    Tenant tenantA;
+    Tenant tenantB;
+    MockHttpSession sessionA;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        jdbcTemplate.execute("DELETE FROM oauth2_registered_client WHERE application_id IS NOT NULL");
+        jdbcTemplate.execute("DELETE FROM applications");
+        jdbcTemplate.execute("DELETE FROM users WHERE tenant_id IN (SELECT id FROM tenants WHERE slug != 'system')");
+        jdbcTemplate.execute("DELETE FROM tenants WHERE slug != 'system'");
+
+        tenantA = tenantRepository.save(new Tenant(null, "corp-a", "Corp A", TenantStatus.ACTIVE, LocalDateTime.now()));
+        tenantB = tenantRepository.save(new Tenant(null, "corp-b", "Corp B", TenantStatus.ACTIVE, LocalDateTime.now()));
+        userRepository.save(new User(null, tenantA.id(), "owner", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+
+        MvcResult login = mockMvc.perform(post("/manage/t/corp-a/login")
+                .param("username", "owner").param("password", "pass").with(csrf()))
+            .andReturn();
+        sessionA = (MockHttpSession) login.getRequest().getSession(false);
+    }
+
+    @Test
+    void ownerCanCreateApplication() throws Exception {
+        mockMvc.perform(post("/manage/t/corp-a/applications").session(sessionA).with(csrf())
+                .param("name", "My App").param("description", "A test app"))
+            .andExpect(status().is3xxRedirection());
+
+        assertThat(applicationRepository.findAllByTenantId(tenantA.id()))
+            .extracting(Application::name).containsExactly("My App");
+    }
+
+    @Test
+    void ownerCanListApplications() throws Exception {
+        applicationRepository.save(new Application(null, tenantA.id(), "App 1", "desc", LocalDateTime.now()));
+
+        mockMvc.perform(get("/manage/t/corp-a/applications").session(sessionA))
+            .andExpect(status().isOk())
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("App 1")));
+    }
+
+    @Test
+    void ownerCanEditApplication() throws Exception {
+        Application app = applicationRepository.save(new Application(null, tenantA.id(), "Old Name", "old desc", LocalDateTime.now()));
+
+        mockMvc.perform(post("/manage/t/corp-a/applications/" + app.id() + "/edit").session(sessionA).with(csrf())
+                .param("name", "New Name").param("description", "new desc"))
+            .andExpect(status().is3xxRedirection());
+
+        assertThat(applicationRepository.findById(app.id()).orElseThrow().name()).isEqualTo("New Name");
+    }
+
+    @Test
+    void ownerCanDeleteApplicationWithoutClients() throws Exception {
+        Application app = applicationRepository.save(new Application(null, tenantA.id(), "App", null, LocalDateTime.now()));
+
+        mockMvc.perform(post("/manage/t/corp-a/applications/" + app.id() + "/delete").session(sessionA).with(csrf()))
+            .andExpect(status().is3xxRedirection());
+
+        assertThat(applicationRepository.findById(app.id())).isEmpty();
+    }
+
+    @Test
+    void deleteBlockedWhenApplicationHasClients() throws Exception {
+        Application app = applicationRepository.save(new Application(null, tenantA.id(), "App", null, LocalDateTime.now()));
+        // Insert a fake client record to simulate the FK constraint check
+        jdbcTemplate.update(
+            "INSERT INTO oauth2_registered_client (id, client_id, client_id_issued_at, client_name, client_authentication_methods, authorization_grant_types, scopes, client_settings, token_settings, application_id) VALUES (?,?,NOW(),'test','client_secret_basic','authorization_code','openid','{}','{}',?)",
+            "fake-client-id", "fake-client", app.id()
+        );
+
+        mockMvc.perform(post("/manage/t/corp-a/applications/" + app.id() + "/delete").session(sessionA).with(csrf()))
+            .andExpect(status().isOk())
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("Cannot delete")));
+
+        assertThat(applicationRepository.findById(app.id())).isPresent();
+    }
+
+    @Test
+    void tenantAApplicationsNotVisibleToTenantBSession() throws Exception {
+        Application appA = applicationRepository.save(new Application(null, tenantA.id(), "App A", null, LocalDateTime.now()));
+        userRepository.save(new User(null, tenantB.id(), "ownerB", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        MvcResult loginB = mockMvc.perform(post("/manage/t/corp-b/login")
+                .param("username", "ownerB").param("password", "pass").with(csrf()))
+            .andReturn();
+        MockHttpSession sessionB = (MockHttpSession) loginB.getRequest().getSession(false);
+
+        mockMvc.perform(get("/manage/t/corp-a/applications").session(sessionB))
+            .andExpect(status().isForbidden());
+    }
+}

--- a/src/test/java/com/stucray/limen/management/system/SystemAdminIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/system/SystemAdminIntegrationTest.java
@@ -1,0 +1,147 @@
+package com.stucray.limen.management.system;
+
+import com.stucray.limen.TestcontainersConfiguration;
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.tenant.TenantStatus;
+import com.stucray.limen.user.User;
+import com.stucray.limen.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest(properties = {"LIMEN_SIGNING_KEY_PATH=./target/test-signing-key.jwk"})
+@AutoConfigureMockMvc
+class SystemAdminIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired TenantRepository tenantRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired PasswordEncoder passwordEncoder;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    MockHttpSession adminSession;
+    Tenant customerTenant;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        jdbcTemplate.execute("DELETE FROM applications");
+        jdbcTemplate.execute("DELETE FROM users WHERE tenant_id IN (SELECT id FROM tenants WHERE slug != 'system')");
+        jdbcTemplate.execute("DELETE FROM tenants WHERE slug != 'system'");
+        jdbcTemplate.execute("DELETE FROM users WHERE tenant_id = (SELECT id FROM tenants WHERE slug = 'system')");
+
+        Tenant systemTenant = tenantRepository.findBySlug("system").orElseThrow();
+        userRepository.save(new User(null, systemTenant.id(), "sysadmin", passwordEncoder.encode("syspass"), true, false, false, LocalDateTime.now()));
+
+        MvcResult login = mockMvc.perform(post("/manage/t/system/login")
+                .param("username", "sysadmin").param("password", "syspass").with(csrf()))
+            .andReturn();
+        adminSession = (MockHttpSession) login.getRequest().getSession(false);
+
+        customerTenant = tenantRepository.save(new Tenant(null, "customer", "Customer", TenantStatus.ACTIVE, LocalDateTime.now()));
+    }
+
+    @Test
+    void adminCanListTenants() throws Exception {
+        mockMvc.perform(get("/manage/system/tenants").session(adminSession))
+            .andExpect(status().isOk())
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("customer")));
+    }
+
+    @Test
+    void adminCanSuspendTenant() throws Exception {
+        mockMvc.perform(post("/manage/system/tenants/" + customerTenant.id() + "/suspend").session(adminSession).with(csrf()))
+            .andExpect(status().is3xxRedirection());
+
+        assertThat(tenantRepository.findById(customerTenant.id()).orElseThrow().status())
+            .isEqualTo(TenantStatus.SUSPENDED);
+    }
+
+    @Test
+    void suspendedTenantLoginIsBlocked() throws Exception {
+        userRepository.save(new User(null, customerTenant.id(), "owner", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        tenantRepository.save(customerTenant.withStatus(TenantStatus.SUSPENDED));
+
+        mockMvc.perform(post("/manage/t/customer/login")
+                .param("username", "owner").param("password", "pass").with(csrf()))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/manage/t/customer/login?error"));
+    }
+
+    @Test
+    void adminCanUnsuspendTenant() throws Exception {
+        tenantRepository.save(customerTenant.withStatus(TenantStatus.SUSPENDED));
+
+        mockMvc.perform(post("/manage/system/tenants/" + customerTenant.id() + "/unsuspend").session(adminSession).with(csrf()))
+            .andExpect(status().is3xxRedirection());
+
+        assertThat(tenantRepository.findById(customerTenant.id()).orElseThrow().status())
+            .isEqualTo(TenantStatus.ACTIVE);
+    }
+
+    @Test
+    void adminCanDeleteTenant() throws Exception {
+        mockMvc.perform(post("/manage/system/tenants/" + customerTenant.id() + "/delete").session(adminSession).with(csrf()))
+            .andExpect(status().is3xxRedirection());
+
+        assertThat(tenantRepository.findById(customerTenant.id())).isEmpty();
+    }
+
+    @Test
+    void systemTenantCannotBeSuspended() throws Exception {
+        Tenant systemTenant = tenantRepository.findBySlug("system").orElseThrow();
+
+        mockMvc.perform(post("/manage/system/tenants/" + systemTenant.id() + "/suspend").session(adminSession).with(csrf()))
+            .andExpect(status().is3xxRedirection());
+
+        assertThat(tenantRepository.findBySlug("system").orElseThrow().status())
+            .isEqualTo(TenantStatus.ACTIVE);
+    }
+
+    @Test
+    void systemTenantCannotBeDeleted() throws Exception {
+        Tenant systemTenant = tenantRepository.findBySlug("system").orElseThrow();
+
+        mockMvc.perform(post("/manage/system/tenants/" + systemTenant.id() + "/delete").session(adminSession).with(csrf()))
+            .andExpect(status().is3xxRedirection());
+
+        assertThat(tenantRepository.findBySlug("system")).isPresent();
+    }
+
+    @Test
+    void tenantOwnerCanViewAndUpdateTenantDetails() throws Exception {
+        Tenant corp = tenantRepository.save(new Tenant(null, "my-corp", "My Corp", TenantStatus.ACTIVE, LocalDateTime.now()));
+        userRepository.save(new User(null, corp.id(), "owner", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        MvcResult login = mockMvc.perform(post("/manage/t/my-corp/login")
+                .param("username", "owner").param("password", "pass").with(csrf()))
+            .andReturn();
+        MockHttpSession ownerSession = (MockHttpSession) login.getRequest().getSession(false);
+
+        mockMvc.perform(get("/manage/t/my-corp/settings").session(ownerSession))
+            .andExpect(status().isOk())
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("My Corp")));
+
+        mockMvc.perform(post("/manage/t/my-corp/settings/display-name").session(ownerSession).with(csrf())
+                .param("displayName", "My Corp Renamed"))
+            .andExpect(status().is3xxRedirection());
+
+        assertThat(tenantRepository.findBySlug("my-corp").orElseThrow().displayName())
+            .isEqualTo("My Corp Renamed");
+    }
+}

--- a/src/test/java/com/stucray/limen/management/users/UserManagementIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/users/UserManagementIntegrationTest.java
@@ -1,0 +1,150 @@
+package com.stucray.limen.management.users;
+
+import com.stucray.limen.TestcontainersConfiguration;
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.tenant.TenantStatus;
+import com.stucray.limen.user.User;
+import com.stucray.limen.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest(properties = {"LIMEN_SIGNING_KEY_PATH=./target/test-signing-key.jwk"})
+@AutoConfigureMockMvc
+class UserManagementIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired TenantRepository tenantRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired PasswordEncoder passwordEncoder;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    Tenant tenant;
+    MockHttpSession ownerSession;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        jdbcTemplate.execute("DELETE FROM users WHERE tenant_id IN (SELECT id FROM tenants WHERE slug != 'system')");
+        jdbcTemplate.execute("DELETE FROM tenants WHERE slug != 'system'");
+
+        tenant = tenantRepository.save(new Tenant(null, "corp", "Corp", TenantStatus.ACTIVE, LocalDateTime.now()));
+        userRepository.save(new User(null, tenant.id(), "owner", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+
+        MvcResult login = mockMvc.perform(post("/manage/t/corp/login")
+                .param("username", "owner").param("password", "pass").with(csrf()))
+            .andReturn();
+        ownerSession = (MockHttpSession) login.getRequest().getSession(false);
+    }
+
+    @Test
+    void ownerCanListUsers() throws Exception {
+        mockMvc.perform(get("/manage/t/corp/users").session(ownerSession))
+            .andExpect(status().isOk())
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("owner")));
+    }
+
+    @Test
+    void ownerCanCreateUser() throws Exception {
+        mockMvc.perform(post("/manage/t/corp/users").session(ownerSession).with(csrf())
+                .param("username", "alice").param("temporaryPassword", "temppass1"))
+            .andExpect(status().is3xxRedirection());
+
+        assertThat(userRepository.findByUsernameAndTenantId("alice", tenant.id())).isPresent();
+        assertThat(userRepository.findByUsernameAndTenantId("alice", tenant.id()).orElseThrow().mustChangePassword()).isTrue();
+    }
+
+    @Test
+    void ownerCanDisableAndEnableUser() throws Exception {
+        User alice = userRepository.save(new User(null, tenant.id(), "alice", passwordEncoder.encode("pass"), true, false, false, LocalDateTime.now()));
+
+        mockMvc.perform(post("/manage/t/corp/users/" + alice.id() + "/disable").session(ownerSession).with(csrf()))
+            .andExpect(status().is3xxRedirection());
+        assertThat(userRepository.findById(alice.id()).orElseThrow().enabled()).isFalse();
+
+        mockMvc.perform(post("/manage/t/corp/users/" + alice.id() + "/enable").session(ownerSession).with(csrf()))
+            .andExpect(status().is3xxRedirection());
+        assertThat(userRepository.findById(alice.id()).orElseThrow().enabled()).isTrue();
+    }
+
+    @Test
+    void ownerCanDeleteUser() throws Exception {
+        User alice = userRepository.save(new User(null, tenant.id(), "alice", passwordEncoder.encode("pass"), true, false, false, LocalDateTime.now()));
+
+        mockMvc.perform(post("/manage/t/corp/users/" + alice.id() + "/delete").session(ownerSession).with(csrf()))
+            .andExpect(status().is3xxRedirection());
+        assertThat(userRepository.findById(alice.id())).isEmpty();
+    }
+
+    @Test
+    void ownerCanResetPassword() throws Exception {
+        User alice = userRepository.save(new User(null, tenant.id(), "alice", passwordEncoder.encode("oldpass"), true, false, false, LocalDateTime.now()));
+
+        mockMvc.perform(post("/manage/t/corp/users/" + alice.id() + "/reset-password").session(ownerSession).with(csrf())
+                .param("temporaryPassword", "newpass123"))
+            .andExpect(status().is3xxRedirection());
+
+        User updated = userRepository.findById(alice.id()).orElseThrow();
+        assertThat(updated.mustChangePassword()).isTrue();
+    }
+
+    @Test
+    void ownerCanGrantAndRevokeTenantOwnerRole() throws Exception {
+        User alice = userRepository.save(new User(null, tenant.id(), "alice", passwordEncoder.encode("pass"), true, false, false, LocalDateTime.now()));
+
+        mockMvc.perform(post("/manage/t/corp/users/" + alice.id() + "/grant-owner").session(ownerSession).with(csrf()))
+            .andExpect(status().is3xxRedirection());
+        assertThat(userRepository.findById(alice.id()).orElseThrow().tenantOwner()).isTrue();
+
+        mockMvc.perform(post("/manage/t/corp/users/" + alice.id() + "/revoke-owner").session(ownerSession).with(csrf()))
+            .andExpect(status().is3xxRedirection());
+        assertThat(userRepository.findById(alice.id()).orElseThrow().tenantOwner()).isFalse();
+    }
+
+    @Test
+    void userWithMustChangePasswordIsInterceptedToChangePasswordPage() throws Exception {
+        userRepository.save(new User(null, tenant.id(), "newuser", passwordEncoder.encode("temp"), true, true, false, LocalDateTime.now()));
+
+        MvcResult login = mockMvc.perform(post("/manage/t/corp/login")
+                .param("username", "newuser").param("password", "temp").with(csrf()))
+            .andReturn();
+        MockHttpSession newUserSession = (MockHttpSession) login.getRequest().getSession(false);
+
+        mockMvc.perform(get("/manage/t/corp/").session(newUserSession))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/manage/t/corp/change-password"));
+    }
+
+    @Test
+    void mustChangePasswordClearedAfterChange() throws Exception {
+        User newUser = userRepository.save(new User(null, tenant.id(), "newuser", passwordEncoder.encode("temp"), true, true, false, LocalDateTime.now()));
+
+        MvcResult login = mockMvc.perform(post("/manage/t/corp/login")
+                .param("username", "newuser").param("password", "temp").with(csrf()))
+            .andReturn();
+        MockHttpSession newUserSession = (MockHttpSession) login.getRequest().getSession(false);
+
+        mockMvc.perform(post("/manage/t/corp/change-password").session(newUserSession).with(csrf())
+                .param("newPassword", "newpass123").param("confirmPassword", "newpass123"))
+            .andExpect(status().is3xxRedirection());
+
+        assertThat(userRepository.findById(newUser.id()).orElseThrow().mustChangePassword()).isFalse();
+    }
+}

--- a/src/test/java/com/stucray/limen/oauth2/TenantOAuth2RoutingIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/TenantOAuth2RoutingIntegrationTest.java
@@ -1,0 +1,151 @@
+package com.stucray.limen.oauth2;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stucray.limen.TestcontainersConfiguration;
+import com.stucray.limen.management.applications.Application;
+import com.stucray.limen.management.applications.ApplicationRepository;
+import com.stucray.limen.management.clients.ClientManagementService;
+import com.stucray.limen.management.clients.ClientManagementService.ClientCreationResult;
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.tenant.TenantStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest(properties = {"LIMEN_SIGNING_KEY_PATH=./target/test-signing-key.jwk"})
+@AutoConfigureMockMvc
+class TenantOAuth2RoutingIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired TenantRepository tenantRepository;
+    @Autowired ApplicationRepository applicationRepository;
+    @Autowired ClientManagementService clientManagementService;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    Tenant alphaCorpTenant;
+    Tenant betaCorpTenant;
+    Application alphaApp;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.execute("DELETE FROM oauth2_registered_client WHERE application_id IS NOT NULL");
+        jdbcTemplate.execute("DELETE FROM applications");
+        jdbcTemplate.execute("DELETE FROM users WHERE tenant_id != (SELECT id FROM tenants WHERE slug = 'system')");
+        jdbcTemplate.execute("DELETE FROM tenants WHERE slug != 'system'");
+
+        alphaCorpTenant = tenantRepository.save(new Tenant(
+            null, "alpha-corp", "Alpha Corp", TenantStatus.ACTIVE, LocalDateTime.now()
+        ));
+        betaCorpTenant = tenantRepository.save(new Tenant(
+            null, "beta-corp", "Beta Corp", TenantStatus.ACTIVE, LocalDateTime.now()
+        ));
+        alphaApp = applicationRepository.save(new Application(
+            null, alphaCorpTenant.id(), "Alpha App", "Test app", LocalDateTime.now()
+        ));
+    }
+
+    @Test
+    void discoveryDocumentHasTenantIssuer() throws Exception {
+        mockMvc.perform(get("/t/alpha-corp/.well-known/openid-configuration"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.issuer").value("http://localhost/t/alpha-corp"))
+            .andExpect(jsonPath("$.token_endpoint").value("http://localhost/t/alpha-corp/oauth2/token"))
+            .andExpect(jsonPath("$.jwks_uri").value("http://localhost/t/alpha-corp/oauth2/jwks"))
+            .andExpect(jsonPath("$.authorization_endpoint").value("http://localhost/t/alpha-corp/oauth2/authorize"));
+    }
+
+    @Test
+    void unknownTenantSlugReturns404() throws Exception {
+        mockMvc.perform(get("/t/no-such-tenant/.well-known/openid-configuration"))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void suspendedTenantReturns403() throws Exception {
+        tenantRepository.save(new Tenant(
+            null, "suspended-co", "Suspended Co", TenantStatus.SUSPENDED, LocalDateTime.now()
+        ));
+
+        mockMvc.perform(get("/t/suspended-co/.well-known/openid-configuration"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void clientCredentialsTokenFlowSucceedsForTenantClient() throws Exception {
+        ClientCreationResult result = clientManagementService.createClient(
+            alphaApp.id(), alphaCorpTenant.id(),
+            "m2m-client",
+            Set.of(AuthorizationGrantType.CLIENT_CREDENTIALS),
+            Set.of(), Set.of(), Set.of("read"),
+            false, true
+        );
+
+        String clientId = result.client().registeredClientId();
+        String rawSecret = result.rawSecret();
+
+        // Look up the actual OAuth2 client_id (UUID) registered with SAS
+        String oauthClientId = jdbcTemplate.queryForObject(
+            "SELECT client_id FROM oauth2_registered_client WHERE id = ?",
+            String.class, clientId
+        );
+
+        String tokenResponse = mockMvc.perform(post("/t/alpha-corp/oauth2/token")
+                .param("grant_type", "client_credentials")
+                .param("scope", "read")
+                .with(httpBasic(oauthClientId, rawSecret)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.access_token").exists())
+            .andReturn().getResponse().getContentAsString();
+
+        JsonNode json = objectMapper.readTree(tokenResponse);
+        assertThat(json.get("access_token").asText()).isNotBlank();
+    }
+
+    @Test
+    void crossTenantClientRejected() throws Exception {
+        // Register a client under alpha-corp
+        ClientCreationResult result = clientManagementService.createClient(
+            alphaApp.id(), alphaCorpTenant.id(),
+            "alpha-m2m",
+            Set.of(AuthorizationGrantType.CLIENT_CREDENTIALS),
+            Set.of(), Set.of(), Set.of("read"),
+            false, true
+        );
+
+        String clientId = result.client().registeredClientId();
+        String rawSecret = result.rawSecret();
+
+        String oauthClientId = jdbcTemplate.queryForObject(
+            "SELECT client_id FROM oauth2_registered_client WHERE id = ?",
+            String.class, clientId
+        );
+
+        // Attempt to use it via beta-corp's endpoint — must be rejected
+        mockMvc.perform(post("/t/beta-corp/oauth2/token")
+                .param("grant_type", "client_credentials")
+                .param("scope", "read")
+                .with(httpBasic(oauthClientId, rawSecret)))
+            .andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
## Summary

- Introduces the core multi-tenant domain model: **Tenant**, **Application**, and **Client**, backed by four Flyway migrations (V5–V8)
- Path-based tenant isolation — each tenant gets a scoped issuer URL (`/t/{slug}/`) and OAuth2 endpoints; cross-tenant client usage is rejected at the `TenantAwareRegisteredClientRepository` layer
- Self-service tenant signup, per-tenant management UI (users, applications, clients), system admin tenant controls, and forced password change on first login
- Fixes OIDC discovery document issuer: `TenantIssuerContextFilter` (registered in the SAS security chain before `CsrfFilter`) overwrites `AuthorizationServerContextHolder` with the correct per-tenant issuer after `AuthorizationServerContextFilter` has run

## Test plan

- [ ] All 61 existing + new integration tests pass (`mvn test`)
- [ ] `TenantOAuth2RoutingIntegrationTest` — discovery doc issuer, unknown/suspended tenant 404/403, client credentials token flow, cross-tenant rejection
- [ ] `ManagementLoginIntegrationTest` — per-tenant login at `/manage/t/{slug}/login`
- [ ] `SignupIntegrationTest` — self-service tenant creation
- [ ] `ApplicationManagementIntegrationTest` — CRUD for applications within a tenant
- [ ] `UserManagementIntegrationTest` — owner creates users, forced password change flow
- [ ] `SystemAdminIntegrationTest` — system admin can suspend/unsuspend/delete tenants

🤖 Generated with [Claude Code](https://claude.com/claude-code)