### PR TITLE
Force password change on OAuth2 authorization endpoint (#20)

### DIFF
--- a/src/main/java/com/stucray/limen/oauth2/EndUserPasswordChangeController.java
+++ b/src/main/java/com/stucray/limen/oauth2/EndUserPasswordChangeController.java
@@ -1,0 +1,85 @@
+package com.stucray.limen.oauth2;
+
+import com.stucray.limen.management.users.UserManagementService;
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.user.User;
+import com.stucray.limen.user.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
+import org.springframework.security.web.savedrequest.SavedRequest;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.net.URI;
+
+@Controller
+public class EndUserPasswordChangeController {
+
+    private final UserManagementService userManagementService;
+    private final UserRepository userRepository;
+    private final TenantRepository tenantRepository;
+    private final HttpSessionRequestCache requestCache = new HttpSessionRequestCache();
+
+    public EndUserPasswordChangeController(
+        UserManagementService userManagementService,
+        UserRepository userRepository,
+        TenantRepository tenantRepository
+    ) {
+        this.userManagementService = userManagementService;
+        this.userRepository = userRepository;
+        this.tenantRepository = tenantRepository;
+    }
+
+    @GetMapping("/t/{slug}/change-password")
+    public String form(@PathVariable String slug, Model model) {
+        model.addAttribute("slug", slug);
+        return "change-password";
+    }
+
+    @PostMapping("/t/{slug}/change-password")
+    public String submit(
+        @PathVariable String slug,
+        @AuthenticationPrincipal UserDetails principal,
+        @RequestParam String newPassword,
+        @RequestParam String confirmPassword,
+        HttpServletRequest request,
+        HttpServletResponse response,
+        Model model
+    ) {
+        if (!newPassword.equals(confirmPassword)) {
+            model.addAttribute("slug", slug);
+            model.addAttribute("errorMessage", "Passwords do not match");
+            return "change-password";
+        }
+        if (newPassword.length() < 8) {
+            model.addAttribute("slug", slug);
+            model.addAttribute("errorMessage", "Password must be at least 8 characters");
+            return "change-password";
+        }
+
+        Long tenantId = tenantRepository.findBySlug(slug)
+            .orElseThrow(() -> new IllegalArgumentException("Unknown tenant: " + slug))
+            .id();
+        User user = userRepository.findByUsernameAndTenantId(principal.getUsername(), tenantId)
+            .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        userManagementService.changePassword(user.id(), tenantId, newPassword);
+
+        SavedRequest savedRequest = requestCache.getRequest(request, response);
+        if (savedRequest != null && savedRequest.getRedirectUrl().contains("/oauth2/authorize")) {
+            requestCache.removeRequest(request, response);
+            URI uri = URI.create(savedRequest.getRedirectUrl());
+            String newPath = "/t/" + slug + uri.getRawPath();
+            String query = uri.getRawQuery();
+            return "redirect:" + uri.getScheme() + "://" + uri.getAuthority() + newPath
+                + (query != null ? "?" + query : "");
+        }
+        return "redirect:/t/" + slug + "/";
+    }
+}

--- a/src/main/java/com/stucray/limen/oauth2/TenantLoginSuccessHandler.java
+++ b/src/main/java/com/stucray/limen/oauth2/TenantLoginSuccessHandler.java
@@ -1,5 +1,7 @@
 package com.stucray.limen.oauth2;
 
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.user.UserRepository;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -14,6 +16,13 @@ import java.net.URI;
 public class TenantLoginSuccessHandler extends SavedRequestAwareAuthenticationSuccessHandler {
 
     private final HttpSessionRequestCache requestCache = new HttpSessionRequestCache();
+    private final UserRepository userRepository;
+    private final TenantRepository tenantRepository;
+
+    public TenantLoginSuccessHandler(UserRepository userRepository, TenantRepository tenantRepository) {
+        this.userRepository = userRepository;
+        this.tenantRepository = tenantRepository;
+    }
 
     @Override
     public void onAuthenticationSuccess(
@@ -23,6 +32,12 @@ public class TenantLoginSuccessHandler extends SavedRequestAwareAuthenticationSu
         if (slug != null) {
             SavedRequest savedRequest = requestCache.getRequest(request, response);
             if (savedRequest != null && savedRequest.getRedirectUrl().contains("/oauth2/authorize")) {
+                if (mustChangePassword(auth.getName(), slug)) {
+                    // Leave SavedRequest in cache so the change-password POST can resume the OAuth2 flow
+                    getRedirectStrategy().sendRedirect(request, response,
+                        "/t/" + slug + "/change-password");
+                    return;
+                }
                 requestCache.removeRequest(request, response);
                 clearAuthenticationAttributes(request);
                 getRedirectStrategy().sendRedirect(request, response,
@@ -31,6 +46,13 @@ public class TenantLoginSuccessHandler extends SavedRequestAwareAuthenticationSu
             }
         }
         super.onAuthenticationSuccess(request, response, auth);
+    }
+
+    private boolean mustChangePassword(String username, String slug) {
+        return tenantRepository.findBySlug(slug)
+            .flatMap(tenant -> userRepository.findByUsernameAndTenantId(username, tenant.id()))
+            .map(user -> user.mustChangePassword())
+            .orElse(false);
     }
 
     private String prependTenantPrefix(String redirectUrl, String slug) {

--- a/src/main/java/com/stucray/limen/security/SecurityConfig.java
+++ b/src/main/java/com/stucray/limen/security/SecurityConfig.java
@@ -1,6 +1,8 @@
 package com.stucray.limen.security;
 
 import com.stucray.limen.oauth2.TenantLoginSuccessHandler;
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.user.UserRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -26,7 +28,9 @@ public class SecurityConfig {
     public SecurityFilterChain defaultSecurityFilterChain(
         HttpSecurity http,
         PersistentTokenRepository tokenRepository,
-        UserDetailsService userDetailsService
+        UserDetailsService userDetailsService,
+        UserRepository userRepository,
+        TenantRepository tenantRepository
     ) throws Exception {
         return http
             .authorizeHttpRequests(auth -> auth
@@ -35,7 +39,7 @@ public class SecurityConfig {
             )
             .formLogin(form -> form
                 .loginPage("/login").permitAll()
-                .successHandler(new TenantLoginSuccessHandler())
+                .successHandler(new TenantLoginSuccessHandler(userRepository, tenantRepository))
             )
             .logout(logout -> logout
                 .deleteCookies("JSESSIONID", "remember-me")

--- a/src/main/resources/templates/change-password.html
+++ b/src/main/resources/templates/change-password.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head><title>Change Password</title></head>
+<body>
+<h1>You must change your password before continuing</h1>
+
+<div th:if="${errorMessage}" th:text="${errorMessage}"></div>
+
+<form method="post" th:action="@{'/t/' + ${slug} + '/change-password'}">
+    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+    <div>
+        <label>New password <input type="password" name="newPassword" minlength="8" autofocus required/></label>
+    </div>
+    <div>
+        <label>Confirm password <input type="password" name="confirmPassword" required/></label>
+    </div>
+    <button type="submit">Change password</button>
+</form>
+</body>
+</html>

--- a/src/test/java/com/stucray/limen/oauth2/OAuth2ForcedPasswordChangeIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/OAuth2ForcedPasswordChangeIntegrationTest.java
@@ -1,0 +1,214 @@
+package com.stucray.limen.oauth2;
+
+import com.stucray.limen.TestcontainersConfiguration;
+import com.stucray.limen.management.applications.Application;
+import com.stucray.limen.management.applications.ApplicationRepository;
+import com.stucray.limen.management.clients.TenantClient;
+import com.stucray.limen.management.clients.TenantClientRepository;
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.tenant.TenantStatus;
+import com.stucray.limen.user.User;
+import com.stucray.limen.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.oidc.OidcScopes;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest(properties = {"LIMEN_SIGNING_KEY_PATH=./target/test-signing-key.jwk"})
+@AutoConfigureMockMvc
+class OAuth2ForcedPasswordChangeIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired TenantRepository tenantRepository;
+    @Autowired ApplicationRepository applicationRepository;
+    @Autowired RegisteredClientRepository registeredClientRepository;
+    @Autowired TenantClientRepository tenantClientRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired PasswordEncoder passwordEncoder;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    Tenant tenant;
+    Application app;
+    String oauthClientId;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.execute("DELETE FROM oauth2_registered_client WHERE application_id IS NOT NULL");
+        jdbcTemplate.execute("DELETE FROM applications");
+        jdbcTemplate.execute("DELETE FROM users WHERE tenant_id != (SELECT id FROM tenants WHERE slug = 'system')");
+        jdbcTemplate.execute("DELETE FROM tenants WHERE slug != 'system'");
+
+        tenant = tenantRepository.save(new Tenant(
+            null, "alpha-corp", "Alpha Corp", TenantStatus.ACTIVE, LocalDateTime.now()));
+        app = applicationRepository.save(new Application(
+            null, tenant.id(), "Alpha App", "Test app", LocalDateTime.now()));
+
+        String internalId = UUID.randomUUID().toString();
+        oauthClientId = UUID.randomUUID().toString();
+        RegisteredClient rc = RegisteredClient.withId(internalId)
+            .clientId(oauthClientId)
+            .clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .redirectUri("http://localhost/callback")
+            .scope(OidcScopes.OPENID)
+            .clientSettings(ClientSettings.builder()
+                .requireProofKey(true)
+                .requireAuthorizationConsent(false)
+                .build())
+            .build();
+        registeredClientRepository.save(rc);
+        tenantClientRepository.save(new TenantClient(
+            null, internalId, app.id(), tenant.id(), "Test Client", false));
+    }
+
+    @Test
+    void userWithMustChangePasswordRedirectedToChangePasswordPage() throws Exception {
+        userRepository.save(new User(
+            null, tenant.id(), "alice",
+            passwordEncoder.encode("temp"),
+            true, true, false, LocalDateTime.now()));
+
+        MockHttpSession session = startAuthorize(newPkce().challenge());
+
+        MvcResult loginResult = mockMvc.perform(post("/t/alpha-corp/login")
+                .param("username", "alice").param("password", "temp")
+                .session(session).with(csrf()))
+            .andExpect(status().is3xxRedirection())
+            .andReturn();
+
+        assertThat(loginResult.getResponse().getHeader("Location"))
+            .isEqualTo("/t/alpha-corp/change-password");
+    }
+
+    @Test
+    void changePasswordResumesOAuth2FlowAndClearsFlag() throws Exception {
+        User original = userRepository.save(new User(
+            null, tenant.id(), "alice",
+            passwordEncoder.encode("temp"),
+            true, true, false, LocalDateTime.now()));
+
+        MockHttpSession session = startAuthorize(newPkce().challenge());
+
+        mockMvc.perform(post("/t/alpha-corp/login")
+                .param("username", "alice").param("password", "temp")
+                .session(session).with(csrf()))
+            .andExpect(status().is3xxRedirection());
+
+        MvcResult changeResult = mockMvc.perform(post("/t/alpha-corp/change-password")
+                .param("newPassword", "newpass123")
+                .param("confirmPassword", "newpass123")
+                .session(session).with(csrf()))
+            .andExpect(status().is3xxRedirection())
+            .andReturn();
+
+        assertThat(changeResult.getResponse().getHeader("Location"))
+            .contains("/t/alpha-corp/oauth2/authorize");
+        assertThat(userRepository.findById(original.id()).orElseThrow().mustChangePassword()).isFalse();
+
+        MvcResult codeResult = mockMvc.perform(get(changeResult.getResponse().getHeader("Location")).session(session))
+            .andExpect(status().is3xxRedirection())
+            .andReturn();
+
+        String code = UriComponentsBuilder.fromUriString(codeResult.getResponse().getHeader("Location"))
+            .build().getQueryParams().getFirst("code");
+        assertThat(code).isNotBlank();
+    }
+
+    @Test
+    void mismatchedPasswordsRerendersFormAndDoesNotClearFlag() throws Exception {
+        User original = userRepository.save(new User(
+            null, tenant.id(), "alice",
+            passwordEncoder.encode("temp"),
+            true, true, false, LocalDateTime.now()));
+
+        MockHttpSession session = startAuthorize(newPkce().challenge());
+
+        mockMvc.perform(post("/t/alpha-corp/login")
+                .param("username", "alice").param("password", "temp")
+                .session(session).with(csrf()))
+            .andExpect(status().is3xxRedirection());
+
+        mockMvc.perform(post("/t/alpha-corp/change-password")
+                .param("newPassword", "newpass123")
+                .param("confirmPassword", "different1")
+                .session(session).with(csrf()))
+            .andExpect(status().isOk());
+
+        assertThat(userRepository.findById(original.id()).orElseThrow().mustChangePassword()).isTrue();
+    }
+
+    @Test
+    void userWithoutMustChangePasswordCompletesNormally() throws Exception {
+        userRepository.save(new User(
+            null, tenant.id(), "bob",
+            passwordEncoder.encode("password"),
+            true, false, false, LocalDateTime.now()));
+
+        MockHttpSession session = startAuthorize(newPkce().challenge());
+
+        MvcResult loginResult = mockMvc.perform(post("/t/alpha-corp/login")
+                .param("username", "bob").param("password", "password")
+                .session(session).with(csrf()))
+            .andExpect(status().is3xxRedirection())
+            .andReturn();
+
+        assertThat(loginResult.getResponse().getHeader("Location"))
+            .contains("/t/alpha-corp/oauth2/authorize");
+    }
+
+    private MockHttpSession startAuthorize(String codeChallenge) throws Exception {
+        MockHttpSession session = new MockHttpSession();
+        String authzUri = UriComponentsBuilder.fromPath("/t/alpha-corp/oauth2/authorize")
+            .queryParam("response_type", "code")
+            .queryParam("client_id", oauthClientId)
+            .queryParam("redirect_uri", "http://localhost/callback")
+            .queryParam("scope", OidcScopes.OPENID)
+            .queryParam("state", "test-state")
+            .queryParam("code_challenge", codeChallenge)
+            .queryParam("code_challenge_method", "S256")
+            .build().toUriString();
+        mockMvc.perform(get(authzUri).session(session))
+            .andExpect(status().is3xxRedirection());
+        return session;
+    }
+
+    private Pkce newPkce() throws Exception {
+        byte[] verifierBytes = new byte[32];
+        new SecureRandom().nextBytes(verifierBytes);
+        String verifier = Base64.getUrlEncoder().withoutPadding().encodeToString(verifierBytes);
+        byte[] hash = MessageDigest.getInstance("SHA-256").digest(verifier.getBytes(StandardCharsets.US_ASCII));
+        String challenge = Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+        return new Pkce(verifier, challenge);
+    }
+
+    private record Pkce(String verifier, String challenge) {}
+}


### PR DESCRIPTION
## Summary

- End-users with `mustChangePassword=true` logging in via `/oauth2/authorize` are now redirected to `/t/{slug}/change-password` before the authorization grant is issued
- After a successful password change the original `/oauth2/authorize` request resumes (correct redirect URI, state, PKCE), and `mustChangePassword` is cleared
- Closes #20

## Implementation

- `TenantLoginSuccessHandler` now takes `UserRepository` + `TenantRepository` and looks up the freshly-authenticated end user. If they have `mustChangePassword=true` and a SavedRequest pointing at `/oauth2/authorize`, it redirects to `/t/{slug}/change-password` **without removing** the SavedRequest, so the change-password POST handler can resume the OAuth2 flow.
- New `EndUserPasswordChangeController` mounted at `/t/{slug}/change-password`. POST validates (match + min length 8), calls `UserManagementService.changePassword` (which clears the flag), then consumes the SavedRequest and redirects with the `/t/{slug}` prefix re-applied.
- New `templates/change-password.html` for end users (the management one at `templates/manage/users/change-password.html` posts to a different URL and is unchanged).
- `SecurityConfig` updated to wire `UserRepository` + `TenantRepository` into the success handler.

## Test plan

New `OAuth2ForcedPasswordChangeIntegrationTest` covers:

- [x] User with `mustChangePassword=true` is redirected to `/t/{slug}/change-password` after login
- [x] Successful password change resumes the OAuth2 flow and produces an authorization code; `mustChangePassword` flag is cleared
- [x] Mismatched passwords re-render the form (status 200) and do not clear the flag
- [x] User with `mustChangePassword=false` completes the flow normally (redirected to `/oauth2/authorize`, not to change-password)

Full suite: `./mvnw test` → 73/73 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)