### PR TITLE
Redirect / to the System Tenant management login

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -265,7 +265,7 @@ The schema was originally built up across 12 migrations during the v1 PRD, inclu
 | Surface | Pattern | Notes |
 |---|---|---|
 | Public | `GET /signup`, `POST /signup` | Self-service Tenant creation |
-| Public | `GET /login` | Generic landing; redirects to `/manage/t/{slug}/login` when context allows |
+| Public | `GET /login`, `POST /login` | Form-login URL. Serves the OAuth2 end-user login form (reached internally as `/login` after `TenantOAuth2RoutingFilter` strips `/t/{slug}/` from `/t/{slug}/login`) and also acts as the catch-all formLogin for any unauthenticated request that doesn't match a higher-precedence chain. The overlap is a known gap — see §5. |
 | OAuth2 | `GET /t/{slug}/.well-known/openid-configuration` | Per-tenant discovery |
 | OAuth2 | `GET /t/{slug}/.well-known/jwks.json` | Per-tenant JWKS |
 | OAuth2 | `GET /t/{slug}/oauth2/authorize` | Authorization endpoint |
@@ -297,6 +297,7 @@ These are known limitations of the v1 surface. None of them block the product wo
 - **No email capability.** Forced password change exists, but there is no password-reset-via-email flow, no signup confirmation, and no notification on suspicious login. Tenant Owners must hand out temporary passwords out-of-band.
 - **No account lockout or brute-force protection** on either the management login or the end-user login.
 - **No session management UI.** Users cannot list or revoke their active sessions, and Tenant Owners cannot terminate a User's sessions.
+- **`/login` does double duty as the OAuth2 end-user login form and the catch-all formLogin entry point.** Internal `/t/{slug}/login` traffic is rewritten to `/login` by `TenantOAuth2RoutingFilter` and authenticates correctly into the OAuth2 flow via `TenantLoginSuccessHandler`. But the catch-all `SecurityConfig` chain also wires `formLogin().loginPage("/login")` against `.anyRequest().authenticated()`, so any unauthenticated request that doesn't match the OAuth2 or management chains is bounced to the same `/login`. After authenticating, the saved-request mechanism redirects the visitor back to their original URL — which is typically `/`, has no controller, and returns 404. The narrow workaround is to give `/` a useful destination (e.g. redirect it to `/manage/t/system/login`); the broader fix is to remove the catch-all formLogin entirely and let each surface declare its own login URL with its own success handler and default target.
 
 ### Authorization (the v2 hole)
 

--- a/src/main/java/com/stucray/limen/security/SecurityConfig.java
+++ b/src/main/java/com/stucray/limen/security/SecurityConfig.java
@@ -41,7 +41,7 @@ public class SecurityConfig {
 
         return http
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/actuator/health").permitAll()
+                .requestMatchers("/", "/actuator/health").permitAll()
                 .anyRequest().authenticated()
             )
             .requestCache(rc -> rc.requestCache(requestCache))

--- a/src/main/java/com/stucray/limen/web/RootController.java
+++ b/src/main/java/com/stucray/limen/web/RootController.java
@@ -1,0 +1,13 @@
+package com.stucray.limen.web;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class RootController {
+
+    @GetMapping("/")
+    public String redirectToSystemLogin() {
+        return "redirect:/manage/t/system/login";
+    }
+}


### PR DESCRIPTION
## Summary

- Add a `RootController` that maps `/` to `redirect:/manage/t/system/login`, and `permitAll` on `/` in `SecurityConfig` so unauthenticated visitors hit the redirect rather than being bounced through the OAuth2 form-login.
- Document the underlying gap in `docs/ARCHITECTURE.md`: `/login` is doing double duty as the OAuth2 end-user form (reached internally via `TenantOAuth2RoutingFilter` rewriting `/t/{slug}/login` → `/login`) and the catch-all formLogin for any unauthenticated request that doesn't match a higher-precedence chain. Post-login the saved-request mechanism redirected the visitor back to `/`, which had no controller, returning 404.
- This is a narrow mitigation; the broader fix is to remove the catch-all formLogin entirely and let each surface declare its own login URL with its own success handler. That's noted in the architecture gaps section to revisit.

## Test plan

- [x] All 92 existing tests pass (`./mvnw test`)
- [ ] Navigate to `http://localhost:8090/` in a browser — expect redirect to `/manage/t/system/login`
- [ ] Login as the bootstrapped admin — expect to land on `/manage/t/system/`
- [ ] OAuth2 end-user flow still works (existing integration tests cover this end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)