### PR TITLE
Implement JWT claims and auth code + PKCE flow (#8)

### DIFF
--- a/research/How-to Implement Multitenancy  Spring Authorization Server.md
+++ b/research/How-to Implement Multitenancy  Spring Authorization Server.md
@@ -1,0 +1,616 @@
+---
+title: "How-to: Implement Multitenancy :: Spring Authorization Server"
+source: "https://docs.spring.io/spring-authorization-server/reference/guides/how-to-multitenancy.html"
+author:
+published:
+created: 2026-04-26
+description:
+tags:
+  - "clippings"
+---
+## How-to: Implement Multitenancy
+
+This guide shows how to customize Spring Authorization Server to support multiple issuers per host in a multi-tenant hosting configuration. The purpose of this guide is to demonstrate a general pattern for building multi-tenant capable components for Spring Authorization Server, which can also be applied to other components to suit your needs.
+
+## Define the tenant identifier
+
+The [OpenID Connect 1.0 Provider Configuration Endpoint](https://docs.spring.io/spring-authorization-server/reference/protocol-endpoints.html#oidc-provider-configuration-endpoint) and [OAuth2 Authorization Server Metadata Endpoint](https://docs.spring.io/spring-authorization-server/reference/protocol-endpoints.html#oauth2-authorization-server-metadata-endpoint) allow for path components in the issuer identifier value, which effectively enables supporting multiple issuers per host.
+
+For example, an [OpenID Provider Configuration Request](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationRequest) "http://localhost:9000/issuer1/.well-known/openid-configuration" or an [Authorization Server Metadata Request](https://datatracker.ietf.org/doc/html/rfc8414#section-3.1) "http://localhost:9000/.well-known/oauth-authorization-server/issuer1" would return the following configuration metadata:
+
+```json
+{
+  "issuer": "http://localhost:9000/issuer1",
+  "authorization_endpoint": "http://localhost:9000/issuer1/oauth2/authorize",
+  "token_endpoint": "http://localhost:9000/issuer1/oauth2/token",
+  "jwks_uri": "http://localhost:9000/issuer1/oauth2/jwks",
+  "revocation_endpoint": "http://localhost:9000/issuer1/oauth2/revoke",
+  "introspection_endpoint": "http://localhost:9000/issuer1/oauth2/introspect",
+  ...
+}
+```
+
+|  | The base URL of the [Protocol Endpoints](https://docs.spring.io/spring-authorization-server/reference/protocol-endpoints.html) is the issuer identifier value. |
+| --- | --- |
+
+Essentially, an issuer identifier with a path component represents the *"tenant identifier"*.
+
+## Enable multiple issuers
+
+Support for using multiple issuers per host is disabled by default. To enable, add the following configuration:
+
+```java
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.server.authorization.settings.AuthorizationServerSettings;
+
+@Configuration(proxyBeanMethods = false)
+public class AuthorizationServerSettingsConfig {
+
+    @Bean
+    public AuthorizationServerSettings authorizationServerSettings() {
+        return AuthorizationServerSettings.builder()
+                .multipleIssuersAllowed(true)    (1)
+                .build();
+    }
+
+}
+```
+
+| **1** | Set to `true` to allow usage of multiple issuers per host. |
+| --- | --- |
+
+## Create a component registry
+
+We start by building a simple registry for managing the concrete components for each tenant. The registry contains the logic for retrieving a concrete implementation of a particular class using the issuer identifier value.
+
+We will use the following class in each of the delegating implementations below:
+
+```java
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.springframework.lang.Nullable;
+import org.springframework.security.oauth2.server.authorization.context.AuthorizationServerContext;
+import org.springframework.security.oauth2.server.authorization.context.AuthorizationServerContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+
+@Component
+public class TenantPerIssuerComponentRegistry {
+    private final ConcurrentMap<String, Map<Class<?>, Object>> registry = new ConcurrentHashMap<>();
+
+    public <T> void register(String tenantId, Class<T> componentClass, T component) {    (1)
+        Assert.hasText(tenantId, "tenantId cannot be empty");
+        Assert.notNull(componentClass, "componentClass cannot be null");
+        Assert.notNull(component, "component cannot be null");
+        Map<Class<?>, Object> components = this.registry.computeIfAbsent(tenantId, (key) -> new ConcurrentHashMap<>());
+        components.put(componentClass, component);
+    }
+
+    @Nullable
+    public <T> T get(Class<T> componentClass) {
+        AuthorizationServerContext context = AuthorizationServerContextHolder.getContext();
+        if (context == null || context.getIssuer() == null) {
+            return null;
+        }
+        for (Map.Entry<String, Map<Class<?>, Object>> entry : this.registry.entrySet()) {
+            if (context.getIssuer().endsWith(entry.getKey())) {
+                return componentClass.cast(entry.getValue().get(componentClass));
+            }
+        }
+        return null;
+    }
+}
+```
+
+| **1** | Component registration implicitly enables an allowlist of approved issuers that can be used. |
+| --- | --- |
+
+|  | This registry is designed to allow components to be easily registered at startup to support adding tenants statically, but also supports [adding tenants dynamically](#multi-tenant-add-tenants-dynamically) at runtime. |
+| --- | --- |
+
+## Create multi-tenant components
+
+The components that require multi-tenant capability are:
+
+For each of these components, an implementation of a composite can be provided that delegates to the concrete component associated to the *"requested"* issuer identifier.
+
+Let’s step through a scenario of how to customize Spring Authorization Server to support 2x tenants for each multi-tenant capable component.
+
+### Multi-tenant RegisteredClientRepository
+
+The following example shows a sample implementation of a [`RegisteredClientRepository`](https://docs.spring.io/spring-authorization-server/reference/core-model-components.html#registered-client-repository) that is composed of 2x `JdbcRegisteredClientRepository` instances, where each instance is mapped to an issuer identifier:
+
+```java
+import java.util.UUID;
+
+import javax.sql.DataSource;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.server.authorization.client.JdbcRegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.util.Assert;
+
+@Configuration(proxyBeanMethods = false)
+public class RegisteredClientRepositoryConfig {
+
+    @Bean
+    public RegisteredClientRepository registeredClientRepository(
+            @Qualifier("issuer1-data-source") DataSource issuer1DataSource,
+            @Qualifier("issuer2-data-source") DataSource issuer2DataSource,
+            TenantPerIssuerComponentRegistry componentRegistry) {
+
+        JdbcRegisteredClientRepository issuer1RegisteredClientRepository =
+                new JdbcRegisteredClientRepository(new JdbcTemplate(issuer1DataSource));    (1)
+
+        issuer1RegisteredClientRepository.save(
+                RegisteredClient.withId(UUID.randomUUID().toString())
+                        .clientId("client-1")
+                        .clientSecret("{noop}secret")
+                        .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+                        .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
+                        .scope("scope-1")
+                        .build()
+        );
+
+        JdbcRegisteredClientRepository issuer2RegisteredClientRepository =
+                new JdbcRegisteredClientRepository(new JdbcTemplate(issuer2DataSource));    (2)
+
+        issuer2RegisteredClientRepository.save(
+                RegisteredClient.withId(UUID.randomUUID().toString())
+                        .clientId("client-2")
+                        .clientSecret("{noop}secret")
+                        .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+                        .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
+                        .scope("scope-2")
+                        .build()
+        );
+
+        componentRegistry.register("issuer1", RegisteredClientRepository.class, issuer1RegisteredClientRepository);
+        componentRegistry.register("issuer2", RegisteredClientRepository.class, issuer2RegisteredClientRepository);
+
+        return new DelegatingRegisteredClientRepository(componentRegistry);
+    }
+
+    private static class DelegatingRegisteredClientRepository implements RegisteredClientRepository {    (3)
+
+        private final TenantPerIssuerComponentRegistry componentRegistry;
+
+        private DelegatingRegisteredClientRepository(TenantPerIssuerComponentRegistry componentRegistry) {
+            this.componentRegistry = componentRegistry;
+        }
+
+        @Override
+        public void save(RegisteredClient registeredClient) {
+            getRegisteredClientRepository().save(registeredClient);
+        }
+
+        @Override
+        public RegisteredClient findById(String id) {
+            return getRegisteredClientRepository().findById(id);
+        }
+
+        @Override
+        public RegisteredClient findByClientId(String clientId) {
+            return getRegisteredClientRepository().findByClientId(clientId);
+        }
+
+        private RegisteredClientRepository getRegisteredClientRepository() {
+            RegisteredClientRepository registeredClientRepository =
+                    this.componentRegistry.get(RegisteredClientRepository.class);    (4)
+            Assert.state(registeredClientRepository != null,
+                    "RegisteredClientRepository not found for \"requested\" issuer identifier.");    (5)
+            return registeredClientRepository;
+        }
+
+    }
+
+}
+```
+
+|  | Click on the "Expand folded text" icon in the code sample above to display the full example. |
+| --- | --- |
+
+| **1** | A `JdbcRegisteredClientRepository` instance mapped to issuer identifier `issuer1` and using a dedicated `DataSource`. |
+| --- | --- |
+| **2** | A `JdbcRegisteredClientRepository` instance mapped to issuer identifier `issuer2` and using a dedicated `DataSource`. |
+| **3** | A composite implementation of a `RegisteredClientRepository` that delegates to a `JdbcRegisteredClientRepository` mapped to the *"requested"* issuer identifier. |
+| **4** | Obtain the `JdbcRegisteredClientRepository` that is mapped to the *"requested"* issuer identifier indicated by `AuthorizationServerContext.getIssuer()`. |
+| **5** | If unable to find `JdbcRegisteredClientRepository`, then error since the *"requested"* issuer identifier is not in the allowlist of approved issuers. |
+
+|  | Explicitly configuring the issuer identifier via `AuthorizationServerSettings.builder().issuer("http://localhost:9000")` forces to a single-tenant configuration. Avoid explicitly configuring the issuer identifier when using a multi-tenant hosting configuration. |
+| --- | --- |
+
+In the preceding example, each of the `JdbcRegisteredClientRepository` instances are configured with a `JdbcTemplate` and associated `DataSource`. This is important in a multi-tenant configuration as a primary requirement is to have the ability to isolate the data from each tenant.
+
+Configuring a dedicated `DataSource` for each component instance provides the flexibility to isolate the data in its own schema within the same database instance or alternatively isolate the data in a separate database instance altogether.
+
+The following example shows a sample configuration of 2x `DataSource` `@Bean` (one for each tenant) that are used by the multi-tenant capable components:
+
+```java
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+
+@Configuration(proxyBeanMethods = false)
+public class DataSourceConfig {
+
+    @Bean("issuer1-data-source")
+    public EmbeddedDatabase issuer1DataSource() {
+        return new EmbeddedDatabaseBuilder()
+                .setName("issuer1-db")    (1)
+                .setType(EmbeddedDatabaseType.H2)
+                .setScriptEncoding("UTF-8")
+                .addScript("org/springframework/security/oauth2/server/authorization/oauth2-authorization-schema.sql")
+                .addScript("org/springframework/security/oauth2/server/authorization/oauth2-authorization-consent-schema.sql")
+                .addScript("org/springframework/security/oauth2/server/authorization/client/oauth2-registered-client-schema.sql")
+                .build();
+    }
+
+    @Bean("issuer2-data-source")
+    public EmbeddedDatabase issuer2DataSource() {
+        return new EmbeddedDatabaseBuilder()
+                .setName("issuer2-db")    (2)
+                .setType(EmbeddedDatabaseType.H2)
+                .setScriptEncoding("UTF-8")
+                .addScript("org/springframework/security/oauth2/server/authorization/oauth2-authorization-schema.sql")
+                .addScript("org/springframework/security/oauth2/server/authorization/oauth2-authorization-consent-schema.sql")
+                .addScript("org/springframework/security/oauth2/server/authorization/client/oauth2-registered-client-schema.sql")
+                .build();
+    }
+
+}
+```
+
+| **1** | Use a separate H2 database instance using `issuer1-db` as the name. |
+| --- | --- |
+| **2** | Use a separate H2 database instance using `issuer2-db` as the name. |
+
+### Multi-tenant OAuth2AuthorizationService
+
+The following example shows a sample implementation of an [`OAuth2AuthorizationService`](https://docs.spring.io/spring-authorization-server/reference/core-model-components.html#oauth2-authorization-service) that is composed of 2x `JdbcOAuth2AuthorizationService` instances, where each instance is mapped to an issuer identifier:
+
+```java
+import javax.sql.DataSource;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.oauth2.server.authorization.JdbcOAuth2AuthorizationService;
+import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
+import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.util.Assert;
+
+@Configuration(proxyBeanMethods = false)
+public class OAuth2AuthorizationServiceConfig {
+
+    @Bean
+    public OAuth2AuthorizationService authorizationService(
+            @Qualifier("issuer1-data-source") DataSource issuer1DataSource,
+            @Qualifier("issuer2-data-source") DataSource issuer2DataSource,
+            TenantPerIssuerComponentRegistry componentRegistry,
+            RegisteredClientRepository registeredClientRepository) {
+
+        componentRegistry.register("issuer1", OAuth2AuthorizationService.class,
+                new JdbcOAuth2AuthorizationService(    (1)
+                        new JdbcTemplate(issuer1DataSource), registeredClientRepository));
+        componentRegistry.register("issuer2", OAuth2AuthorizationService.class,
+                new JdbcOAuth2AuthorizationService(    (2)
+                        new JdbcTemplate(issuer2DataSource), registeredClientRepository));
+
+        return new DelegatingOAuth2AuthorizationService(componentRegistry);
+    }
+
+    private static class DelegatingOAuth2AuthorizationService implements OAuth2AuthorizationService {    (3)
+
+        private final TenantPerIssuerComponentRegistry componentRegistry;
+
+        private DelegatingOAuth2AuthorizationService(TenantPerIssuerComponentRegistry componentRegistry) {
+            this.componentRegistry = componentRegistry;
+        }
+
+        @Override
+        public void save(OAuth2Authorization authorization) {
+            getAuthorizationService().save(authorization);
+        }
+
+        @Override
+        public void remove(OAuth2Authorization authorization) {
+            getAuthorizationService().remove(authorization);
+        }
+
+        @Override
+        public OAuth2Authorization findById(String id) {
+            return getAuthorizationService().findById(id);
+        }
+
+        @Override
+        public OAuth2Authorization findByToken(String token, OAuth2TokenType tokenType) {
+            return getAuthorizationService().findByToken(token, tokenType);
+        }
+
+        private OAuth2AuthorizationService getAuthorizationService() {
+            OAuth2AuthorizationService authorizationService =
+                    this.componentRegistry.get(OAuth2AuthorizationService.class);    (4)
+            Assert.state(authorizationService != null,
+                    "OAuth2AuthorizationService not found for \"requested\" issuer identifier.");    (5)
+            return authorizationService;
+        }
+
+    }
+
+}
+```
+
+| **1** | A `JdbcOAuth2AuthorizationService` instance mapped to issuer identifier `issuer1` and using a dedicated `DataSource`. |
+| --- | --- |
+| **2** | A `JdbcOAuth2AuthorizationService` instance mapped to issuer identifier `issuer2` and using a dedicated `DataSource`. |
+| **3** | A composite implementation of an `OAuth2AuthorizationService` that delegates to a `JdbcOAuth2AuthorizationService` mapped to the *"requested"* issuer identifier. |
+| **4** | Obtain the `JdbcOAuth2AuthorizationService` that is mapped to the *"requested"* issuer identifier indicated by `AuthorizationServerContext.getIssuer()`. |
+| **5** | If unable to find `JdbcOAuth2AuthorizationService`, then error since the *"requested"* issuer identifier is not in the allowlist of approved issuers. |
+
+### Multi-tenant OAuth2AuthorizationConsentService
+
+The following example shows a sample implementation of an [`OAuth2AuthorizationConsentService`](https://docs.spring.io/spring-authorization-server/reference/core-model-components.html#oauth2-authorization-consent-service) that is composed of 2x `JdbcOAuth2AuthorizationConsentService` instances, where each instance is mapped to an issuer identifier:
+
+```java
+import javax.sql.DataSource;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.oauth2.server.authorization.JdbcOAuth2AuthorizationConsentService;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsent;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsentService;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.util.Assert;
+
+@Configuration(proxyBeanMethods = false)
+public class OAuth2AuthorizationConsentServiceConfig {
+
+    @Bean
+    public OAuth2AuthorizationConsentService authorizationConsentService(
+            @Qualifier("issuer1-data-source") DataSource issuer1DataSource,
+            @Qualifier("issuer2-data-source") DataSource issuer2DataSource,
+            TenantPerIssuerComponentRegistry componentRegistry,
+            RegisteredClientRepository registeredClientRepository) {
+
+        componentRegistry.register("issuer1", OAuth2AuthorizationConsentService.class,
+                new JdbcOAuth2AuthorizationConsentService(    (1)
+                        new JdbcTemplate(issuer1DataSource), registeredClientRepository));
+        componentRegistry.register("issuer2", OAuth2AuthorizationConsentService.class,
+                new JdbcOAuth2AuthorizationConsentService(    (2)
+                        new JdbcTemplate(issuer2DataSource), registeredClientRepository));
+
+        return new DelegatingOAuth2AuthorizationConsentService(componentRegistry);
+    }
+
+    private static class DelegatingOAuth2AuthorizationConsentService implements OAuth2AuthorizationConsentService {    (3)
+
+        private final TenantPerIssuerComponentRegistry componentRegistry;
+
+        private DelegatingOAuth2AuthorizationConsentService(TenantPerIssuerComponentRegistry componentRegistry) {
+            this.componentRegistry = componentRegistry;
+        }
+
+        @Override
+        public void save(OAuth2AuthorizationConsent authorizationConsent) {
+            getAuthorizationConsentService().save(authorizationConsent);
+        }
+
+        @Override
+        public void remove(OAuth2AuthorizationConsent authorizationConsent) {
+            getAuthorizationConsentService().remove(authorizationConsent);
+        }
+
+        @Override
+        public OAuth2AuthorizationConsent findById(String registeredClientId, String principalName) {
+            return getAuthorizationConsentService().findById(registeredClientId, principalName);
+        }
+
+        private OAuth2AuthorizationConsentService getAuthorizationConsentService() {
+            OAuth2AuthorizationConsentService authorizationConsentService =
+                    this.componentRegistry.get(OAuth2AuthorizationConsentService.class);    (4)
+            Assert.state(authorizationConsentService != null,
+                    "OAuth2AuthorizationConsentService not found for \"requested\" issuer identifier.");    (5)
+            return authorizationConsentService;
+        }
+
+    }
+
+}
+```
+
+| **1** | A `JdbcOAuth2AuthorizationConsentService` instance mapped to issuer identifier `issuer1` and using a dedicated `DataSource`. |
+| --- | --- |
+| **2** | A `JdbcOAuth2AuthorizationConsentService` instance mapped to issuer identifier `issuer2` and using a dedicated `DataSource`. |
+| **3** | A composite implementation of an `OAuth2AuthorizationConsentService` that delegates to a `JdbcOAuth2AuthorizationConsentService` mapped to the *"requested"* issuer identifier. |
+| **4** | Obtain the `JdbcOAuth2AuthorizationConsentService` that is mapped to the *"requested"* issuer identifier indicated by `AuthorizationServerContext.getIssuer()`. |
+| **5** | If unable to find `JdbcOAuth2AuthorizationConsentService`, then error since the *"requested"* issuer identifier is not in the allowlist of approved issuers. |
+
+### Multi-tenant JWKSource
+
+And finally, the following example shows a sample implementation of a `JWKSource<SecurityContext>` that is composed of 2x `JWKSet` instances, where each instance is mapped to an issuer identifier:
+
+```java
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.List;
+import java.util.UUID;
+
+import com.nimbusds.jose.KeySourceException;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSelector;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.proc.SecurityContext;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.Assert;
+
+@Configuration(proxyBeanMethods = false)
+public class JWKSourceConfig {
+
+    @Bean
+    public JWKSource<SecurityContext> jwkSource(TenantPerIssuerComponentRegistry componentRegistry) {
+        componentRegistry.register("issuer1", JWKSet.class, new JWKSet(generateRSAJwk()));    (1)
+        componentRegistry.register("issuer2", JWKSet.class, new JWKSet(generateRSAJwk()));    (2)
+
+        return new DelegatingJWKSource(componentRegistry);
+    }
+
+    private static RSAKey generateRSAJwk() {
+        KeyPair keyPair;
+        try {
+            KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+            keyPairGenerator.initialize(2048);
+            keyPair = keyPairGenerator.generateKeyPair();
+        } catch (Exception ex) {
+            throw new IllegalStateException(ex);
+        }
+
+        RSAPublicKey publicKey = (RSAPublicKey) keyPair.getPublic();
+        RSAPrivateKey privateKey = (RSAPrivateKey) keyPair.getPrivate();
+        return new RSAKey.Builder(publicKey)
+                .privateKey(privateKey)
+                .keyID(UUID.randomUUID().toString())
+                .build();
+    }
+
+    private static class DelegatingJWKSource implements JWKSource<SecurityContext> {    (3)
+
+        private final TenantPerIssuerComponentRegistry componentRegistry;
+
+        private DelegatingJWKSource(TenantPerIssuerComponentRegistry componentRegistry) {
+            this.componentRegistry = componentRegistry;
+        }
+
+        @Override
+        public List<JWK> get(JWKSelector jwkSelector, SecurityContext context) throws KeySourceException {
+            return jwkSelector.select(getJwkSet());
+        }
+
+        private JWKSet getJwkSet() {
+            JWKSet jwkSet = this.componentRegistry.get(JWKSet.class);    (4)
+            Assert.state(jwkSet != null, "JWKSet not found for \"requested\" issuer identifier.");    (5)
+            return jwkSet;
+        }
+
+    }
+
+}
+```
+
+| **1** | A `JWKSet` instance mapped to issuer identifier `issuer1`. |
+| --- | --- |
+| **2** | A `JWKSet` instance mapped to issuer identifier `issuer2`. |
+| **3** | A composite implementation of an `JWKSource<SecurityContext>` that uses the `JWKSet` mapped to the *"requested"* issuer identifier. |
+| **4** | Obtain the `JWKSet` that is mapped to the *"requested"* issuer identifier indicated by `AuthorizationServerContext.getIssuer()`. |
+| **5** | If unable to find `JWKSet`, then error since the *"requested"* issuer identifier is not in the allowlist of approved issuers. |
+
+## Add Tenants Dynamically
+
+If the number of tenants is dynamic and can change at runtime, defining each `DataSource` as a `@Bean` may not be feasible. In this case, the `DataSource` and corresponding components can be registered through other means at application startup and/or runtime.
+
+The following example shows a Spring `@Service` capable of adding tenants dynamically:
+
+```java
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.UUID;
+
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import org.springframework.security.oauth2.server.authorization.JdbcOAuth2AuthorizationConsentService;
+import org.springframework.security.oauth2.server.authorization.JdbcOAuth2AuthorizationService;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsentService;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
+import org.springframework.security.oauth2.server.authorization.client.JdbcRegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TenantService {
+
+    private final TenantPerIssuerComponentRegistry componentRegistry;
+
+    public TenantService(TenantPerIssuerComponentRegistry componentRegistry) {
+        this.componentRegistry = componentRegistry;
+    }
+
+    public void createTenant(String tenantId) {
+        EmbeddedDatabase dataSource = createDataSource(tenantId);
+        JdbcTemplate jdbcOperations = new JdbcTemplate(dataSource);
+
+        RegisteredClientRepository registeredClientRepository =
+                new JdbcRegisteredClientRepository(jdbcOperations);
+        this.componentRegistry.register(tenantId, RegisteredClientRepository.class, registeredClientRepository);
+
+        OAuth2AuthorizationService authorizationService =
+                new JdbcOAuth2AuthorizationService(jdbcOperations, registeredClientRepository);
+        this.componentRegistry.register(tenantId, OAuth2AuthorizationService.class, authorizationService);
+
+        OAuth2AuthorizationConsentService authorizationConsentService =
+                new JdbcOAuth2AuthorizationConsentService(jdbcOperations, registeredClientRepository);
+        this.componentRegistry.register(tenantId, OAuth2AuthorizationConsentService.class, authorizationConsentService);
+
+        JWKSet jwkSet = new JWKSet(generateRSAJwk());
+        this.componentRegistry.register(tenantId, JWKSet.class, jwkSet);
+    }
+
+    private EmbeddedDatabase createDataSource(String tenantId) {
+        return new EmbeddedDatabaseBuilder()
+                .setName(tenantId)
+                .setType(EmbeddedDatabaseType.H2)
+                .setScriptEncoding("UTF-8")
+                .addScript("org/springframework/security/oauth2/server/authorization/oauth2-authorization-schema.sql")
+                .addScript("org/springframework/security/oauth2/server/authorization/oauth2-authorization-consent-schema.sql")
+                .addScript("org/springframework/security/oauth2/server/authorization/client/oauth2-registered-client-schema.sql")
+                .build();
+    }
+
+    private static RSAKey generateRSAJwk() {
+        KeyPair keyPair;
+        try {
+            KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+            keyPairGenerator.initialize(2048);
+            keyPair = keyPairGenerator.generateKeyPair();
+        } catch (Exception ex) {
+            throw new IllegalStateException(ex);
+        }
+
+        RSAPublicKey publicKey = (RSAPublicKey) keyPair.getPublic();
+        RSAPrivateKey privateKey = (RSAPrivateKey) keyPair.getPrivate();
+        return new RSAKey.Builder(publicKey)
+                .privateKey(privateKey)
+                .keyID(UUID.randomUUID().toString())
+                .build();
+    }
+
+}
+```

--- a/src/main/java/com/stucray/limen/identity/AuthUserDetailsService.java
+++ b/src/main/java/com/stucray/limen/identity/AuthUserDetailsService.java
@@ -1,5 +1,6 @@
 package com.stucray.limen.identity;
 
+import com.stucray.limen.oauth2.TenantContext;
 import com.stucray.limen.tenant.TenantRepository;
 import com.stucray.limen.user.UserRepository;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -11,10 +12,6 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
-/**
- * UserDetailsService for the OAuth2 authorization code flow login page.
- * Scoped to the system tenant until per-tenant OAuth2 routing is wired up in a later slice.
- */
 @Service
 public class AuthUserDetailsService implements UserDetailsService {
 
@@ -28,11 +25,14 @@ public class AuthUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) {
-        Long systemTenantId = tenantRepository.findBySlug(UserBootstrap.SYSTEM_SLUG)
-            .orElseThrow(() -> new UsernameNotFoundException(username))
-            .id();
-
-        return userRepository.findByUsernameAndTenantId(username, systemTenantId)
+        Long tenantId = TenantContext.getTenantId();
+        if (tenantId == null) {
+            tenantId = tenantRepository.findBySlug(UserBootstrap.SYSTEM_SLUG)
+                .orElseThrow(() -> new UsernameNotFoundException(username))
+                .id();
+        }
+        final Long resolvedTenantId = tenantId;
+        return userRepository.findByUsernameAndTenantId(username, resolvedTenantId)
             .map(user -> new User(
                 user.username(),
                 user.passwordHash(),

--- a/src/main/java/com/stucray/limen/oauth2/TenantLoginSuccessHandler.java
+++ b/src/main/java/com/stucray/limen/oauth2/TenantLoginSuccessHandler.java
@@ -1,0 +1,43 @@
+package com.stucray.limen.oauth2;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
+import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
+import org.springframework.security.web.savedrequest.SavedRequest;
+
+import java.io.IOException;
+import java.net.URI;
+
+public class TenantLoginSuccessHandler extends SavedRequestAwareAuthenticationSuccessHandler {
+
+    private final HttpSessionRequestCache requestCache = new HttpSessionRequestCache();
+
+    @Override
+    public void onAuthenticationSuccess(
+        HttpServletRequest request, HttpServletResponse response, Authentication auth
+    ) throws IOException, ServletException {
+        String slug = (String) request.getSession().getAttribute("OAUTH2_TENANT_SLUG");
+        if (slug != null) {
+            SavedRequest savedRequest = requestCache.getRequest(request, response);
+            if (savedRequest != null && savedRequest.getRedirectUrl().contains("/oauth2/authorize")) {
+                requestCache.removeRequest(request, response);
+                clearAuthenticationAttributes(request);
+                getRedirectStrategy().sendRedirect(request, response,
+                    prependTenantPrefix(savedRequest.getRedirectUrl(), slug));
+                return;
+            }
+        }
+        super.onAuthenticationSuccess(request, response, auth);
+    }
+
+    private String prependTenantPrefix(String redirectUrl, String slug) {
+        URI uri = URI.create(redirectUrl);
+        String newPath = "/t/" + slug + uri.getRawPath();
+        String query = uri.getRawQuery();
+        return uri.getScheme() + "://" + uri.getAuthority() + newPath
+            + (query != null ? "?" + query : "");
+    }
+}

--- a/src/main/java/com/stucray/limen/oauth2/TenantLoginUrlAuthenticationEntryPoint.java
+++ b/src/main/java/com/stucray/limen/oauth2/TenantLoginUrlAuthenticationEntryPoint.java
@@ -1,0 +1,21 @@
+package com.stucray.limen.oauth2;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
+
+public class TenantLoginUrlAuthenticationEntryPoint extends LoginUrlAuthenticationEntryPoint {
+
+    public TenantLoginUrlAuthenticationEntryPoint() {
+        super("/login");
+    }
+
+    @Override
+    protected String determineUrlToUseForThisRequest(
+        HttpServletRequest request, HttpServletResponse response, AuthenticationException exception
+    ) {
+        String slug = TenantContext.getSlug();
+        return slug != null ? "/t/" + slug + "/login" : "/login";
+    }
+}

--- a/src/main/java/com/stucray/limen/oauth2/TenantOAuth2RoutingFilter.java
+++ b/src/main/java/com/stucray/limen/oauth2/TenantOAuth2RoutingFilter.java
@@ -28,7 +28,7 @@ import java.util.regex.Pattern;
 public class TenantOAuth2RoutingFilter extends OncePerRequestFilter {
 
     private static final Pattern TENANT_PATH =
-        Pattern.compile("^/t/([^/]+)/(oauth2|.well-known)/.*");
+        Pattern.compile("^/t/([^/]+)/((oauth2|\\.well-known|connect)/.*|login|userinfo)$");
 
     private final TenantRepository tenantRepository;
 
@@ -61,6 +61,7 @@ public class TenantOAuth2RoutingFilter extends OncePerRequestFilter {
         }
 
         TenantContext.set(slug, tenant.id());
+        request.getSession(true).setAttribute("OAUTH2_TENANT_SLUG", slug);
         try {
             chain.doFilter(new TenantOAuth2RequestWrapper(request, slug), response);
         } finally {

--- a/src/main/java/com/stucray/limen/security/SasConfig.java
+++ b/src/main/java/com/stucray/limen/security/SasConfig.java
@@ -2,7 +2,9 @@ package com.stucray.limen.security;
 
 import com.stucray.limen.management.clients.TenantClientRepository;
 import com.stucray.limen.oauth2.TenantAwareRegisteredClientRepository;
+import com.stucray.limen.oauth2.TenantContext;
 import com.stucray.limen.oauth2.TenantIssuerContextFilter;
+import com.stucray.limen.oauth2.TenantLoginUrlAuthenticationEntryPoint;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
@@ -11,17 +13,21 @@ import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.web.csrf.CsrfFilter;
+import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
 import org.springframework.security.oauth2.server.authorization.JdbcOAuth2AuthorizationConsentService;
 import org.springframework.security.oauth2.server.authorization.JdbcOAuth2AuthorizationService;
 import org.springframework.security.oauth2.server.authorization.client.JdbcRegisteredClientRepository;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
 import org.springframework.security.oauth2.server.authorization.settings.AuthorizationServerSettings;
+import org.springframework.security.oauth2.server.authorization.token.JwtEncodingContext;
+import org.springframework.security.oauth2.server.authorization.token.OAuth2TokenCustomizer;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
+import org.springframework.security.web.csrf.CsrfFilter;
 import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.security.web.util.matcher.MediaTypeRequestMatcher;
 import org.springframework.security.web.util.matcher.OrRequestMatcher;
+
+import java.util.ArrayList;
 
 import java.util.Set;
 
@@ -39,7 +45,7 @@ public class SasConfig {
             .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
             .oauth2ResourceServer(rs -> rs.jwt(Customizer.withDefaults()))
             .exceptionHandling(ex -> ex.defaultAuthenticationEntryPointFor(
-                new LoginUrlAuthenticationEntryPoint("/login"),
+                new TenantLoginUrlAuthenticationEntryPoint(),
                 new OrRequestMatcher(
                     htmlRequestMatcher(),
                     PathPatternRequestMatcher.withDefaults().matcher("/oauth2/authorize")
@@ -82,6 +88,18 @@ public class SasConfig {
         return AuthorizationServerSettings.builder()
             .issuer("http://localhost:8090")
             .build();
+    }
+
+    @Bean
+    public OAuth2TokenCustomizer<JwtEncodingContext> jwtTokenCustomizer() {
+        return context -> {
+            if (!OAuth2TokenType.ACCESS_TOKEN.equals(context.getTokenType())) return;
+            String slug = TenantContext.getSlug();
+            if (slug != null) {
+                context.getClaims().claim("tenant", slug);
+            }
+            context.getClaims().claim("roles", new ArrayList<>());
+        };
     }
 
     private static MediaTypeRequestMatcher htmlRequestMatcher() {

--- a/src/main/java/com/stucray/limen/security/SecurityConfig.java
+++ b/src/main/java/com/stucray/limen/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.stucray.limen.security;
 
+import com.stucray.limen.oauth2.TenantLoginSuccessHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -32,7 +33,10 @@ public class SecurityConfig {
                 .requestMatchers("/actuator/health").permitAll()
                 .anyRequest().authenticated()
             )
-            .formLogin(form -> form.loginPage("/login").permitAll())
+            .formLogin(form -> form
+                .loginPage("/login").permitAll()
+                .successHandler(new TenantLoginSuccessHandler())
+            )
             .logout(logout -> logout
                 .deleteCookies("JSESSIONID", "remember-me")
                 .invalidateHttpSession(true)

--- a/src/main/java/com/stucray/limen/web/LoginController.java
+++ b/src/main/java/com/stucray/limen/web/LoginController.java
@@ -1,13 +1,19 @@
 package com.stucray.limen.web;
 
+import com.stucray.limen.oauth2.TenantContext;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
 public class LoginController {
 
     @GetMapping("/login")
-    public String login() {
+    public String login(Model model) {
+        String slug = TenantContext.getSlug();
+        if (slug != null) {
+            model.addAttribute("tenantSlug", slug);
+        }
         return "login";
     }
 }

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
-<head><title>Sign in — Overround</title></head>
+<head><title>Sign in</title></head>
 <body>
-<form method="post" th:action="@{/login}">
+<form method="post" th:action="${tenantSlug != null} ? @{/t/{slug}/login(slug=${tenantSlug})} : @{/login}">
     <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
     <div><label>Username <input type="text" name="username" autofocus required/></label></div>
     <div><label>Password <input type="password" name="password" required/></label></div>

--- a/src/test/java/com/stucray/limen/oauth2/TenantOAuth2RoutingIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/TenantOAuth2RoutingIntegrationTest.java
@@ -2,14 +2,19 @@ package com.stucray.limen.oauth2;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jwt.SignedJWT;
 import com.stucray.limen.TestcontainersConfiguration;
 import com.stucray.limen.management.applications.Application;
 import com.stucray.limen.management.applications.ApplicationRepository;
 import com.stucray.limen.management.clients.ClientManagementService;
 import com.stucray.limen.management.clients.ClientManagementService.ClientCreationResult;
+import com.stucray.limen.management.clients.TenantClient;
+import com.stucray.limen.management.clients.TenantClientRepository;
 import com.stucray.limen.tenant.Tenant;
 import com.stucray.limen.tenant.TenantRepository;
 import com.stucray.limen.tenant.TenantStatus;
+import com.stucray.limen.user.User;
+import com.stucray.limen.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,13 +22,30 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.oidc.OidcScopes;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.util.UriComponentsBuilder;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
 import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -39,6 +61,10 @@ class TenantOAuth2RoutingIntegrationTest {
     @Autowired TenantRepository tenantRepository;
     @Autowired ApplicationRepository applicationRepository;
     @Autowired ClientManagementService clientManagementService;
+    @Autowired RegisteredClientRepository registeredClientRepository;
+    @Autowired TenantClientRepository tenantClientRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired PasswordEncoder passwordEncoder;
     @Autowired JdbcTemplate jdbcTemplate;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -147,5 +173,215 @@ class TenantOAuth2RoutingIntegrationTest {
                 .param("scope", "read")
                 .with(httpBasic(oauthClientId, rawSecret)))
             .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void clientCredentialsTokenIncludesTenantAndRolesClaims() throws Exception {
+        ClientCreationResult result = clientManagementService.createClient(
+            alphaApp.id(), alphaCorpTenant.id(),
+            "claims-m2m",
+            Set.of(AuthorizationGrantType.CLIENT_CREDENTIALS),
+            Set.of(), Set.of(), Set.of("read"),
+            false, true
+        );
+
+        String oauthClientId = jdbcTemplate.queryForObject(
+            "SELECT client_id FROM oauth2_registered_client WHERE id = ?",
+            String.class, result.client().registeredClientId()
+        );
+
+        String tokenJson = mockMvc.perform(post("/t/alpha-corp/oauth2/token")
+                .param("grant_type", "client_credentials")
+                .param("scope", "read")
+                .with(httpBasic(oauthClientId, result.rawSecret())))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.access_token").exists())
+            .andReturn().getResponse().getContentAsString();
+
+        String accessToken = objectMapper.readTree(tokenJson).get("access_token").asText();
+        Map<String, Object> claims = SignedJWT.parse(accessToken).getJWTClaimsSet().getClaims();
+
+        assertThat(claims.get("tenant")).isEqualTo("alpha-corp");
+        assertThat(claims.get("roles")).isInstanceOf(List.class);
+        assertThat((List<?>) claims.get("roles")).isEmpty();
+        assertThat(claims.get("iss")).asString().isEqualTo("http://localhost/t/alpha-corp");
+    }
+
+    @Test
+    void authorizationCodePkceFlowProducesTokenWithTenantClaims() throws Exception {
+        userRepository.save(new User(
+            null, alphaCorpTenant.id(), "alice",
+            passwordEncoder.encode("password"),
+            true, false, false, LocalDateTime.now()
+        ));
+
+        // Create public PKCE client with consent disabled (bypasses consent step in test)
+        String internalId = UUID.randomUUID().toString();
+        String clientId = UUID.randomUUID().toString();
+        RegisteredClient rc = RegisteredClient.withId(internalId)
+            .clientId(clientId)
+            .clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .redirectUri("http://localhost/callback")
+            .scope(OidcScopes.OPENID)
+            .clientSettings(ClientSettings.builder()
+                .requireProofKey(true)
+                .requireAuthorizationConsent(false)
+                .build())
+            .build();
+        registeredClientRepository.save(rc);
+        tenantClientRepository.save(new TenantClient(
+            null, internalId, alphaApp.id(), alphaCorpTenant.id(), "PKCE Test Client", false
+        ));
+
+        // PKCE code verifier + challenge
+        byte[] verifierBytes = new byte[32];
+        new SecureRandom().nextBytes(verifierBytes);
+        String codeVerifier = Base64.getUrlEncoder().withoutPadding().encodeToString(verifierBytes);
+        byte[] hash = MessageDigest.getInstance("SHA-256").digest(codeVerifier.getBytes(StandardCharsets.US_ASCII));
+        String codeChallenge = Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+
+        // 1. GET /t/alpha-corp/oauth2/authorize → redirect to /t/alpha-corp/login
+        String authzUri = UriComponentsBuilder.fromPath("/t/alpha-corp/oauth2/authorize")
+            .queryParam("response_type", "code")
+            .queryParam("client_id", clientId)
+            .queryParam("redirect_uri", "http://localhost/callback")
+            .queryParam("scope", OidcScopes.OPENID)
+            .queryParam("state", "test-state")
+            .queryParam("code_challenge", codeChallenge)
+            .queryParam("code_challenge_method", "S256")
+            .build().toUriString();
+
+        MockHttpSession session = new MockHttpSession();
+        MvcResult authzResult = mockMvc.perform(get(authzUri).session(session))
+            .andExpect(status().is3xxRedirection())
+            .andReturn();
+
+        String loginLocation = authzResult.getResponse().getHeader("Location");
+        assertThat(loginLocation).contains("/t/alpha-corp/login");
+
+        // 2. POST /t/alpha-corp/login → redirect to /t/alpha-corp/oauth2/authorize
+        MvcResult loginResult = mockMvc.perform(post("/t/alpha-corp/login")
+                .param("username", "alice")
+                .param("password", "password")
+                .session(session)
+                .with(csrf()))
+            .andExpect(status().is3xxRedirection())
+            .andReturn();
+
+        String postLoginLocation = loginResult.getResponse().getHeader("Location");
+        assertThat(postLoginLocation).contains("/t/alpha-corp/oauth2/authorize");
+
+        // 3. GET /t/alpha-corp/oauth2/authorize (authenticated) → redirect with authorization code
+        MvcResult codeResult = mockMvc.perform(get(postLoginLocation).session(session))
+            .andExpect(status().is3xxRedirection())
+            .andReturn();
+
+        String codeLocation = codeResult.getResponse().getHeader("Location");
+        String code = UriComponentsBuilder.fromUriString(codeLocation).build()
+            .getQueryParams().getFirst("code");
+        assertThat(code).isNotBlank();
+
+        // 4. POST /t/alpha-corp/oauth2/token → access token
+        String tokenJson = mockMvc.perform(post("/t/alpha-corp/oauth2/token")
+                .param("grant_type", "authorization_code")
+                .param("code", code)
+                .param("redirect_uri", "http://localhost/callback")
+                .param("code_verifier", codeVerifier)
+                .param("client_id", clientId))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.access_token").exists())
+            .andReturn().getResponse().getContentAsString();
+
+        String accessToken = objectMapper.readTree(tokenJson).get("access_token").asText();
+        Map<String, Object> claims = SignedJWT.parse(accessToken).getJWTClaimsSet().getClaims();
+
+        assertThat(claims.get("tenant")).isEqualTo("alpha-corp");
+        assertThat(claims.get("roles")).isInstanceOf(List.class);
+        assertThat((List<?>) claims.get("roles")).isEmpty();
+        assertThat(claims.get("iss")).asString().isEqualTo("http://localhost/t/alpha-corp");
+    }
+
+    @Test
+    void userinfoEndpointReturnsClaimsForTenantUser() throws Exception {
+        userRepository.save(new User(
+            null, alphaCorpTenant.id(), "bob",
+            passwordEncoder.encode("password"),
+            true, false, false, LocalDateTime.now()
+        ));
+
+        String internalId = UUID.randomUUID().toString();
+        String clientId = UUID.randomUUID().toString();
+        RegisteredClient rc = RegisteredClient.withId(internalId)
+            .clientId(clientId)
+            .clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .redirectUri("http://localhost/callback")
+            .scope(OidcScopes.OPENID)
+            .clientSettings(ClientSettings.builder()
+                .requireProofKey(true)
+                .requireAuthorizationConsent(false)
+                .build())
+            .build();
+        registeredClientRepository.save(rc);
+        tenantClientRepository.save(new TenantClient(
+            null, internalId, alphaApp.id(), alphaCorpTenant.id(), "UserInfo Test Client", false
+        ));
+
+        byte[] verifierBytes = new byte[32];
+        new SecureRandom().nextBytes(verifierBytes);
+        String codeVerifier = Base64.getUrlEncoder().withoutPadding().encodeToString(verifierBytes);
+        byte[] hash = MessageDigest.getInstance("SHA-256").digest(codeVerifier.getBytes(StandardCharsets.US_ASCII));
+        String codeChallenge = Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+
+        MockHttpSession session = new MockHttpSession();
+        mockMvc.perform(get(UriComponentsBuilder.fromPath("/t/alpha-corp/oauth2/authorize")
+                .queryParam("response_type", "code")
+                .queryParam("client_id", clientId)
+                .queryParam("redirect_uri", "http://localhost/callback")
+                .queryParam("scope", OidcScopes.OPENID)
+                .queryParam("state", "s1")
+                .queryParam("code_challenge", codeChallenge)
+                .queryParam("code_challenge_method", "S256")
+                .build().toUriString()).session(session))
+            .andExpect(status().is3xxRedirection());
+
+        mockMvc.perform(post("/t/alpha-corp/login")
+                .param("username", "bob")
+                .param("password", "password")
+                .session(session)
+                .with(csrf()))
+            .andExpect(status().is3xxRedirection());
+
+        MvcResult codeResult = mockMvc.perform(get(UriComponentsBuilder.fromPath("/t/alpha-corp/oauth2/authorize")
+                .queryParam("response_type", "code")
+                .queryParam("client_id", clientId)
+                .queryParam("redirect_uri", "http://localhost/callback")
+                .queryParam("scope", OidcScopes.OPENID)
+                .queryParam("state", "s1")
+                .queryParam("code_challenge", codeChallenge)
+                .queryParam("code_challenge_method", "S256")
+                .build().toUriString()).session(session))
+            .andExpect(status().is3xxRedirection())
+            .andReturn();
+
+        String code = UriComponentsBuilder.fromUriString(codeResult.getResponse().getHeader("Location"))
+            .build().getQueryParams().getFirst("code");
+
+        String tokenJson = mockMvc.perform(post("/t/alpha-corp/oauth2/token")
+                .param("grant_type", "authorization_code")
+                .param("code", code)
+                .param("redirect_uri", "http://localhost/callback")
+                .param("code_verifier", codeVerifier)
+                .param("client_id", clientId))
+            .andExpect(status().isOk())
+            .andReturn().getResponse().getContentAsString();
+
+        String accessToken = objectMapper.readTree(tokenJson).get("access_token").asText();
+
+        mockMvc.perform(get("/t/alpha-corp/userinfo")
+                .header("Authorization", "Bearer " + accessToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.sub").isNotEmpty());
     }
 }


### PR DESCRIPTION
## Summary

- Adds `tenant` and `roles` claims to all access tokens via `OAuth2TokenCustomizer<JwtEncodingContext>` in `SasConfig`
- Extends `TenantOAuth2RoutingFilter` to handle `/t/{slug}/login` and `/t/{slug}/userinfo`, storing slug in session for post-login redirect reconstruction
- Fixes `AuthUserDetailsService` to load users from the current tenant (via `TenantContext`) rather than always using the system tenant
- Adds `TenantLoginUrlAuthenticationEntryPoint` to redirect unauthenticated OAuth2 requests to `/t/{slug}/login`
- Adds `TenantLoginSuccessHandler` to reconstruct the tenant-prefixed authorize URL after login (saved request has the stripped path)
- Updates login form to post to `/t/{slug}/login` dynamically when in a tenant OAuth2 context

## Test plan

- [x] All 64 existing tests still pass
- [x] `clientCredentialsTokenIncludesTenantAndRolesClaims` — verifies `tenant`, `roles`, and `iss` claims on a `client_credentials` access token
- [x] `authorizationCodePkceFlowProducesTokenWithTenantClaims` — drives the full auth code + PKCE flow end-to-end via MockMvc (authorize → login → authorize → code exchange) and asserts JWT claims
- [x] `userinfoEndpointReturnsClaimsForTenantUser` — verifies the OIDC UserInfo endpoint responds correctly with a tenant-scoped access token

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)