### PR TITLE
Update architecture doc for tenant-isolated login

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,6 +21,7 @@ Concretely, Limen provides:
 | Layer | Choice |
 |---|---|
 | Language | Java 26 |
+| Concurrency | Java virtual threads (`spring.threads.virtual.enabled=true`); per-request tenant binding via `ScopedValue` (`TenantScope`) |
 | Framework | Spring Boot 4.0.5 |
 | OAuth2 / OIDC | Spring Authorization Server (via `spring-boot-starter-security-oauth2-authorization-server`) |
 | Persistence | Spring Data JDBC (records, no JPA / Hibernate) |
@@ -119,7 +120,9 @@ flowchart TB
         ROUT["TenantOAuth2RoutingFilter<br/>matches /t/{slug}/oauth2|.well-known|connect|userinfo"]
         ISS[TenantIssuerContextFilter]
         SAS["Spring Authorization Server<br/>filter chain"]
+        OAL["OAuth2 login filter chain<br/>/t/{slug}/login + change-password"]
         MGTC["Management filter chain<br/>/manage/t/{slug}/**"]
+        TAF["TenantAccessFilter<br/>(both UI chains)"]
       end
 
       subgraph "Tenant-aware storage decorators"
@@ -140,7 +143,10 @@ flowchart TB
     end
 
     EU -->|/t/acme/oauth2/authorize| ROUT
+    EU -->|/t/acme/login| OAL
     MGT -->|/manage/t/acme/applications| MGTC
+    MGTC --> TAF
+    OAL --> TAF
     ROUT --> ISS --> SAS
     SAS --> TRCR
     SAS --> TAS
@@ -171,7 +177,7 @@ These surfaces use the same `users` table for authentication but different filte
 sequenceDiagram
     participant C as OAuth2 Client
     participant F as TenantOAuth2RoutingFilter
-    participant CTX as TenantContext (ThreadLocal)
+    participant SCOPE as TenantScope (ScopedValue)
     participant I as TenantIssuerContextFilter
     participant SAS as Spring Authorization Server
     participant J as TenantJwkSource
@@ -179,22 +185,25 @@ sequenceDiagram
     C->>F: GET /t/acme/oauth2/authorize?...
     F->>F: regex match, extract slug "acme"
     F->>F: load Tenant from DB, check ACTIVE
-    F->>CTX: set(slug, tenantId)
+    F->>SCOPE: ScopedValue.where(...).run(chain.doFilter)
     F->>I: forward, request URI rewritten to /oauth2/authorize
     I->>I: build issuer = https://host/t/acme
     I->>SAS: AuthorizationServerContext set
     SAS->>J: get JWKSet for current tenant
-    J->>CTX: read tenantId
+    J->>SCOPE: read tenantId
     J->>J: load active TenantSigningKey, decrypt
     J-->>SAS: JWKSet
     SAS-->>C: redirect / token response
-    F->>CTX: clear() in finally
+    Note over F,SCOPE: scope auto-unbound when run() returns
 ```
 
-The two crucial properties:
+The three crucial properties:
 
-- **The tenant is resolved before SAS sees the request** — by the time Spring's filter chain runs, the URI no longer contains `/t/{slug}/` and `TenantContext` already holds the resolved tenant. This is what lets us reuse SAS unmodified.
+- **The tenant is resolved before SAS sees the request** — by the time Spring's filter chain runs, the URI no longer contains `/t/{slug}/` and `TenantScope` already holds the resolved tenant. This is what lets us reuse SAS unmodified.
+- **The carrier is `ScopedValue`, not `ThreadLocal`.** The routing filter wraps `chain.doFilter(...)` in `ScopedValue.where(...).run(...)`; the binding is unwound automatically when `run()` returns, with no try/finally and no carrier-thread pinning under virtual threads. Seven SAS-coupled readers (`OAuth2AuthorizationService`, `OAuth2AuthorizationConsentService`, `RegisteredClientRepository`, `JWKSource`, `JwtTokenCustomizer`, the issuer-context filter, the entry point) read the scope on demand.
 - **The JWKSource resolves the tenant on demand** rather than being pre-bound at bean construction, which is necessary because there is one shared SAS bean graph but many tenants.
+
+The login path does **not** go through `TenantOAuth2RoutingFilter` (its regex matches only `oauth2|.well-known|connect|userinfo`). `/t/{slug}/login` is handled directly by the OAuth2 login filter chain (§4.5) and the slug rides on the `TenantAuthToken`, not the scope.
 
 ### 4.3 OAuth2 storage decorators
 
@@ -225,7 +234,13 @@ Properties:
 
 ### 4.5 Authentication flows
 
-There are three login flows in the system: an OAuth2 end-user login, a management-console login, and a forced-password-change interception that overlays both.
+There are three login flows in the system: an OAuth2 end-user login at `/t/{slug}/login`, a management-console login at `/manage/t/{slug}/login`, and a forced-password-change interception that overlays both.
+
+**Unified tenant-aware backend.** Both login URLs go through the same `TenantAuthProvider` (in `com.stucray.limen.auth`), against a `TenantAuthToken` whose slug is captured from the URL path before authentication runs. The provider loads the User by `(tenant_id, username)` and returns a `TenantUserDetails` whose `tenantSlug()`/`tenantId()` are used downstream. Two filter subclasses of `AbstractTenantAuthFilter` differ only in URL pattern and slug-extractor: `OAuth2TenantAuthFilter` for `/t/{slug}/login`, `ManagementTenantAuthFilter` for `/manage/t/{slug}/login`. There is no silent fallback to the System Tenant — a missing-or-mismatched slug fails the request loudly.
+
+**Defence in depth.** A `TenantAccessFilter` runs in both UI chains: any authenticated request whose URL slug differs from the principal's tenant slug is force-logged-out and redirected to the URL slug's login. Bare `/login` 302s to `/manage/t/system/login` (matching `/`).
+
+**Tenant-scoped remember-me.** `TenantPersistentTokenBasedRememberMeServices` encodes the slug as a third segment in the cookie value (`series:token:slug`) and rejects mismatched slugs at decode. Storage is keyed by `(tenant_id, series)` via `TenantPersistentTokenRepository`. Both filter chains share the same repository bean; management gained remember-me as part of this work (it had none previously).
 
 **Forced password change on the OAuth2 path:**
 
@@ -257,6 +272,7 @@ The same pattern applies to the management console at `/manage/t/{slug}/...`, wi
 | Migration | Purpose |
 |---|---|
 | `V1__initial_schema.sql` | All baseline tables (`tenants`, `users`, `persistent_logins`, `applications`, `oauth2_registered_client`, `oauth2_authorization`, `oauth2_authorization_consent`, `client_metadata`, `tenant_signing_key`) and their indexes, including the partial unique "one ACTIVE signing key per tenant" index |
+| `V2__add_tenant_to_persistent_logins.sql` | Adds `tenant_id` to `persistent_logins`, swaps the primary key to `(tenant_id, series)`, and indexes `(tenant_id, username)`. `TRUNCATE`s existing rows — the conservative response to a tenant-isolation gap, since the old two-segment cookie format cannot represent the tenant either |
 
 The schema was originally built up across 12 migrations during the v1 PRD, including two destructive `DROP TABLE / CREATE TABLE` steps to retrofit tenant scoping onto the OAuth2 storage tables. Before any production data existed, those were consolidated into the single baseline above. Future migrations must be **additive** (`ALTER TABLE ADD COLUMN ... NULL` → backfill → `ALTER ... NOT NULL`) — never `DROP TABLE` on the tenant-scoped OAuth2 tables, since they will hold live grants and consents.
 
@@ -265,7 +281,7 @@ The schema was originally built up across 12 migrations during the v1 PRD, inclu
 | Surface | Pattern | Notes |
 |---|---|---|
 | Public | `GET /signup`, `POST /signup` | Self-service Tenant creation |
-| Public | `GET /login`, `POST /login` | Form-login URL. Serves the OAuth2 end-user login form (reached internally as `/login` after `TenantOAuth2RoutingFilter` strips `/t/{slug}/` from `/t/{slug}/login`) and also acts as the catch-all formLogin for any unauthenticated request that doesn't match a higher-precedence chain. The overlap is a known gap — see §5. |
+| Public | `GET /login` | 302 to `/manage/t/system/login`, matching `/`. There is no bare `POST /login` — every login surface is tenant-scoped under `/t/{slug}/login` or `/manage/t/{slug}/login`. |
 | OAuth2 | `GET /t/{slug}/.well-known/openid-configuration` | Per-tenant discovery |
 | OAuth2 | `GET /t/{slug}/.well-known/jwks.json` | Per-tenant JWKS |
 | OAuth2 | `GET /t/{slug}/oauth2/authorize` | Authorization endpoint |
@@ -297,7 +313,6 @@ These are known limitations of the v1 surface. None of them block the product wo
 - **No email capability.** Forced password change exists, but there is no password-reset-via-email flow, no signup confirmation, and no notification on suspicious login. Tenant Owners must hand out temporary passwords out-of-band.
 - **No account lockout or brute-force protection** on either the management login or the end-user login.
 - **No session management UI.** Users cannot list or revoke their active sessions, and Tenant Owners cannot terminate a User's sessions.
-- **`/login` does double duty as the OAuth2 end-user login form and the catch-all formLogin entry point.** Internal `/t/{slug}/login` traffic is rewritten to `/login` by `TenantOAuth2RoutingFilter` and authenticates correctly into the OAuth2 flow via `TenantLoginSuccessHandler`. But the catch-all `SecurityConfig` chain also wires `formLogin().loginPage("/login")` against `.anyRequest().authenticated()`, so any unauthenticated request that doesn't match the OAuth2 or management chains is bounced to the same `/login`. After authenticating, the saved-request mechanism redirects the visitor back to their original URL — which is typically `/`, has no controller, and returns 404. The narrow workaround is to give `/` a useful destination (e.g. redirect it to `/manage/t/system/login`); the broader fix is to remove the catch-all formLogin entirely and let each surface declare its own login URL with its own success handler and default target.
 
 ### Authorization (the v2 hole)
 
@@ -318,7 +333,6 @@ These are known limitations of the v1 surface. None of them block the product wo
 
 ### Schema and data model
 
-- **The remember-me `persistent_logins` table is global, not tenant-scoped.** Each row is keyed by username, which is only unique within a Tenant. This is acceptable today because the cookie is checked against `UserDetailsService` which uses `TenantContext`, but it is a footgun if the resolution path ever changes.
 - **`oauth2_registered_client` is a global SAS table.** Tenant scoping is enforced by the `client_metadata` join and by the tenant-aware decorators; nothing in the SAS table itself prevents a stray query from returning cross-tenant rows. The decorators are the only defence.
 
 ## 6. Roadmap


### PR DESCRIPTION
## Summary

Brings `docs/ARCHITECTURE.md` in line with what merged in PR #36 (tenant-isolated login). The doc still described the old ThreadLocal carrier, the bare `/login` catch-all, and a global `persistent_logins` table — all of which were replaced or removed.

- §2 stack: noted virtual threads (`spring.threads.virtual.enabled=true`) and `TenantScope` as the per-request carrier
- §4.1 component diagram: added the OAuth2 login filter chain and `TenantAccessFilter`
- §4.2 OAuth2 routing: ThreadLocal → ScopedValue throughout the diagram and prose; clarified that the login path no longer goes through `TenantOAuth2RoutingFilter`
- §4.5 auth flows: new paragraphs on the unified `TenantAuthProvider`, the `TenantAccessFilter`, and tenant-scoped remember-me
- §4.6: V2 Flyway migration row added
- §4.7: bare `/login` rewritten as a 302 (no more "double duty" footnote)
- §5 gaps: removed the `/login` overlap and the global `persistent_logins` items — both resolved by #36

Doc-only change. No code touched.

## Test plan

- [ ] Skim the rendered diff on GitHub
- [ ] Confirm the §4.1 and §4.2 mermaid diagrams render

🤖 Generated with [Claude Code](https://claude.com/claude-code)