### PR TITLE
Tenant-scope OAuth2AuthorizationConsentService (#15)

### DIFF
--- a/src/main/java/com/stucray/limen/oauth2/TenantAwareOAuth2AuthorizationConsentService.java
+++ b/src/main/java/com/stucray/limen/oauth2/TenantAwareOAuth2AuthorizationConsentService.java
@@ -1,0 +1,127 @@
+package com.stucray.limen.oauth2;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.server.authorization.JdbcOAuth2AuthorizationConsentService;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsent;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsentService;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Tenant-scoped OAuth2AuthorizationConsentService.
+ *
+ * Spring's JdbcOAuth2AuthorizationConsentService writes (registered_client_id, principal_name,
+ * authorities) — its INSERT cannot supply tenant_id, so a delegate-then-UPDATE strategy would
+ * violate the parent PRD's NOT NULL composite PK on (tenant_id, registered_client_id,
+ * principal_name). Instead we write tenant-aware SQL directly and reuse Spring's public
+ * row mapper / parameters mapper for value translation.
+ *
+ * All operations require a TenantContext; missing context throws IllegalStateException.
+ */
+public class TenantAwareOAuth2AuthorizationConsentService implements OAuth2AuthorizationConsentService {
+
+    private static final String INSERT_SQL =
+        "INSERT INTO oauth2_authorization_consent "
+        + "(tenant_id, registered_client_id, principal_name, authorities) VALUES (?, ?, ?, ?)";
+
+    private static final String UPDATE_SQL =
+        "UPDATE oauth2_authorization_consent SET authorities = ? "
+        + "WHERE tenant_id = ? AND registered_client_id = ? AND principal_name = ?";
+
+    private static final String DELETE_SQL =
+        "DELETE FROM oauth2_authorization_consent "
+        + "WHERE tenant_id = ? AND registered_client_id = ? AND principal_name = ?";
+
+    private static final String SELECT_SQL =
+        "SELECT registered_client_id, principal_name, authorities FROM oauth2_authorization_consent "
+        + "WHERE tenant_id = ? AND registered_client_id = ? AND principal_name = ?";
+
+    private final JdbcTemplate jdbcTemplate;
+    private final JdbcOAuth2AuthorizationConsentService.OAuth2AuthorizationConsentRowMapper rowMapper;
+
+    public TenantAwareOAuth2AuthorizationConsentService(
+        JdbcTemplate jdbcTemplate,
+        RegisteredClientRepository registeredClientRepository
+    ) {
+        Assert.notNull(jdbcTemplate, "jdbcTemplate cannot be null");
+        Assert.notNull(registeredClientRepository, "registeredClientRepository cannot be null");
+        this.jdbcTemplate = jdbcTemplate;
+        this.rowMapper =
+            new JdbcOAuth2AuthorizationConsentService.OAuth2AuthorizationConsentRowMapper(registeredClientRepository);
+    }
+
+    @Override
+    public void save(OAuth2AuthorizationConsent authorizationConsent) {
+        Assert.notNull(authorizationConsent, "authorizationConsent cannot be null");
+        Long tenantId = requireTenantId();
+        String authorities = serializedAuthorities(authorizationConsent);
+        OAuth2AuthorizationConsent existing = findById(
+            authorizationConsent.getRegisteredClientId(),
+            authorizationConsent.getPrincipalName()
+        );
+        if (existing == null) {
+            jdbcTemplate.update(
+                INSERT_SQL,
+                tenantId,
+                authorizationConsent.getRegisteredClientId(),
+                authorizationConsent.getPrincipalName(),
+                authorities
+            );
+        } else {
+            jdbcTemplate.update(
+                UPDATE_SQL,
+                authorities,
+                tenantId,
+                authorizationConsent.getRegisteredClientId(),
+                authorizationConsent.getPrincipalName()
+            );
+        }
+    }
+
+    @Override
+    public void remove(OAuth2AuthorizationConsent authorizationConsent) {
+        Assert.notNull(authorizationConsent, "authorizationConsent cannot be null");
+        Long tenantId = requireTenantId();
+        jdbcTemplate.update(
+            DELETE_SQL,
+            tenantId,
+            authorizationConsent.getRegisteredClientId(),
+            authorizationConsent.getPrincipalName()
+        );
+    }
+
+    @Override
+    public OAuth2AuthorizationConsent findById(String registeredClientId, String principalName) {
+        Assert.hasText(registeredClientId, "registeredClientId cannot be empty");
+        Assert.hasText(principalName, "principalName cannot be empty");
+        Long tenantId = requireTenantId();
+        List<OAuth2AuthorizationConsent> result = jdbcTemplate.query(
+            SELECT_SQL, rowMapper, tenantId, registeredClientId, principalName
+        );
+        return result.isEmpty() ? null : result.get(0);
+    }
+
+    private static String serializedAuthorities(OAuth2AuthorizationConsent consent) {
+        Set<String> authorities = new HashSet<>();
+        for (GrantedAuthority authority : consent.getAuthorities()) {
+            authorities.add(authority.getAuthority());
+        }
+        return StringUtils.collectionToDelimitedString(authorities, ",");
+    }
+
+    private static Long requireTenantId() {
+        Long tenantId = TenantContext.getTenantId();
+        if (tenantId == null) {
+            throw new IllegalStateException(
+                "TenantAwareOAuth2AuthorizationConsentService called without TenantContext"
+            );
+        }
+        return tenantId;
+    }
+}

--- a/src/main/java/com/stucray/limen/security/SasConfig.java
+++ b/src/main/java/com/stucray/limen/security/SasConfig.java
@@ -1,6 +1,7 @@
 package com.stucray.limen.security;
 
 import com.stucray.limen.management.clients.TenantClientRepository;
+import com.stucray.limen.oauth2.TenantAwareOAuth2AuthorizationConsentService;
 import com.stucray.limen.oauth2.TenantAwareRegisteredClientRepository;
 import com.stucray.limen.oauth2.TenantContext;
 import com.stucray.limen.oauth2.TenantIssuerContextFilter;
@@ -14,8 +15,8 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
-import org.springframework.security.oauth2.server.authorization.JdbcOAuth2AuthorizationConsentService;
 import org.springframework.security.oauth2.server.authorization.JdbcOAuth2AuthorizationService;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsentService;
 import org.springframework.security.oauth2.server.authorization.client.JdbcRegisteredClientRepository;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
 import org.springframework.security.oauth2.server.authorization.settings.AuthorizationServerSettings;
@@ -76,11 +77,11 @@ public class SasConfig {
     }
 
     @Bean
-    public JdbcOAuth2AuthorizationConsentService authorizationConsentService(
+    public OAuth2AuthorizationConsentService authorizationConsentService(
         JdbcTemplate jdbcTemplate,
         RegisteredClientRepository registeredClientRepository
     ) {
-        return new JdbcOAuth2AuthorizationConsentService(jdbcTemplate, registeredClientRepository);
+        return new TenantAwareOAuth2AuthorizationConsentService(jdbcTemplate, registeredClientRepository);
     }
 
     @Bean

--- a/src/main/resources/db/migration/V10__oauth2_authorization_consent_tenant_scope.sql
+++ b/src/main/resources/db/migration/V10__oauth2_authorization_consent_tenant_scope.sql
@@ -1,0 +1,9 @@
+DROP TABLE IF EXISTS oauth2_authorization_consent;
+
+CREATE TABLE oauth2_authorization_consent (
+    tenant_id bigint NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    registered_client_id varchar(100) NOT NULL,
+    principal_name varchar(200) NOT NULL,
+    authorities varchar(1000) NOT NULL,
+    PRIMARY KEY (tenant_id, registered_client_id, principal_name)
+);

--- a/src/test/java/com/stucray/limen/IssuerContractTest.java
+++ b/src/test/java/com/stucray/limen/IssuerContractTest.java
@@ -1,10 +1,5 @@
 package com.stucray.limen;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.nimbusds.jose.crypto.RSASSAVerifier;
-import com.nimbusds.jose.jwk.JWK;
-import com.nimbusds.jose.jwk.JWKSet;
-import com.nimbusds.jwt.SignedJWT;
 import com.stucray.limen.tenant.TenantRepository;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
@@ -14,7 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Import;
-import org.springframework.mock.web.MockHttpSession;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
@@ -23,22 +17,11 @@ import org.springframework.security.oauth2.server.authorization.client.Registere
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
 import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.web.util.UriComponentsBuilder;
 
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.SecureRandom;
-import java.security.interfaces.RSAPublicKey;
 import java.time.LocalDateTime;
-import java.util.Base64;
 import java.util.UUID;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -59,12 +42,9 @@ class IssuerContractTest {
     @Autowired PasswordEncoder passwordEncoder;
     @Autowired RegisteredClientRepository registeredClientRepository;
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
-
     @BeforeEach
     void setUp() {
         Long systemTenantId = tenantRepository.findBySlug("system").orElseThrow().id();
-        userRepository.findByUsernameAndTenantId("testuser", systemTenantId).ifPresent(u -> {});
         if (!userRepository.existsByUsernameAndTenantId("testuser", systemTenantId)) {
             userRepository.save(new User(null, systemTenantId, "testuser", passwordEncoder.encode("password"), true, false, false, LocalDateTime.now()));
         }
@@ -107,68 +87,4 @@ class IssuerContractTest {
             .andExpect(jsonPath("$.keys[0].kid").isNotEmpty());
     }
 
-    @Test
-    void authorizationCodeFlowProducesTokenVerifiableAgainstJwks() throws Exception {
-        // 1. Log in to get an authenticated session
-        MvcResult loginResult = mockMvc.perform(post("/login")
-                .param("username", "testuser")
-                .param("password", "password")
-                .with(csrf()))
-            .andExpect(status().is3xxRedirection())
-            .andReturn();
-        MockHttpSession session = (MockHttpSession) loginResult.getRequest().getSession(false);
-
-        // 2. Generate PKCE code verifier + challenge (S256)
-        byte[] verifierBytes = new byte[32];
-        new SecureRandom().nextBytes(verifierBytes);
-        String codeVerifier = Base64.getUrlEncoder().withoutPadding().encodeToString(verifierBytes);
-        byte[] hash = MessageDigest.getInstance("SHA-256").digest(codeVerifier.getBytes(StandardCharsets.US_ASCII));
-        String codeChallenge = Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
-
-        // 3. Authorization request — should redirect straight to the redirect_uri (no consent).
-        // Query params must be in the URI string (not .param()) so MockMvc sets getQueryString(),
-        // which SAS 7's OAuth2EndpointUtils.getQueryParameters() requires to filter query vs form params.
-        String authzUri = UriComponentsBuilder.fromPath("/oauth2/authorize")
-            .queryParam("response_type", "code")
-            .queryParam("client_id", CLIENT_ID)
-            .queryParam("redirect_uri", REDIRECT_URI)
-            .queryParam("scope", "openid profile")
-            .queryParam("state", "test-state")
-            .queryParam("code_challenge", codeChallenge)
-            .queryParam("code_challenge_method", "S256")
-            .build().toUriString();
-        MvcResult authzResult = mockMvc.perform(get(authzUri).session(session))
-            .andExpect(status().is3xxRedirection())
-            .andReturn();
-
-        String location = authzResult.getResponse().getHeader("Location");
-        String code = UriComponentsBuilder.fromUriString(location).build()
-            .getQueryParams().getFirst("code");
-        assertThat(code).isNotBlank();
-
-        // 4. Exchange code for tokens
-        MvcResult tokenResult = mockMvc.perform(post("/oauth2/token")
-                .param("grant_type", "authorization_code")
-                .param("code", code)
-                .param("redirect_uri", REDIRECT_URI)
-                .param("code_verifier", codeVerifier)
-                .with(httpBasic(CLIENT_ID, CLIENT_SECRET)))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.access_token").exists())
-            .andReturn();
-
-        // 5. Verify token signature against JWKS
-        String tokenJson = tokenResult.getResponse().getContentAsString();
-        String accessToken = objectMapper.readTree(tokenJson).get("access_token").asText();
-        SignedJWT signedJWT = SignedJWT.parse(accessToken);
-
-        MvcResult jwksResult = mockMvc.perform(get("/oauth2/jwks")).andReturn();
-        JWKSet jwkSet = JWKSet.parse(jwksResult.getResponse().getContentAsString());
-
-        JWK matchingKey = jwkSet.getKeyByKeyId(signedJWT.getHeader().getKeyID());
-        assertThat(matchingKey).as("JWKS must contain the key that signed the token").isNotNull();
-
-        RSAPublicKey publicKey = (RSAPublicKey) matchingKey.toRSAKey().toPublicKey();
-        assertThat(signedJWT.verify(new RSASSAVerifier(publicKey))).isTrue();
-    }
 }

--- a/src/test/java/com/stucray/limen/oauth2/TenantAwareOAuth2AuthorizationConsentServiceIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/TenantAwareOAuth2AuthorizationConsentServiceIntegrationTest.java
@@ -1,0 +1,210 @@
+package com.stucray.limen.oauth2;
+
+import com.stucray.limen.TestcontainersConfiguration;
+import com.stucray.limen.management.applications.Application;
+import com.stucray.limen.management.applications.ApplicationRepository;
+import com.stucray.limen.management.clients.TenantClient;
+import com.stucray.limen.management.clients.TenantClientRepository;
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.tenant.TenantStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsent;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsentService;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest(properties = {"LIMEN_SIGNING_KEY_PATH=./target/test-signing-key.jwk"})
+class TenantAwareOAuth2AuthorizationConsentServiceIntegrationTest {
+
+    @Autowired OAuth2AuthorizationConsentService consentService;
+    @Autowired RegisteredClientRepository registeredClientRepository;
+    @Autowired TenantRepository tenantRepository;
+    @Autowired ApplicationRepository applicationRepository;
+    @Autowired TenantClientRepository tenantClientRepository;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    Tenant alpha;
+    Tenant beta;
+    RegisteredClient client;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.execute("DELETE FROM oauth2_authorization_consent");
+        jdbcTemplate.execute("DELETE FROM client_metadata");
+        jdbcTemplate.execute("DELETE FROM oauth2_registered_client");
+        jdbcTemplate.execute("DELETE FROM applications");
+        jdbcTemplate.execute("DELETE FROM tenants WHERE slug IN ('consent-alpha', 'consent-beta')");
+
+        alpha = tenantRepository.save(new Tenant(
+            null, "consent-alpha", "Consent Alpha", TenantStatus.ACTIVE, LocalDateTime.now()
+        ));
+        beta = tenantRepository.save(new Tenant(
+            null, "consent-beta", "Consent Beta", TenantStatus.ACTIVE, LocalDateTime.now()
+        ));
+
+        Application alphaApp = applicationRepository.save(new Application(
+            null, alpha.id(), "Alpha App", "Test app", LocalDateTime.now()
+        ));
+
+        String internalId = UUID.randomUUID().toString();
+        client = RegisteredClient.withId(internalId)
+            .clientId(UUID.randomUUID().toString())
+            .clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .redirectUri("http://localhost/callback")
+            .scope("openid")
+            .build();
+        registeredClientRepository.save(client);
+        // Map client to alpha so reads under alpha context resolve via the row mapper.
+        // Cross-tenant reads in beta intentionally don't need a mapping — the tenant
+        // filter eliminates rows before the row mapper runs.
+        tenantClientRepository.save(new TenantClient(
+            null, internalId, alphaApp.id(), alpha.id(), "Alpha Client", false
+        ));
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void saveWithoutTenantContextThrows() {
+        OAuth2AuthorizationConsent consent = OAuth2AuthorizationConsent
+            .withId(client.getId(), "alice")
+            .authority(new SimpleGrantedAuthority("SCOPE_openid"))
+            .build();
+
+        assertThatThrownBy(() -> consentService.save(consent))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("TenantContext");
+    }
+
+    @Test
+    void findByIdWithoutTenantContextThrows() {
+        assertThatThrownBy(() -> consentService.findById(client.getId(), "alice"))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("TenantContext");
+    }
+
+    @Test
+    void removeWithoutTenantContextThrows() {
+        OAuth2AuthorizationConsent consent = OAuth2AuthorizationConsent
+            .withId(client.getId(), "alice")
+            .authority(new SimpleGrantedAuthority("SCOPE_openid"))
+            .build();
+
+        assertThatThrownBy(() -> consentService.remove(consent))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("TenantContext");
+    }
+
+    @Test
+    void crossTenantFindByIdReturnsNull() {
+        TenantContext.set(alpha.slug(), alpha.id());
+        OAuth2AuthorizationConsent consent = OAuth2AuthorizationConsent
+            .withId(client.getId(), "alice")
+            .authority(new SimpleGrantedAuthority("SCOPE_openid"))
+            .build();
+        consentService.save(consent);
+
+        assertThat(consentService.findById(client.getId(), "alice")).isNotNull();
+
+        TenantContext.set(beta.slug(), beta.id());
+        assertThat(consentService.findById(client.getId(), "alice")).isNull();
+    }
+
+    @Test
+    void savePersistsTenantIdColumn() {
+        TenantContext.set(alpha.slug(), alpha.id());
+        OAuth2AuthorizationConsent consent = OAuth2AuthorizationConsent
+            .withId(client.getId(), "alice")
+            .authority(new SimpleGrantedAuthority("SCOPE_openid"))
+            .build();
+        consentService.save(consent);
+
+        Long persistedTenantId = jdbcTemplate.queryForObject(
+            "SELECT tenant_id FROM oauth2_authorization_consent "
+                + "WHERE registered_client_id = ? AND principal_name = ?",
+            Long.class, client.getId(), "alice"
+        );
+        assertThat(persistedTenantId).isEqualTo(alpha.id());
+    }
+
+    @Test
+    void updateOverwritesAuthoritiesWithinTenant() {
+        TenantContext.set(alpha.slug(), alpha.id());
+        consentService.save(OAuth2AuthorizationConsent
+            .withId(client.getId(), "alice")
+            .authority(new SimpleGrantedAuthority("SCOPE_openid"))
+            .build());
+        consentService.save(OAuth2AuthorizationConsent
+            .withId(client.getId(), "alice")
+            .authority(new SimpleGrantedAuthority("SCOPE_openid"))
+            .authority(new SimpleGrantedAuthority("SCOPE_profile"))
+            .build());
+
+        OAuth2AuthorizationConsent consent = consentService.findById(client.getId(), "alice");
+        assertThat(consent).isNotNull();
+        assertThat(consent.getAuthorities())
+            .extracting("authority")
+            .containsExactlyInAnyOrder("SCOPE_openid", "SCOPE_profile");
+
+        Integer rowCount = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM oauth2_authorization_consent "
+                + "WHERE tenant_id = ? AND registered_client_id = ? AND principal_name = ?",
+            Integer.class, alpha.id(), client.getId(), "alice"
+        );
+        assertThat(rowCount).isEqualTo(1);
+    }
+
+    @Test
+    void removeDeletesOnlyCallingTenantsRow() {
+        TenantContext.set(alpha.slug(), alpha.id());
+        OAuth2AuthorizationConsent alphaConsent = OAuth2AuthorizationConsent
+            .withId(client.getId(), "alice")
+            .authority(new SimpleGrantedAuthority("SCOPE_openid"))
+            .build();
+        consentService.save(alphaConsent);
+
+        // Plant a row directly for tenant beta to verify remove is tenant-scoped.
+        // Bypassing the service avoids needing a beta client_metadata mapping (which
+        // the UNIQUE constraint on registered_client_id wouldn't allow).
+        jdbcTemplate.update(
+            "INSERT INTO oauth2_authorization_consent (tenant_id, registered_client_id, principal_name, authorities) "
+                + "VALUES (?, ?, ?, ?)",
+            beta.id(), client.getId(), "alice", "SCOPE_openid"
+        );
+
+        // Remove under alpha — beta's row should survive.
+        consentService.remove(alphaConsent);
+
+        Integer alphaRows = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM oauth2_authorization_consent WHERE tenant_id = ?",
+            Integer.class, alpha.id()
+        );
+        Integer betaRows = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM oauth2_authorization_consent WHERE tenant_id = ?",
+            Integer.class, beta.id()
+        );
+        assertThat(alphaRows).isZero();
+        assertThat(betaRows).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #15. Adds `TenantAwareOAuth2AuthorizationConsentService` so consent storage is scoped to the current `TenantContext`, satisfying PRD #13 user stories 2, 9, 13, and 16.

- New service writes its own tenant-aware SQL on `save`/`remove`/`findById` and reuses Spring's public `OAuth2AuthorizationConsentRowMapper`. It does **not** delegate to `JdbcOAuth2AuthorizationConsentService` — Spring's INSERT cannot supply `tenant_id`, and its `findById(rcid, pn)` "exists" probe is not tenant-filtered, so any delegate path would either violate the new NOT NULL constraint or leak across tenants.
- Unlike #14's nullable + delegate-then-UPDATE pattern, the consent table can use `NOT NULL` + composite PK `(tenant_id, registered_client_id, principal_name)` because the wrapper writes `tenant_id` atomically with the row insert.
- `SasConfig` swaps the bean from `JdbcOAuth2AuthorizationConsentService` to the new tenant-aware implementation.
- Migration `V10` drops and recreates `oauth2_authorization_consent` (data loss is acceptable per PRD — no production users yet).
- Removes `IssuerContractTest.authorizationCodeFlowProducesTokenVerifiableAgainstJwks` for the same reason #14 does: with `TenantContext` now required by the consent service, the legacy non-tenant-scoped auth-code path hard-fails by design. `TenantOAuth2RoutingIntegrationTest` covers the supported tenant-scoped path.

## Test plan

- [x] New `TenantAwareOAuth2AuthorizationConsentServiceIntegrationTest` (7 tests) covers: missing-context throws on save/find/remove; cross-tenant `findById` returns null; `tenant_id` persisted; in-tenant update overwrites; `remove` only deletes the calling tenant's row.
- [x] `TenantOAuth2RoutingIntegrationTest` still passes (acceptance criterion).
- [x] Full local suite: 75 tests, 0 failures (clean build).
- [ ] CI green.

## Notes for reviewers

- This PR can land before or after #14. Migration numbers don't conflict (#14 uses V9, this uses V10).
- Schema constraint `client_metadata.registered_client_id UNIQUE` means a registered client maps to exactly one tenant in practice, so the composite PK is defense-in-depth (and future-proofing if that uniqueness is ever relaxed). One test uses a direct JDBC insert to plant a beta-tenant row to verify `remove` is tenant-scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)