### PR TITLE
Implement SigningKeyStore + encryption-at-rest (#16)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,15 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<environmentVariables>
+						<LIMEN_KEY_ENCRYPTION_KEY>dGVzdC1rZWstdGVzdC1rZWstdGVzdC1rZWstdGVzdC0=</LIMEN_KEY_ENCRYPTION_KEY>
+					</environmentVariables>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/src/main/java/com/stucray/limen/security/JdbcSigningKeyStore.java
+++ b/src/main/java/com/stucray/limen/security/JdbcSigningKeyStore.java
@@ -1,0 +1,144 @@
+package com.stucray.limen.security;
+
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.encrypt.BytesEncryptor;
+import org.springframework.security.crypto.encrypt.Encryptors;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.text.ParseException;
+import java.util.Base64;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class JdbcSigningKeyStore implements SigningKeyStore {
+
+    private static final String ALGORITHM = "RS256";
+    private static final int RSA_KEY_SIZE = 2048;
+    private static final int SALT_BYTES = 16;
+    private static final int KEK_BYTES = 32;
+
+    private final JdbcTemplate jdbcTemplate;
+    private final String kekPassword;
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    public JdbcSigningKeyStore(
+        JdbcTemplate jdbcTemplate,
+        @Value("${LIMEN_KEY_ENCRYPTION_KEY:}") String kek
+    ) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.kekPassword = validateKek(kek);
+    }
+
+    private static String validateKek(String kek) {
+        if (kek == null || kek.isBlank()) {
+            throw new IllegalStateException(
+                "LIMEN_KEY_ENCRYPTION_KEY is not set. Provide a base64-encoded 256-bit AES key."
+            );
+        }
+        byte[] decoded;
+        try {
+            decoded = Base64.getDecoder().decode(kek);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalStateException(
+                "LIMEN_KEY_ENCRYPTION_KEY is not valid base64: " + e.getMessage(), e
+            );
+        }
+        if (decoded.length != KEK_BYTES) {
+            throw new IllegalStateException(
+                "LIMEN_KEY_ENCRYPTION_KEY must decode to " + KEK_BYTES + " bytes (256 bits); got " + decoded.length
+            );
+        }
+        return kek;
+    }
+
+    @Override
+    public void createForTenant(long tenantId) {
+        RSAKey rsaKey;
+        try {
+            rsaKey = new RSAKeyGenerator(RSA_KEY_SIZE)
+                .keyID(UUID.randomUUID().toString())
+                .generate();
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to generate RSA key for tenant " + tenantId, e);
+        }
+
+        byte[] salt = new byte[SALT_BYTES];
+        secureRandom.nextBytes(salt);
+        byte[] ciphertext = encryptor(salt).encrypt(
+            rsaKey.toJSONString().getBytes(StandardCharsets.UTF_8)
+        );
+        String publicJwk = rsaKey.toPublicJWK().toJSONString();
+
+        jdbcTemplate.update(
+            "INSERT INTO tenant_signing_key " +
+                "(tenant_id, kid, algorithm, private_key_ciphertext, iv, public_key_jwk, status) " +
+                "VALUES (?, ?, ?, ?, ?, ?, 'ACTIVE')",
+            tenantId,
+            rsaKey.getKeyID(),
+            ALGORITHM,
+            ciphertext,
+            salt,
+            publicJwk
+        );
+    }
+
+    @Override
+    public RSAKey getActiveSigningKey(long tenantId) {
+        return jdbcTemplate.query(
+            "SELECT private_key_ciphertext, iv FROM tenant_signing_key " +
+                "WHERE tenant_id = ? AND status = 'ACTIVE'",
+            rs -> {
+                if (!rs.next()) {
+                    return null;
+                }
+                byte[] ciphertext = rs.getBytes("private_key_ciphertext");
+                byte[] salt = rs.getBytes("iv");
+                byte[] plaintext = encryptor(salt).decrypt(ciphertext);
+                try {
+                    return RSAKey.parse(new String(plaintext, StandardCharsets.UTF_8));
+                } catch (ParseException e) {
+                    throw new IllegalStateException(
+                        "Stored signing key for tenant " + tenantId + " is corrupt", e
+                    );
+                }
+            },
+            tenantId
+        );
+    }
+
+    @Override
+    public JWKSet getJwkSet(long tenantId) {
+        List<JWK> jwks = jdbcTemplate.query(
+            "SELECT public_key_jwk FROM tenant_signing_key WHERE tenant_id = ?",
+            (rs, rowNum) -> {
+                try {
+                    return JWK.parse(rs.getString("public_key_jwk"));
+                } catch (ParseException e) {
+                    throw new IllegalStateException(
+                        "Stored public JWK for tenant " + tenantId + " is corrupt", e
+                    );
+                }
+            },
+            tenantId
+        );
+        return new JWKSet(jwks);
+    }
+
+    @Override
+    public void deleteForTenant(long tenantId) {
+        jdbcTemplate.update("DELETE FROM tenant_signing_key WHERE tenant_id = ?", tenantId);
+    }
+
+    private BytesEncryptor encryptor(byte[] salt) {
+        return Encryptors.stronger(kekPassword, HexFormat.of().formatHex(salt));
+    }
+}

--- a/src/main/java/com/stucray/limen/security/SigningKeyStore.java
+++ b/src/main/java/com/stucray/limen/security/SigningKeyStore.java
@@ -1,0 +1,15 @@
+package com.stucray.limen.security;
+
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+
+public interface SigningKeyStore {
+
+    void createForTenant(long tenantId);
+
+    RSAKey getActiveSigningKey(long tenantId);
+
+    JWKSet getJwkSet(long tenantId);
+
+    void deleteForTenant(long tenantId);
+}

--- a/src/main/resources/db/migration/V11__tenant_signing_key.sql
+++ b/src/main/resources/db/migration/V11__tenant_signing_key.sql
@@ -1,0 +1,17 @@
+CREATE TABLE tenant_signing_key (
+    id                      bigserial    PRIMARY KEY,
+    tenant_id               bigint       NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    kid                     varchar(64)  NOT NULL,
+    algorithm               varchar(16)  NOT NULL,
+    private_key_ciphertext  bytea        NOT NULL,
+    iv                      bytea        NOT NULL,
+    public_key_jwk          text         NOT NULL,
+    status                  varchar(16)  NOT NULL,
+    created_at              timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT tenant_signing_key_status_check CHECK (status IN ('ACTIVE', 'RETIRED')),
+    CONSTRAINT tenant_signing_key_kid_unique  UNIQUE (tenant_id, kid)
+);
+
+CREATE UNIQUE INDEX tenant_signing_key_one_active_per_tenant
+    ON tenant_signing_key (tenant_id)
+    WHERE status = 'ACTIVE';

--- a/src/test/java/com/stucray/limen/security/JdbcSigningKeyStoreIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/security/JdbcSigningKeyStoreIntegrationTest.java
@@ -1,0 +1,127 @@
+package com.stucray.limen.security;
+
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.stucray.limen.TestcontainersConfiguration;
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.tenant.TenantStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest(properties = {"LIMEN_SIGNING_KEY_PATH=./target/test-signing-key.jwk"})
+class JdbcSigningKeyStoreIntegrationTest {
+
+    @Autowired SigningKeyStore signingKeyStore;
+    @Autowired TenantRepository tenantRepository;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    Tenant tenant;
+
+    @BeforeEach
+    void setUp() {
+        tenant = tenantRepository.save(new Tenant(
+            null, "ks-" + System.nanoTime(), "Key Store Test", TenantStatus.ACTIVE, LocalDateTime.now()
+        ));
+    }
+
+    @Test
+    void createThenGetReturnsKeyWithMatchingPublicJwk() throws Exception {
+        signingKeyStore.createForTenant(tenant.id());
+
+        RSAKey key = signingKeyStore.getActiveSigningKey(tenant.id());
+        assertThat(key).isNotNull();
+        assertThat(key.toPrivateKey()).isNotNull();
+
+        String storedPublicJwk = jdbcTemplate.queryForObject(
+            "SELECT public_key_jwk FROM tenant_signing_key WHERE tenant_id = ? AND status = 'ACTIVE'",
+            String.class,
+            tenant.id()
+        );
+        assertThat(storedPublicJwk).isEqualTo(key.toPublicJWK().toJSONString());
+    }
+
+    @Test
+    void getJwkSetReturnsPublicKeysForTenant() throws Exception {
+        signingKeyStore.createForTenant(tenant.id());
+
+        JWKSet jwkSet = signingKeyStore.getJwkSet(tenant.id());
+        assertThat(jwkSet.getKeys()).hasSize(1);
+        assertThat(jwkSet.getKeys().getFirst()).isInstanceOf(RSAKey.class);
+        assertThat(((RSAKey) jwkSet.getKeys().getFirst()).toPrivateKey()).isNull();
+    }
+
+    @Test
+    void privateKeyCiphertextDoesNotContainPlaintextKeyMaterial() {
+        signingKeyStore.createForTenant(tenant.id());
+
+        byte[] ciphertext = jdbcTemplate.queryForObject(
+            "SELECT private_key_ciphertext FROM tenant_signing_key WHERE tenant_id = ? AND status = 'ACTIVE'",
+            byte[].class,
+            tenant.id()
+        );
+        assertThat(ciphertext).isNotNull();
+        String asText = new String(ciphertext, StandardCharsets.UTF_8);
+        assertThat(asText).doesNotContain("RSA PRIVATE KEY");
+        assertThat(asText).doesNotContain("\"kty\":\"RSA\"");
+        assertThat(asText).doesNotContain("\"d\":");
+
+        for (int i = 0; i < ciphertext.length - 3; i++) {
+            boolean pkcs8Magic = ciphertext[i] == 0x30
+                && ciphertext[i + 1] == (byte) 0x82
+                && ciphertext[i + 2] == 0x04;
+            assertThat(pkcs8Magic).as("no PKCS#8 SEQUENCE header at offset " + i).isFalse();
+        }
+    }
+
+    @Test
+    void deleteForTenantRemovesAllRows() {
+        signingKeyStore.createForTenant(tenant.id());
+        assertThat(rowCount(tenant.id())).isEqualTo(1);
+
+        signingKeyStore.deleteForTenant(tenant.id());
+
+        assertThat(rowCount(tenant.id())).isZero();
+    }
+
+    @Test
+    void getActiveSigningKeyReturnsNullWhenNoneExists() {
+        assertThat(signingKeyStore.getActiveSigningKey(tenant.id())).isNull();
+    }
+
+    @Test
+    void createForTenantTwiceViolatesActiveUniqueConstraint() {
+        signingKeyStore.createForTenant(tenant.id());
+
+        assertThatPartialUniqueIndexBlocksSecondActive();
+    }
+
+    private void assertThatPartialUniqueIndexBlocksSecondActive() {
+        try {
+            signingKeyStore.createForTenant(tenant.id());
+            org.assertj.core.api.Assertions.fail("expected unique-constraint violation");
+        } catch (org.springframework.dao.DataIntegrityViolationException expected) {
+            // partial unique index enforces one ACTIVE key per tenant
+        }
+    }
+
+    private int rowCount(long tenantId) {
+        Integer count = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM tenant_signing_key WHERE tenant_id = ?",
+            Integer.class,
+            tenantId
+        );
+        return count == null ? 0 : count;
+    }
+}


### PR DESCRIPTION
## Summary

- Introduces `SigningKeyStore` interface + `JdbcSigningKeyStore` implementation with per-tenant RSA 2048 keys encrypted at rest via `Encryptors.stronger()`
- Adds Flyway `V11__tenant_signing_key.sql` with `tenants(id)` FK, status check constraint, and a partial unique index enforcing one `ACTIVE` key per tenant
- KEK comes from `LIMEN_KEY_ENCRYPTION_KEY` (base64 256-bit AES); constructor fails fast on missing/malformed input
- Surefire wired with a fixed test KEK so all existing `@SpringBootTest` integration tests continue to start the context

## Deviation from spec

The acceptance criteria asks for AES-GCM via `Encryptors.stronger()` together with a separate `iv (bytea)` column. `Encryptors.stronger(password, salt)` already manages the GCM IV inside its ciphertext envelope, so a literal "GCM IV column" doesn't fit the API. The schema's `iv` column is therefore used to store a fresh 16-byte random PBKDF2 salt per row — providing the per-record key derivation. The "no plaintext key material at rest" guarantee still holds (verified by test).

## Dormant until slice 5a

Per the parent PRD, this slice deliberately leaves `SasConfig` and the existing file-based `SigningKeyProvider` untouched. Cutover happens in #18.

## Test plan

- [x] `./mvnw test` — all 75 tests pass (6 new in `JdbcSigningKeyStoreIntegrationTest`)
- [x] Round-trip: `createForTenant` then `getActiveSigningKey` returns RSA private key whose public-JWK matches `public_key_jwk` column
- [x] At-rest: ciphertext column contains no `RSA PRIVATE KEY` PEM banner, no `"kty":"RSA"` JWK marker, no `"d":` private exponent param, and no PKCS#8 DER `30 82 04` SEQUENCE header
- [x] `getJwkSet` strips private params from the returned JWKs
- [x] Partial unique index blocks a second `ACTIVE` row per tenant
- [x] `deleteForTenant` removes all rows for the tenant
- [x] `getActiveSigningKey` returns `null` when no key exists

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)