### PR TITLE
Implement TenantProvisioningService (#17)

### DIFF
--- a/src/main/java/com/stucray/limen/identity/UserBootstrap.java
+++ b/src/main/java/com/stucray/limen/identity/UserBootstrap.java
@@ -1,8 +1,8 @@
 package com.stucray.limen.identity;
 
 import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantProvisioningService;
 import com.stucray.limen.tenant.TenantRepository;
-import com.stucray.limen.tenant.TenantStatus;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,6 +22,7 @@ public class UserBootstrap implements CommandLineRunner {
     private final String adminUsername;
     private final String adminPassword;
     private final TenantRepository tenantRepository;
+    private final TenantProvisioningService tenantProvisioningService;
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
@@ -29,12 +30,14 @@ public class UserBootstrap implements CommandLineRunner {
         @Value("${LIMEN_ADMIN_USERNAME:#{null}}") String adminUsername,
         @Value("${LIMEN_ADMIN_PASSWORD:#{null}}") String adminPassword,
         TenantRepository tenantRepository,
+        TenantProvisioningService tenantProvisioningService,
         UserRepository userRepository,
         PasswordEncoder passwordEncoder
     ) {
         this.adminUsername = adminUsername;
         this.adminPassword = adminPassword;
         this.tenantRepository = tenantRepository;
+        this.tenantProvisioningService = tenantProvisioningService;
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
     }
@@ -43,9 +46,7 @@ public class UserBootstrap implements CommandLineRunner {
     @Transactional
     public void run(String... args) {
         Tenant systemTenant = tenantRepository.findBySlug(SYSTEM_SLUG)
-            .orElseGet(() -> tenantRepository.save(
-                new Tenant(null, SYSTEM_SLUG, SYSTEM_DISPLAY_NAME, TenantStatus.ACTIVE, LocalDateTime.now())
-            ));
+            .orElseGet(() -> tenantProvisioningService.createTenant(SYSTEM_SLUG, SYSTEM_DISPLAY_NAME));
 
         if (adminUsername == null || adminPassword == null) return;
 

--- a/src/main/java/com/stucray/limen/management/signup/SignupService.java
+++ b/src/main/java/com/stucray/limen/management/signup/SignupService.java
@@ -1,8 +1,8 @@
 package com.stucray.limen.management.signup;
 
 import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantProvisioningService;
 import com.stucray.limen.tenant.TenantRepository;
-import com.stucray.limen.tenant.TenantStatus;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -22,15 +22,18 @@ public class SignupService {
     );
 
     private final TenantRepository tenantRepository;
+    private final TenantProvisioningService tenantProvisioningService;
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
     public SignupService(
         TenantRepository tenantRepository,
+        TenantProvisioningService tenantProvisioningService,
         UserRepository userRepository,
         PasswordEncoder passwordEncoder
     ) {
         this.tenantRepository = tenantRepository;
+        this.tenantProvisioningService = tenantProvisioningService;
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
     }
@@ -74,9 +77,7 @@ public class SignupService {
             return new SignupResult.Error("password", "Password must be at least 8 characters");
         }
 
-        Tenant tenant = tenantRepository.save(
-            new Tenant(null, slug, orgName, TenantStatus.ACTIVE, LocalDateTime.now())
-        );
+        Tenant tenant = tenantProvisioningService.createTenant(slug, orgName);
         userRepository.save(new User(
             null, tenant.id(), username,
             passwordEncoder.encode(form.password()),

--- a/src/main/java/com/stucray/limen/tenant/TenantProvisioningService.java
+++ b/src/main/java/com/stucray/limen/tenant/TenantProvisioningService.java
@@ -1,0 +1,37 @@
+package com.stucray.limen.tenant;
+
+import com.stucray.limen.security.SigningKeyStore;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@Transactional
+public class TenantProvisioningService {
+
+    private final TenantRepository tenantRepository;
+    private final SigningKeyStore signingKeyStore;
+
+    public TenantProvisioningService(
+        TenantRepository tenantRepository,
+        SigningKeyStore signingKeyStore
+    ) {
+        this.tenantRepository = tenantRepository;
+        this.signingKeyStore = signingKeyStore;
+    }
+
+    public Tenant createTenant(String slug, String displayName) {
+        Tenant tenant = tenantRepository.save(
+            new Tenant(null, slug, displayName, TenantStatus.ACTIVE, LocalDateTime.now())
+        );
+        if (!tenant.isSystem()) {
+            signingKeyStore.createForTenant(tenant.id());
+        }
+        return tenant;
+    }
+
+    public void deleteTenant(long id) {
+        tenantRepository.deleteById(id);
+    }
+}

--- a/src/test/java/com/stucray/limen/identity/UserBootstrapTest.java
+++ b/src/test/java/com/stucray/limen/identity/UserBootstrapTest.java
@@ -1,6 +1,7 @@
 package com.stucray.limen.identity;
 
 import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantProvisioningService;
 import com.stucray.limen.tenant.TenantRepository;
 import com.stucray.limen.tenant.TenantStatus;
 import com.stucray.limen.user.User;
@@ -15,7 +16,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.*;
 class UserBootstrapTest {
 
     @Mock TenantRepository tenantRepository;
+    @Mock TenantProvisioningService tenantProvisioningService;
     @Mock UserRepository userRepository;
     @Mock PasswordEncoder passwordEncoder;
 
@@ -36,27 +37,27 @@ class UserBootstrapTest {
 
     @Test
     void alwaysBootstrapsSystemTenant() throws Exception {
-        new UserBootstrap(null, null, tenantRepository, userRepository, passwordEncoder).run();
+        new UserBootstrap(null, null, tenantRepository, tenantProvisioningService, userRepository, passwordEncoder).run();
         verify(tenantRepository).findBySlug("system");
-        verifyNoInteractions(userRepository, passwordEncoder);
+        verifyNoInteractions(tenantProvisioningService, userRepository, passwordEncoder);
     }
 
     @Test
     void createsSystemTenantWhenAbsent() throws Exception {
         given(tenantRepository.findBySlug("system")).willReturn(Optional.empty());
-        given(tenantRepository.save(any())).willReturn(SYSTEM_TENANT);
+        given(tenantProvisioningService.createTenant("system", "System")).willReturn(SYSTEM_TENANT);
 
-        new UserBootstrap(null, null, tenantRepository, userRepository, passwordEncoder).run();
+        new UserBootstrap(null, null, tenantRepository, tenantProvisioningService, userRepository, passwordEncoder).run();
 
-        verify(tenantRepository).save(argThat(t -> t.slug().equals("system")));
+        verify(tenantProvisioningService).createTenant("system", "System");
     }
 
     @Test
     void doesNothingWithUsersWhenCredentialsUnset() throws Exception {
-        new UserBootstrap(null, "pass", tenantRepository, userRepository, passwordEncoder).run();
+        new UserBootstrap(null, "pass", tenantRepository, tenantProvisioningService, userRepository, passwordEncoder).run();
         verifyNoInteractions(userRepository, passwordEncoder);
 
-        new UserBootstrap("admin", null, tenantRepository, userRepository, passwordEncoder).run();
+        new UserBootstrap("admin", null, tenantRepository, tenantProvisioningService, userRepository, passwordEncoder).run();
         verifyNoInteractions(userRepository, passwordEncoder);
     }
 
@@ -65,7 +66,7 @@ class UserBootstrapTest {
         given(userRepository.findByUsernameAndTenantId("admin", 1L)).willReturn(Optional.empty());
         given(passwordEncoder.encode("pass")).willReturn("hashed");
 
-        new UserBootstrap("admin", "pass", tenantRepository, userRepository, passwordEncoder).run();
+        new UserBootstrap("admin", "pass", tenantRepository, tenantProvisioningService, userRepository, passwordEncoder).run();
 
         verify(userRepository).save(argThat(u ->
             u.username().equals("admin") && u.passwordHash().equals("hashed")
@@ -79,7 +80,7 @@ class UserBootstrapTest {
         given(userRepository.findByUsernameAndTenantId("admin", 1L)).willReturn(Optional.of(existing));
         given(passwordEncoder.encode("newpass")).willReturn("newhash");
 
-        new UserBootstrap("admin", "newpass", tenantRepository, userRepository, passwordEncoder).run();
+        new UserBootstrap("admin", "newpass", tenantRepository, tenantProvisioningService, userRepository, passwordEncoder).run();
 
         verify(userRepository).save(argThat(u -> u.id().equals(10L) && u.passwordHash().equals("newhash")));
     }

--- a/src/test/java/com/stucray/limen/tenant/TenantProvisioningServiceIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/tenant/TenantProvisioningServiceIntegrationTest.java
@@ -1,0 +1,89 @@
+package com.stucray.limen.tenant;
+
+import com.stucray.limen.TestcontainersConfiguration;
+import com.stucray.limen.security.SigningKeyStore;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doThrow;
+
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest(properties = {"LIMEN_SIGNING_KEY_PATH=./target/test-signing-key.jwk"})
+class TenantProvisioningServiceIntegrationTest {
+
+    @Autowired TenantProvisioningService service;
+    @Autowired TenantRepository tenantRepository;
+    @Autowired JdbcTemplate jdbcTemplate;
+    @MockitoSpyBean SigningKeyStore signingKeyStore;
+
+    @Test
+    void createTenantPersistsTenantAndActiveSigningKey() {
+        String slug = "acme-" + System.nanoTime();
+
+        Tenant tenant = service.createTenant(slug, "Acme Corp");
+
+        assertThat(tenant.id()).isNotNull();
+        assertThat(tenant.slug()).isEqualTo(slug);
+        assertThat(tenant.displayName()).isEqualTo("Acme Corp");
+        assertThat(tenant.status()).isEqualTo(TenantStatus.ACTIVE);
+
+        Long activeKeys = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM tenant_signing_key WHERE tenant_id = ? AND status = 'ACTIVE'",
+            Long.class,
+            tenant.id()
+        );
+        assertThat(activeKeys).isOne();
+    }
+
+    @Test
+    void createTenantSkipsSigningKeyForSystemSlug() {
+        tenantRepository.findBySlug("system").ifPresent(t -> tenantRepository.deleteById(t.id()));
+
+        Tenant systemTenant = service.createTenant("system", "System");
+
+        assertThat(systemTenant.slug()).isEqualTo("system");
+        Long keyCount = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM tenant_signing_key WHERE tenant_id = ?",
+            Long.class,
+            systemTenant.id()
+        );
+        assertThat(keyCount).isZero();
+    }
+
+    @Test
+    void signingKeyFailureRollsBackTenantInsert() {
+        doThrow(new IllegalStateException("simulated key store failure"))
+            .when(signingKeyStore).createForTenant(anyLong());
+
+        String slug = "rollback-" + System.nanoTime();
+
+        assertThatThrownBy(() -> service.createTenant(slug, "Rollback Corp"))
+            .isInstanceOf(IllegalStateException.class);
+
+        assertThat(tenantRepository.findBySlug(slug)).isEmpty();
+    }
+
+    @Test
+    void deleteTenantCascadesToSigningKeys() {
+        String slug = "deleteme-" + System.nanoTime();
+        Tenant tenant = service.createTenant(slug, "Delete Me");
+        long tenantId = tenant.id();
+
+        service.deleteTenant(tenantId);
+
+        assertThat(tenantRepository.findById(tenantId)).isEmpty();
+        Long keyCount = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM tenant_signing_key WHERE tenant_id = ?",
+            Long.class,
+            tenantId
+        );
+        assertThat(keyCount).isZero();
+    }
+}


### PR DESCRIPTION
## Summary

- New `@Transactional TenantProvisioningService.createTenant(slug, displayName)` orchestrates tenant row insert + `SigningKeyStore.createForTenant` atomically.
- `slug == "system"` short-circuit: skip signing key (parent PRD user story 12 — system tenant doesn't issue tokens).
- `deleteTenant(id)` delegates to `TenantRepository.deleteById`; FK cascade from `tenant_signing_key` (V11) handles signing-key cleanup.
- Routes the two production call sites — `UserBootstrap` (system init) and `SignupService` (customer signup) — through the new service. Test fixtures continue using `TenantRepository.save` directly to keep fixture cost low.

## Test plan

- [x] `./mvnw clean test` — 95/95 green
- [x] Happy path: `createTenant("acme-{n}", ...)` → tenant + ACTIVE `tenant_signing_key` row
- [x] System tenant: `createTenant("system", "System")` → tenant row, zero signing keys
- [x] Atomicity: `@MockitoSpyBean SigningKeyStore` stubbed to throw → tenant row rolled back
- [x] Cascade: `deleteTenant(id)` removes tenant + signing keys

Closes #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)