### PR TITLE
Tenant-scope OAuth2AuthorizationService (#14)

### DIFF
--- a/src/main/java/com/stucray/limen/oauth2/TenantAwareOAuth2AuthorizationService.java
+++ b/src/main/java/com/stucray/limen/oauth2/TenantAwareOAuth2AuthorizationService.java
@@ -1,0 +1,112 @@
+package com.stucray.limen.oauth2;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.oauth2.server.authorization.JdbcOAuth2AuthorizationService;
+import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
+import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.util.Assert;
+
+import java.util.List;
+
+/**
+ * Decorates an OAuth2AuthorizationService to enforce tenant isolation at the storage layer.
+ *
+ * Save delegates to the wrapped service then UPDATEs tenant_id on the inserted row from
+ * TenantContext. Reads run tenant-filtered SQL using Spring's OAuth2AuthorizationRowMapper.
+ * findByToken delegates to inherit Spring's column-routing for token types, then re-fetches
+ * via the tenant-filtered findById.
+ *
+ * All operations require a TenantContext; missing context throws IllegalStateException.
+ */
+public class TenantAwareOAuth2AuthorizationService implements OAuth2AuthorizationService {
+
+    private final OAuth2AuthorizationService delegate;
+    private final JdbcTemplate jdbcTemplate;
+    private final JdbcOAuth2AuthorizationService.JsonMapperOAuth2AuthorizationRowMapper rowMapper;
+
+    public TenantAwareOAuth2AuthorizationService(
+        OAuth2AuthorizationService delegate,
+        JdbcTemplate jdbcTemplate,
+        RegisteredClientRepository registeredClientRepository
+    ) {
+        this.delegate = delegate;
+        this.jdbcTemplate = jdbcTemplate;
+        this.rowMapper = new JdbcOAuth2AuthorizationService.JsonMapperOAuth2AuthorizationRowMapper(registeredClientRepository);
+    }
+
+    @Override
+    public void save(OAuth2Authorization authorization) {
+        Assert.notNull(authorization, "authorization cannot be null");
+        Long tenantId = requireTenantId();
+        delegate.save(authorization);
+        jdbcTemplate.update(
+            "UPDATE oauth2_authorization SET tenant_id = ? WHERE id = ? AND (tenant_id IS NULL OR tenant_id = ?)",
+            tenantId, authorization.getId(), tenantId
+        );
+    }
+
+    @Override
+    public void remove(OAuth2Authorization authorization) {
+        Assert.notNull(authorization, "authorization cannot be null");
+        requireTenantId();
+        delegate.remove(authorization);
+    }
+
+    @Override
+    public OAuth2Authorization findById(String id) {
+        Assert.hasText(id, "id cannot be empty");
+        Long tenantId = requireTenantId();
+        List<OAuth2Authorization> result = jdbcTemplate.query(
+            "SELECT * FROM oauth2_authorization WHERE id = ? AND tenant_id = ?",
+            rowMapper, id, tenantId
+        );
+        return result.isEmpty() ? null : result.get(0);
+    }
+
+    @Override
+    public OAuth2Authorization findByToken(String token, OAuth2TokenType tokenType) {
+        Assert.hasText(token, "token cannot be empty");
+        Long tenantId = requireTenantId();
+        String sql;
+        Object[] params;
+        String column = tokenColumn(tokenType);
+        if (column == null) {
+            sql = "SELECT id FROM oauth2_authorization WHERE tenant_id = ? AND ("
+                + "state = ? OR authorization_code_value = ? OR access_token_value = ? OR "
+                + "oidc_id_token_value = ? OR refresh_token_value = ? OR user_code_value = ? OR "
+                + "device_code_value = ?)";
+            params = new Object[]{tenantId, token, token, token, token, token, token, token};
+        } else {
+            sql = "SELECT id FROM oauth2_authorization WHERE tenant_id = ? AND " + column + " = ?";
+            params = new Object[]{tenantId, token};
+        }
+        List<String> ids = jdbcTemplate.queryForList(sql, String.class, params);
+        return ids.isEmpty() ? null : findById(ids.get(0));
+    }
+
+    private static String tokenColumn(OAuth2TokenType tokenType) {
+        if (tokenType == null) return null;
+        return switch (tokenType.getValue()) {
+            case "state" -> "state";
+            case "code" -> "authorization_code_value";
+            case "access_token" -> "access_token_value";
+            case "id_token" -> "oidc_id_token_value";
+            case "refresh_token" -> "refresh_token_value";
+            case "user_code" -> "user_code_value";
+            case "device_code" -> "device_code_value";
+            default -> null;
+        };
+    }
+
+    private static Long requireTenantId() {
+        Long tenantId = TenantContext.getTenantId();
+        if (tenantId == null) {
+            throw new IllegalStateException(
+                "TenantAwareOAuth2AuthorizationService called without TenantContext"
+            );
+        }
+        return tenantId;
+    }
+}

--- a/src/main/java/com/stucray/limen/security/SasConfig.java
+++ b/src/main/java/com/stucray/limen/security/SasConfig.java
@@ -1,6 +1,7 @@
 package com.stucray.limen.security;
 
 import com.stucray.limen.management.clients.TenantClientRepository;
+import com.stucray.limen.oauth2.TenantAwareOAuth2AuthorizationService;
 import com.stucray.limen.oauth2.TenantAwareRegisteredClientRepository;
 import com.stucray.limen.oauth2.TenantContext;
 import com.stucray.limen.oauth2.TenantIssuerContextFilter;
@@ -16,6 +17,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
 import org.springframework.security.oauth2.server.authorization.JdbcOAuth2AuthorizationConsentService;
 import org.springframework.security.oauth2.server.authorization.JdbcOAuth2AuthorizationService;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
 import org.springframework.security.oauth2.server.authorization.client.JdbcRegisteredClientRepository;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
 import org.springframework.security.oauth2.server.authorization.settings.AuthorizationServerSettings;
@@ -68,11 +70,13 @@ public class SasConfig {
     }
 
     @Bean
-    public JdbcOAuth2AuthorizationService authorizationService(
+    public OAuth2AuthorizationService authorizationService(
         JdbcTemplate jdbcTemplate,
         RegisteredClientRepository registeredClientRepository
     ) {
-        return new JdbcOAuth2AuthorizationService(jdbcTemplate, registeredClientRepository);
+        JdbcOAuth2AuthorizationService delegate =
+            new JdbcOAuth2AuthorizationService(jdbcTemplate, registeredClientRepository);
+        return new TenantAwareOAuth2AuthorizationService(delegate, jdbcTemplate, registeredClientRepository);
     }
 
     @Bean

--- a/src/main/resources/db/migration/V9__oauth2_authorization_tenant_scope.sql
+++ b/src/main/resources/db/migration/V9__oauth2_authorization_tenant_scope.sql
@@ -1,0 +1,41 @@
+DROP TABLE IF EXISTS oauth2_authorization;
+
+CREATE TABLE oauth2_authorization (
+    id varchar(100) NOT NULL,
+    tenant_id bigint REFERENCES tenants(id) ON DELETE CASCADE,
+    registered_client_id varchar(100) NOT NULL,
+    principal_name varchar(200) NOT NULL,
+    authorization_grant_type varchar(100) NOT NULL,
+    authorized_scopes varchar(1000) DEFAULT NULL,
+    attributes text DEFAULT NULL,
+    state varchar(500) DEFAULT NULL,
+    authorization_code_value text DEFAULT NULL,
+    authorization_code_issued_at timestamp DEFAULT NULL,
+    authorization_code_expires_at timestamp DEFAULT NULL,
+    authorization_code_metadata text DEFAULT NULL,
+    access_token_value text DEFAULT NULL,
+    access_token_issued_at timestamp DEFAULT NULL,
+    access_token_expires_at timestamp DEFAULT NULL,
+    access_token_metadata text DEFAULT NULL,
+    access_token_type varchar(100) DEFAULT NULL,
+    access_token_scopes varchar(1000) DEFAULT NULL,
+    oidc_id_token_value text DEFAULT NULL,
+    oidc_id_token_issued_at timestamp DEFAULT NULL,
+    oidc_id_token_expires_at timestamp DEFAULT NULL,
+    oidc_id_token_metadata text DEFAULT NULL,
+    refresh_token_value text DEFAULT NULL,
+    refresh_token_issued_at timestamp DEFAULT NULL,
+    refresh_token_expires_at timestamp DEFAULT NULL,
+    refresh_token_metadata text DEFAULT NULL,
+    user_code_value text DEFAULT NULL,
+    user_code_issued_at timestamp DEFAULT NULL,
+    user_code_expires_at timestamp DEFAULT NULL,
+    user_code_metadata text DEFAULT NULL,
+    device_code_value text DEFAULT NULL,
+    device_code_issued_at timestamp DEFAULT NULL,
+    device_code_expires_at timestamp DEFAULT NULL,
+    device_code_metadata text DEFAULT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_oauth2_authorization_tenant_id ON oauth2_authorization (tenant_id);

--- a/src/test/java/com/stucray/limen/IssuerContractTest.java
+++ b/src/test/java/com/stucray/limen/IssuerContractTest.java
@@ -107,68 +107,9 @@ class IssuerContractTest {
             .andExpect(jsonPath("$.keys[0].kid").isNotEmpty());
     }
 
-    @Test
-    void authorizationCodeFlowProducesTokenVerifiableAgainstJwks() throws Exception {
-        // 1. Log in to get an authenticated session
-        MvcResult loginResult = mockMvc.perform(post("/login")
-                .param("username", "testuser")
-                .param("password", "password")
-                .with(csrf()))
-            .andExpect(status().is3xxRedirection())
-            .andReturn();
-        MockHttpSession session = (MockHttpSession) loginResult.getRequest().getSession(false);
-
-        // 2. Generate PKCE code verifier + challenge (S256)
-        byte[] verifierBytes = new byte[32];
-        new SecureRandom().nextBytes(verifierBytes);
-        String codeVerifier = Base64.getUrlEncoder().withoutPadding().encodeToString(verifierBytes);
-        byte[] hash = MessageDigest.getInstance("SHA-256").digest(codeVerifier.getBytes(StandardCharsets.US_ASCII));
-        String codeChallenge = Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
-
-        // 3. Authorization request — should redirect straight to the redirect_uri (no consent).
-        // Query params must be in the URI string (not .param()) so MockMvc sets getQueryString(),
-        // which SAS 7's OAuth2EndpointUtils.getQueryParameters() requires to filter query vs form params.
-        String authzUri = UriComponentsBuilder.fromPath("/oauth2/authorize")
-            .queryParam("response_type", "code")
-            .queryParam("client_id", CLIENT_ID)
-            .queryParam("redirect_uri", REDIRECT_URI)
-            .queryParam("scope", "openid profile")
-            .queryParam("state", "test-state")
-            .queryParam("code_challenge", codeChallenge)
-            .queryParam("code_challenge_method", "S256")
-            .build().toUriString();
-        MvcResult authzResult = mockMvc.perform(get(authzUri).session(session))
-            .andExpect(status().is3xxRedirection())
-            .andReturn();
-
-        String location = authzResult.getResponse().getHeader("Location");
-        String code = UriComponentsBuilder.fromUriString(location).build()
-            .getQueryParams().getFirst("code");
-        assertThat(code).isNotBlank();
-
-        // 4. Exchange code for tokens
-        MvcResult tokenResult = mockMvc.perform(post("/oauth2/token")
-                .param("grant_type", "authorization_code")
-                .param("code", code)
-                .param("redirect_uri", REDIRECT_URI)
-                .param("code_verifier", codeVerifier)
-                .with(httpBasic(CLIENT_ID, CLIENT_SECRET)))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.access_token").exists())
-            .andReturn();
-
-        // 5. Verify token signature against JWKS
-        String tokenJson = tokenResult.getResponse().getContentAsString();
-        String accessToken = objectMapper.readTree(tokenJson).get("access_token").asText();
-        SignedJWT signedJWT = SignedJWT.parse(accessToken);
-
-        MvcResult jwksResult = mockMvc.perform(get("/oauth2/jwks")).andReturn();
-        JWKSet jwkSet = JWKSet.parse(jwksResult.getResponse().getContentAsString());
-
-        JWK matchingKey = jwkSet.getKeyByKeyId(signedJWT.getHeader().getKeyID());
-        assertThat(matchingKey).as("JWKS must contain the key that signed the token").isNotNull();
-
-        RSAPublicKey publicKey = (RSAPublicKey) matchingKey.toRSAKey().toPublicKey();
-        assertThat(signedJWT.verify(new RSASSAVerifier(publicKey))).isTrue();
-    }
+    // Legacy global authorization-code flow test removed: end-to-end token issuance is now
+    // tenant-scoped (see TenantOAuth2RoutingIntegrationTest#authorizationCodePkceFlowProducesTokenWithTenantClaims).
+    // Calling the global /oauth2/authorize without going through the /t/{slug}/ routing filter
+    // intentionally fails because TenantAwareOAuth2AuthorizationService hard-fails on missing
+    // TenantContext to surface filter-chain misconfigurations (parent PRD #13 user story 9).
 }

--- a/src/test/java/com/stucray/limen/oauth2/TenantAwareOAuth2AuthorizationServiceIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/TenantAwareOAuth2AuthorizationServiceIntegrationTest.java
@@ -1,0 +1,170 @@
+package com.stucray.limen.oauth2;
+
+import com.stucray.limen.TestcontainersConfiguration;
+import com.stucray.limen.management.applications.Application;
+import com.stucray.limen.management.applications.ApplicationRepository;
+import com.stucray.limen.management.clients.TenantClient;
+import com.stucray.limen.management.clients.TenantClientRepository;
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.tenant.TenantStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
+import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest(properties = {"LIMEN_SIGNING_KEY_PATH=./target/test-signing-key.jwk"})
+class TenantAwareOAuth2AuthorizationServiceIntegrationTest {
+
+    @Autowired OAuth2AuthorizationService authorizationService;
+    @Autowired RegisteredClientRepository registeredClientRepository;
+    @Autowired TenantRepository tenantRepository;
+    @Autowired ApplicationRepository applicationRepository;
+    @Autowired TenantClientRepository tenantClientRepository;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    Tenant alpha;
+    Tenant beta;
+    RegisteredClient client;
+    Application alphaApp;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.execute("DELETE FROM oauth2_authorization");
+        jdbcTemplate.execute("DELETE FROM client_metadata");
+        jdbcTemplate.execute("DELETE FROM oauth2_registered_client");
+        jdbcTemplate.execute("DELETE FROM applications");
+        jdbcTemplate.execute("DELETE FROM tenants WHERE slug IN ('iso-alpha', 'iso-beta')");
+
+        alpha = tenantRepository.save(new Tenant(
+            null, "iso-alpha", "Iso Alpha", TenantStatus.ACTIVE, LocalDateTime.now()
+        ));
+        beta = tenantRepository.save(new Tenant(
+            null, "iso-beta", "Iso Beta", TenantStatus.ACTIVE, LocalDateTime.now()
+        ));
+        alphaApp = applicationRepository.save(new Application(
+            null, alpha.id(), "Alpha App", "Test app", LocalDateTime.now()
+        ));
+
+        String internalId = UUID.randomUUID().toString();
+        client = RegisteredClient.withId(internalId)
+            .clientId(UUID.randomUUID().toString())
+            .clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .redirectUri("http://localhost/callback")
+            .scope("openid")
+            .build();
+        registeredClientRepository.save(client);
+        // Map client to alpha so TenantAwareRegisteredClientRepository#findById succeeds
+        // for the row mapper when reading authorizations under alpha context.
+        tenantClientRepository.save(new TenantClient(
+            null, internalId, alphaApp.id(), alpha.id(), "Iso Test Client", false
+        ));
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void saveWithoutTenantContextThrows() {
+        OAuth2Authorization auth = buildAuthorizationWithAccessToken("alice", "tok-1");
+
+        assertThatThrownBy(() -> authorizationService.save(auth))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("TenantContext");
+    }
+
+    @Test
+    void findByIdWithoutTenantContextThrows() {
+        assertThatThrownBy(() -> authorizationService.findById("any-id"))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("TenantContext");
+    }
+
+    @Test
+    void findByTokenWithoutTenantContextThrows() {
+        assertThatThrownBy(() -> authorizationService.findByToken("any-token", OAuth2TokenType.ACCESS_TOKEN))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("TenantContext");
+    }
+
+    @Test
+    void crossTenantFindByIdReturnsNull() {
+        TenantContext.set(alpha.slug(), alpha.id());
+        OAuth2Authorization saved = buildAuthorizationWithAccessToken("alice", "tok-alpha-1");
+        authorizationService.save(saved);
+
+        // Verify alpha can read it back
+        assertThat(authorizationService.findById(saved.getId())).isNotNull();
+
+        // Switch context to beta
+        TenantContext.set(beta.slug(), beta.id());
+        assertThat(authorizationService.findById(saved.getId())).isNull();
+    }
+
+    @Test
+    void crossTenantFindByTokenReturnsNull() {
+        TenantContext.set(alpha.slug(), alpha.id());
+        OAuth2Authorization saved = buildAuthorizationWithAccessToken("alice", "tok-alpha-2");
+        authorizationService.save(saved);
+
+        // Verify alpha can find by access token
+        OAuth2Authorization underAlpha =
+            authorizationService.findByToken("tok-alpha-2", OAuth2TokenType.ACCESS_TOKEN);
+        assertThat(underAlpha).isNotNull();
+        assertThat(underAlpha.getId()).isEqualTo(saved.getId());
+
+        // Beta cannot find it even with the exact token value
+        TenantContext.set(beta.slug(), beta.id());
+        assertThat(authorizationService.findByToken("tok-alpha-2", OAuth2TokenType.ACCESS_TOKEN)).isNull();
+    }
+
+    @Test
+    void savePersistsTenantIdColumn() {
+        TenantContext.set(alpha.slug(), alpha.id());
+        OAuth2Authorization saved = buildAuthorizationWithAccessToken("alice", "tok-alpha-3");
+        authorizationService.save(saved);
+
+        Long persistedTenantId = jdbcTemplate.queryForObject(
+            "SELECT tenant_id FROM oauth2_authorization WHERE id = ?",
+            Long.class, saved.getId()
+        );
+        assertThat(persistedTenantId).isEqualTo(alpha.id());
+    }
+
+    private OAuth2Authorization buildAuthorizationWithAccessToken(String principalName, String tokenValue) {
+        OAuth2AccessToken accessToken = new OAuth2AccessToken(
+            OAuth2AccessToken.TokenType.BEARER,
+            tokenValue,
+            Instant.now(),
+            Instant.now().plusSeconds(300)
+        );
+        return OAuth2Authorization.withRegisteredClient(client)
+            .id(UUID.randomUUID().toString())
+            .principalName(principalName)
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .accessToken(accessToken)
+            .build();
+    }
+}


### PR DESCRIPTION
Closes #14 (Slice 1 of #13).

## Summary

- Add `TenantAwareOAuth2AuthorizationService` decorator over `JdbcOAuth2AuthorizationService` that scopes authorization storage to the current `TenantContext`.
- Add Flyway V9 migration: drop and recreate `oauth2_authorization` with a `tenant_id` column referencing `tenants(id)`.
- Wire the decorator as the `OAuth2AuthorizationService` bean in `SasConfig`.
- Cross-tenant isolation tests in `TenantAwareOAuth2AuthorizationServiceIntegrationTest`.

## Key implementation notes

- **Row mapper:** uses `JsonMapperOAuth2AuthorizationRowMapper` (Jackson 3, JSR-310-aware) — the deprecated Jackson 2 `OAuth2AuthorizationRowMapper` is what Spring AS itself moved away from in 7.0 and doesn't deserialize Spring Security 7's `FactorGrantedAuthority.issuedAt`.
- **`findByToken` does a tenant-scoped id lookup first**, then delegates to the tenant-filtered `findById`. Filtering at the SQL level avoids invoking the row mapper on a foreign-tenant row (which would otherwise throw `DataRetrievalFailureException` because `TenantAwareRegisteredClientRepository` denies the client lookup under a different tenant).
- **Save's UPDATE is guarded by `(tenant_id IS NULL OR tenant_id = ?)`** so an existing row's owner can never be silently overwritten by a misconfigured caller.
- **Hard-fail on missing `TenantContext`** (parent PRD user story 9). The redundant legacy auth-code test in `IssuerContractTest` is removed; `TenantOAuth2RoutingIntegrationTest.authorizationCodePkceFlowProducesTokenWithTenantClaims` already covers the supported tenant-scoped path.

## Deviation from acceptance criteria

The issue checklist says `tenant_id BIGINT NOT NULL`, but `Jdbc OAuth2AuthorizationService.save` inserts without a `tenant_id` value, so the delegate-then-UPDATE strategy in the parent PRD necessarily produces a brief window with `tenant_id` NULL. The PRD's "Implementation Decisions" section explicitly accepts this, so the migration uses a nullable `tenant_id`. Tenant-filtered reads exclude NULL rows naturally, preserving isolation.

## Test plan

- [x] `./mvnw test` — 74 tests, all passing
- [x] `TenantAwareOAuth2AuthorizationServiceIntegrationTest` — cross-tenant `findById`/`findByToken` return null, `tenant_id` is persisted, and missing `TenantContext` throws `IllegalStateException`
- [x] `TenantOAuth2RoutingIntegrationTest` — full auth-code + PKCE flow under `/t/alpha-corp/` continues to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)