### PR TITLE
Add TODO for deprecated JdbcTokenRepositoryImpl.setDataSource

### DIFF
--- a/src/main/java/com/stucray/limen/security/SecurityConfig.java
+++ b/src/main/java/com/stucray/limen/security/SecurityConfig.java
@@ -60,6 +60,7 @@ public class SecurityConfig {
     @Bean
     public PersistentTokenRepository persistentTokenRepository(DataSource dataSource) {
         JdbcTokenRepositoryImpl repo = new JdbcTokenRepositoryImpl();
+        //TODO: How do we replace deprecated method csll?
         repo.setDataSource(dataSource);
         return repo;
     }


### PR DESCRIPTION
## Summary

- Drops a `//TODO` note next to `repo.setDataSource(dataSource)` in `SecurityConfig#persistentTokenRepository` — Spring's `JdbcTokenRepositoryImpl#setDataSource` is deprecated and we want to investigate the replacement.

## Test plan

- [ ] No behavior change; just a comment. Existing test suite still applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)