### PR TITLE
Cut over to per-tenant JWKSource (#18)

### DIFF
--- a/src/main/java/com/stucray/limen/oauth2/TenantJwkSource.java
+++ b/src/main/java/com/stucray/limen/oauth2/TenantJwkSource.java
@@ -1,0 +1,60 @@
+package com.stucray.limen.oauth2;
+
+import com.nimbusds.jose.KeySourceException;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSelector;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.stucray.limen.security.SigningKeyStore;
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import org.springframework.security.oauth2.server.authorization.context.AuthorizationServerContext;
+import org.springframework.security.oauth2.server.authorization.context.AuthorizationServerContextHolder;
+
+import java.util.List;
+
+public class TenantJwkSource implements JWKSource<SecurityContext> {
+
+    private static final String TENANT_PATH_SEGMENT = "/t/";
+
+    private final TenantRepository tenantRepository;
+    private final SigningKeyStore signingKeyStore;
+
+    public TenantJwkSource(TenantRepository tenantRepository, SigningKeyStore signingKeyStore) {
+        this.tenantRepository = tenantRepository;
+        this.signingKeyStore = signingKeyStore;
+    }
+
+    @Override
+    public List<JWK> get(JWKSelector selector, SecurityContext securityContext) throws KeySourceException {
+        Long tenantId = resolveTenantId();
+        if (tenantId == null) {
+            throw new IllegalStateException(
+                "TenantJwkSource invoked with no tenant context — no AuthorizationServerContext issuer and no TenantContext"
+            );
+        }
+        RSAKey activeKey = signingKeyStore.getActiveSigningKey(tenantId);
+        if (activeKey == null) {
+            throw new IllegalStateException("No active signing key for tenant " + tenantId);
+        }
+        return selector.select(new JWKSet(activeKey));
+    }
+
+    private Long resolveTenantId() {
+        AuthorizationServerContext context = AuthorizationServerContextHolder.getContext();
+        if (context != null) {
+            String issuer = context.getIssuer();
+            if (issuer != null) {
+                int idx = issuer.lastIndexOf(TENANT_PATH_SEGMENT);
+                if (idx >= 0) {
+                    String slug = issuer.substring(idx + TENANT_PATH_SEGMENT.length());
+                    Long fromIssuer = tenantRepository.findBySlug(slug).map(Tenant::id).orElse(null);
+                    if (fromIssuer != null) return fromIssuer;
+                }
+            }
+        }
+        return TenantContext.getTenantId();
+    }
+}

--- a/src/main/java/com/stucray/limen/security/JdbcSigningKeyStore.java
+++ b/src/main/java/com/stucray/limen/security/JdbcSigningKeyStore.java
@@ -12,6 +12,9 @@ import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.text.ParseException;
 import java.util.Base64;
 import java.util.HexFormat;
@@ -28,7 +31,6 @@ public class JdbcSigningKeyStore implements SigningKeyStore {
 
     private final JdbcTemplate jdbcTemplate;
     private final String kekPassword;
-    private final SecureRandom secureRandom = new SecureRandom();
 
     public JdbcSigningKeyStore(
         JdbcTemplate jdbcTemplate,
@@ -62,6 +64,13 @@ public class JdbcSigningKeyStore implements SigningKeyStore {
 
     @Override
     public void createForTenant(long tenantId) {
+        jdbcTemplate.execute((Connection conn) -> {
+            insertActiveSigningKey(conn, tenantId, kekPassword);
+            return null;
+        });
+    }
+
+    public static void insertActiveSigningKey(Connection conn, long tenantId, String kekPassword) throws SQLException {
         RSAKey rsaKey;
         try {
             rsaKey = new RSAKeyGenerator(RSA_KEY_SIZE)
@@ -70,25 +79,25 @@ public class JdbcSigningKeyStore implements SigningKeyStore {
         } catch (Exception e) {
             throw new IllegalStateException("Failed to generate RSA key for tenant " + tenantId, e);
         }
-
         byte[] salt = new byte[SALT_BYTES];
-        secureRandom.nextBytes(salt);
-        byte[] ciphertext = encryptor(salt).encrypt(
-            rsaKey.toJSONString().getBytes(StandardCharsets.UTF_8)
-        );
+        new SecureRandom().nextBytes(salt);
+        byte[] ciphertext = Encryptors.stronger(kekPassword, HexFormat.of().formatHex(salt))
+            .encrypt(rsaKey.toJSONString().getBytes(StandardCharsets.UTF_8));
         String publicJwk = rsaKey.toPublicJWK().toJSONString();
 
-        jdbcTemplate.update(
+        try (PreparedStatement ps = conn.prepareStatement(
             "INSERT INTO tenant_signing_key " +
                 "(tenant_id, kid, algorithm, private_key_ciphertext, iv, public_key_jwk, status) " +
-                "VALUES (?, ?, ?, ?, ?, ?, 'ACTIVE')",
-            tenantId,
-            rsaKey.getKeyID(),
-            ALGORITHM,
-            ciphertext,
-            salt,
-            publicJwk
-        );
+                "VALUES (?, ?, ?, ?, ?, ?, 'ACTIVE')"
+        )) {
+            ps.setLong(1, tenantId);
+            ps.setString(2, rsaKey.getKeyID());
+            ps.setString(3, ALGORITHM);
+            ps.setBytes(4, ciphertext);
+            ps.setBytes(5, salt);
+            ps.setString(6, publicJwk);
+            ps.executeUpdate();
+        }
     }
 
     @Override

--- a/src/main/java/com/stucray/limen/security/SasConfig.java
+++ b/src/main/java/com/stucray/limen/security/SasConfig.java
@@ -1,12 +1,16 @@
 package com.stucray.limen.security;
 
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.proc.SecurityContext;
 import com.stucray.limen.management.clients.TenantClientRepository;
 import com.stucray.limen.oauth2.TenantAwareOAuth2AuthorizationConsentService;
 import com.stucray.limen.oauth2.TenantAwareOAuth2AuthorizationService;
 import com.stucray.limen.oauth2.TenantAwareRegisteredClientRepository;
 import com.stucray.limen.oauth2.TenantContext;
 import com.stucray.limen.oauth2.TenantIssuerContextFilter;
+import com.stucray.limen.oauth2.TenantJwkSource;
 import com.stucray.limen.oauth2.TenantLoginUrlAuthenticationEntryPoint;
+import com.stucray.limen.tenant.TenantRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
@@ -86,6 +90,14 @@ public class SasConfig {
         RegisteredClientRepository registeredClientRepository
     ) {
         return new TenantAwareOAuth2AuthorizationConsentService(jdbcTemplate, registeredClientRepository);
+    }
+
+    @Bean
+    public JWKSource<SecurityContext> jwkSource(
+        TenantRepository tenantRepository,
+        SigningKeyStore signingKeyStore
+    ) {
+        return new TenantJwkSource(tenantRepository, signingKeyStore);
     }
 
     @Bean

--- a/src/main/java/com/stucray/limen/security/SigningKeyProvider.java
+++ b/src/main/java/com/stucray/limen/security/SigningKeyProvider.java
@@ -6,25 +6,23 @@ import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
 import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
 import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.proc.SecurityContext;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.ParseException;
 import java.util.UUID;
 
-@Configuration
+// Dead code post slice 5a (#18): per-tenant signing keys are served by TenantJwkSource.
+// Kept temporarily so slice 5b (#19) can excise this class, dev-signing-key.jwk, and
+// LIMEN_SIGNING_KEY_PATH together. Do not re-wire as a @Configuration.
 public class SigningKeyProvider {
 
     private final Path keyPath;
 
-    public SigningKeyProvider(@Value("${LIMEN_SIGNING_KEY_PATH:./dev-signing-key.jwk}") String keyPath) {
+    public SigningKeyProvider(String keyPath) {
         this.keyPath = Path.of(keyPath);
     }
 
-    @Bean
     public JWKSource<SecurityContext> jwkSource() throws Exception {
         if (Files.exists(keyPath)) {
             return load();

--- a/src/main/java/db/migration/V12__BackfillTenantSigningKeys.java
+++ b/src/main/java/db/migration/V12__BackfillTenantSigningKeys.java
@@ -1,0 +1,40 @@
+package db.migration;
+
+import com.stucray.limen.security.JdbcSigningKeyStore;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+
+@SuppressWarnings("checkstyle:TypeName")
+public class V12__BackfillTenantSigningKeys extends BaseJavaMigration {
+
+    @Override
+    public void migrate(Context context) throws Exception {
+        String kek = System.getenv("LIMEN_KEY_ENCRYPTION_KEY");
+        if (kek == null || kek.isBlank()) {
+            throw new IllegalStateException(
+                "LIMEN_KEY_ENCRYPTION_KEY is not set; cannot backfill tenant signing keys"
+            );
+        }
+        Connection conn = context.getConnection();
+        List<Long> tenantIds = new ArrayList<>();
+        try (PreparedStatement ps = conn.prepareStatement(
+            "SELECT t.id FROM tenants t " +
+            "WHERE t.slug <> 'system' " +
+            "AND NOT EXISTS (SELECT 1 FROM tenant_signing_key k " +
+            "                WHERE k.tenant_id = t.id AND k.status = 'ACTIVE')"
+        ); ResultSet rs = ps.executeQuery()) {
+            while (rs.next()) {
+                tenantIds.add(rs.getLong("id"));
+            }
+        }
+        for (Long tenantId : tenantIds) {
+            JdbcSigningKeyStore.insertActiveSigningKey(conn, tenantId, kek);
+        }
+    }
+}

--- a/src/test/java/com/stucray/limen/IssuerContractTest.java
+++ b/src/test/java/com/stucray/limen/IssuerContractTest.java
@@ -78,14 +78,11 @@ class IssuerContractTest {
             .andExpect(jsonPath("$.token_endpoint").value("http://localhost:8090/oauth2/token"));
     }
 
-    @Test
-    void jwksEndpointServesRsaKey() throws Exception {
-        mockMvc.perform(get("/oauth2/jwks"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.keys").isArray())
-            .andExpect(jsonPath("$.keys[0].kty").value("RSA"))
-            .andExpect(jsonPath("$.keys[0].kid").isNotEmpty());
-    }
+    // Legacy global JWKS endpoint test removed in slice 5a (#18): the JWKSource bean is now
+    // TenantJwkSource, which requires a tenant context (issuer or TenantContext). The global
+    // /oauth2/jwks endpoint has no tenant context and intentionally fails — clients must use
+    // /t/{slug}/.well-known/jwks.json. Tenant-scoped JWKS isolation is asserted in
+    // TenantOAuth2RoutingIntegrationTest#tenantJwksEndpointsServeIsolatedKeys.
 
     // Legacy global authorization-code flow test removed: end-to-end token issuance is now
     // tenant-scoped (see TenantOAuth2RoutingIntegrationTest#authorizationCodePkceFlowProducesTokenWithTenantClaims).

--- a/src/test/java/com/stucray/limen/management/clients/ClientTokenSettingsIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/clients/ClientTokenSettingsIntegrationTest.java
@@ -6,8 +6,8 @@ import com.stucray.limen.TestcontainersConfiguration;
 import com.stucray.limen.management.applications.Application;
 import com.stucray.limen.management.applications.ApplicationRepository;
 import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantProvisioningService;
 import com.stucray.limen.tenant.TenantRepository;
-import com.stucray.limen.tenant.TenantStatus;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,6 +48,7 @@ class ClientTokenSettingsIntegrationTest {
 
     @Autowired MockMvc mockMvc;
     @Autowired TenantRepository tenantRepository;
+    @Autowired TenantProvisioningService tenantProvisioningService;
     @Autowired ApplicationRepository applicationRepository;
     @Autowired ClientManagementService clientManagementService;
     @Autowired TenantClientRepository tenantClientRepository;
@@ -67,7 +68,7 @@ class ClientTokenSettingsIntegrationTest {
         jdbcTemplate.execute("DELETE FROM users WHERE tenant_id != (SELECT id FROM tenants WHERE slug = 'system')");
         jdbcTemplate.execute("DELETE FROM tenants WHERE slug != 'system'");
 
-        tenant = tenantRepository.save(new Tenant(null, "token-test", "Token Test", TenantStatus.ACTIVE, LocalDateTime.now()));
+        tenant = tenantProvisioningService.createTenant("token-test", "Token Test");
         app = applicationRepository.save(new Application(null, tenant.id(), "Test App", null, LocalDateTime.now()));
         userRepository.save(new User(null, tenant.id(), "alice", passwordEncoder.encode("password"), true, false, false, LocalDateTime.now()));
     }

--- a/src/test/java/com/stucray/limen/oauth2/TenantOAuth2RoutingIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/TenantOAuth2RoutingIntegrationTest.java
@@ -2,6 +2,10 @@ package com.stucray.limen.oauth2;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.crypto.RSASSAVerifier;
 import com.nimbusds.jwt.SignedJWT;
 import com.stucray.limen.TestcontainersConfiguration;
 import com.stucray.limen.management.applications.Application;
@@ -11,6 +15,7 @@ import com.stucray.limen.management.clients.ClientManagementService.ClientCreati
 import com.stucray.limen.management.clients.TenantClient;
 import com.stucray.limen.management.clients.TenantClientRepository;
 import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantProvisioningService;
 import com.stucray.limen.tenant.TenantRepository;
 import com.stucray.limen.tenant.TenantStatus;
 import com.stucray.limen.user.User;
@@ -59,6 +64,7 @@ class TenantOAuth2RoutingIntegrationTest {
 
     @Autowired MockMvc mockMvc;
     @Autowired TenantRepository tenantRepository;
+    @Autowired TenantProvisioningService tenantProvisioningService;
     @Autowired ApplicationRepository applicationRepository;
     @Autowired ClientManagementService clientManagementService;
     @Autowired RegisteredClientRepository registeredClientRepository;
@@ -80,12 +86,8 @@ class TenantOAuth2RoutingIntegrationTest {
         jdbcTemplate.execute("DELETE FROM users WHERE tenant_id != (SELECT id FROM tenants WHERE slug = 'system')");
         jdbcTemplate.execute("DELETE FROM tenants WHERE slug != 'system'");
 
-        alphaCorpTenant = tenantRepository.save(new Tenant(
-            null, "alpha-corp", "Alpha Corp", TenantStatus.ACTIVE, LocalDateTime.now()
-        ));
-        betaCorpTenant = tenantRepository.save(new Tenant(
-            null, "beta-corp", "Beta Corp", TenantStatus.ACTIVE, LocalDateTime.now()
-        ));
+        alphaCorpTenant = tenantProvisioningService.createTenant("alpha-corp", "Alpha Corp");
+        betaCorpTenant = tenantProvisioningService.createTenant("beta-corp", "Beta Corp");
         alphaApp = applicationRepository.save(new Application(
             null, alphaCorpTenant.id(), "Alpha App", "Test app", LocalDateTime.now()
         ));
@@ -300,6 +302,53 @@ class TenantOAuth2RoutingIntegrationTest {
         assertThat(claims.get("roles")).isInstanceOf(List.class);
         assertThat((List<?>) claims.get("roles")).isEmpty();
         assertThat(claims.get("iss")).asString().isEqualTo("http://localhost/t/alpha-corp");
+    }
+
+    @Test
+    void tenantJwksEndpointsServeIsolatedKeys() throws Exception {
+        ClientCreationResult result = clientManagementService.createClient(
+            alphaApp.id(), alphaCorpTenant.id(),
+            "isolation-m2m",
+            Set.of(AuthorizationGrantType.CLIENT_CREDENTIALS),
+            Set.of(), Set.of(), Set.of("read"),
+            false, true, 5, 30, false
+        );
+        String oauthClientId = jdbcTemplate.queryForObject(
+            "SELECT client_id FROM oauth2_registered_client WHERE id = ?",
+            String.class, result.client().registeredClientId()
+        );
+
+        String tokenJson = mockMvc.perform(post("/t/alpha-corp/oauth2/token")
+                .param("grant_type", "client_credentials")
+                .param("scope", "read")
+                .with(httpBasic(oauthClientId, result.rawSecret())))
+            .andExpect(status().isOk())
+            .andReturn().getResponse().getContentAsString();
+        String accessToken = objectMapper.readTree(tokenJson).get("access_token").asText();
+        SignedJWT jwt = SignedJWT.parse(accessToken);
+        String kid = jwt.getHeader().getKeyID();
+
+        String alphaJwksJson = mockMvc.perform(get("/t/alpha-corp/oauth2/jwks"))
+            .andExpect(status().isOk())
+            .andReturn().getResponse().getContentAsString();
+        JWKSet alphaJwks = JWKSet.parse(alphaJwksJson);
+        JWK alphaMatch = alphaJwks.getKeyByKeyId(kid);
+        assertThat(alphaMatch).as("alpha JWKS contains the signing kid").isNotNull();
+        assertThat(jwt.verify(new RSASSAVerifier((RSAKey) alphaMatch)))
+            .as("alpha-issued token verifies against alpha's JWKS")
+            .isTrue();
+
+        String betaJwksJson = mockMvc.perform(get("/t/beta-corp/oauth2/jwks"))
+            .andExpect(status().isOk())
+            .andReturn().getResponse().getContentAsString();
+        JWKSet betaJwks = JWKSet.parse(betaJwksJson);
+        assertThat(betaJwks.getKeyByKeyId(kid))
+            .as("beta JWKS does NOT contain alpha's signing kid")
+            .isNull();
+        RSAKey betaActiveKey = (RSAKey) betaJwks.getKeys().getFirst();
+        assertThat(jwt.verify(new RSASSAVerifier(betaActiveKey)))
+            .as("alpha-issued token does not verify against beta's active key")
+            .isFalse();
     }
 
     @Test


### PR DESCRIPTION
Closes #18. Implements slice 5a of #13. (Replaces closed PR #27, which auto-closed when its base ref was deleted in the chain merge.)

## Summary

- New `TenantJwkSource` (`JWKSource<SecurityContext>`) replaces the global signing-key code path. Resolves tenant from `AuthorizationServerContext.getIssuer()` first, then falls back to `TenantContext`.
- `SasConfig` wires `TenantJwkSource` as the active `JWKSource` bean.
- New Flyway Java migration `V12__BackfillTenantSigningKeys` populates `tenant_signing_key` rows for existing non-system tenants. Implemented as a plain `BaseJavaMigration` in `db.migration` (not Spring-managed) to avoid the `Flyway → V12 → JdbcTemplate @DependsOn(flyway)` cycle.
- New end-to-end isolation assertion in `TenantOAuth2RoutingIntegrationTest#tenantJwksEndpointsServeIsolatedKeys`.
- 95/95 tests green.

## Notes

The original PR for this work (#27) was auto-closed by GitHub when its chained base branch was deleted during the merge of #25. Branch rebased onto main; this is a fresh PR with the same commit content (rebased).

🤖 Generated with [Claude Code](https://claude.com/claude-code)