### PR TITLE
v2 slice 1: per-Application Role catalogue

### DIFF
--- a/src/main/java/com/stucray/limen/management/roles/Role.java
+++ b/src/main/java/com/stucray/limen/management/roles/Role.java
@@ -1,0 +1,23 @@
+package com.stucray.limen.management.roles;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+
+@Table("role")
+public record Role(
+    @Id Long id,
+    Long applicationId,
+    String name,
+    String description,
+    LocalDateTime createdAt
+) {
+    public Role withName(String newName) {
+        return new Role(id, applicationId, newName, description, createdAt);
+    }
+
+    public Role withDescription(String newDescription) {
+        return new Role(id, applicationId, name, newDescription, createdAt);
+    }
+}

--- a/src/main/java/com/stucray/limen/management/roles/RoleManagementService.java
+++ b/src/main/java/com/stucray/limen/management/roles/RoleManagementService.java
@@ -1,0 +1,65 @@
+package com.stucray.limen.management.roles;
+
+import com.stucray.limen.management.applications.Application;
+import com.stucray.limen.management.applications.ApplicationRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Roles are transitively scoped to a Tenant via Application. Every public
+ * method requires the caller to pass `(applicationId, tenantId)`; the
+ * Application is fetched first so cross-tenant access is rejected before any
+ * role row is touched.
+ */
+@Service
+public class RoleManagementService {
+
+    private final RoleRepository roleRepository;
+    private final ApplicationRepository applicationRepository;
+
+    public RoleManagementService(RoleRepository roleRepository, ApplicationRepository applicationRepository) {
+        this.roleRepository = roleRepository;
+        this.applicationRepository = applicationRepository;
+    }
+
+    public List<Role> listRoles(Long applicationId, Long tenantId) {
+        requireApplication(applicationId, tenantId);
+        return roleRepository.findAllByApplicationId(applicationId);
+    }
+
+    public Role getRole(Long roleId, Long applicationId, Long tenantId) {
+        requireApplication(applicationId, tenantId);
+        return roleRepository.findByIdAndApplicationId(roleId, applicationId)
+            .orElseThrow(() -> new IllegalArgumentException("Role not found"));
+    }
+
+    public Role createRole(Long applicationId, Long tenantId, String name, String description) {
+        requireApplication(applicationId, tenantId);
+        if (roleRepository.existsByNameAndApplicationId(name, applicationId)) {
+            throw new IllegalArgumentException("A role named '" + name + "' already exists in this application");
+        }
+        return roleRepository.save(
+            new Role(null, applicationId, name, description, LocalDateTime.now())
+        );
+    }
+
+    public void updateRole(Long roleId, Long applicationId, Long tenantId, String name, String description) {
+        Role role = getRole(roleId, applicationId, tenantId);
+        if (!role.name().equals(name) && roleRepository.existsByNameAndApplicationId(name, applicationId)) {
+            throw new IllegalArgumentException("A role named '" + name + "' already exists in this application");
+        }
+        roleRepository.save(role.withName(name).withDescription(description));
+    }
+
+    public void deleteRole(Long roleId, Long applicationId, Long tenantId) {
+        Role role = getRole(roleId, applicationId, tenantId);
+        roleRepository.delete(role);
+    }
+
+    private Application requireApplication(Long applicationId, Long tenantId) {
+        return applicationRepository.findByIdAndTenantId(applicationId, tenantId)
+            .orElseThrow(() -> new IllegalArgumentException("Application not found"));
+    }
+}

--- a/src/main/java/com/stucray/limen/management/roles/RoleRepository.java
+++ b/src/main/java/com/stucray/limen/management/roles/RoleRepository.java
@@ -1,0 +1,12 @@
+package com.stucray.limen.management.roles;
+
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface RoleRepository extends CrudRepository<Role, Long> {
+    List<Role> findAllByApplicationId(Long applicationId);
+    Optional<Role> findByIdAndApplicationId(Long id, Long applicationId);
+    boolean existsByNameAndApplicationId(String name, Long applicationId);
+}

--- a/src/main/java/com/stucray/limen/management/roles/RolesController.java
+++ b/src/main/java/com/stucray/limen/management/roles/RolesController.java
@@ -1,0 +1,138 @@
+package com.stucray.limen.management.roles;
+
+import com.stucray.limen.auth.TenantUserDetails;
+import com.stucray.limen.management.applications.Application;
+import com.stucray.limen.management.applications.ApplicationService;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequestMapping("/manage/t/{slug}/applications/{appId}/roles")
+public class RolesController {
+
+    private final RoleManagementService roleManagementService;
+    private final ApplicationService applicationService;
+
+    public RolesController(RoleManagementService roleManagementService, ApplicationService applicationService) {
+        this.roleManagementService = roleManagementService;
+        this.applicationService = applicationService;
+    }
+
+    @GetMapping
+    public String list(
+        @PathVariable String slug,
+        @PathVariable Long appId,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        Model model
+    ) {
+        Application app = applicationService.getApplication(appId, principal.tenantId());
+        model.addAttribute("slug", slug);
+        model.addAttribute("app", app);
+        model.addAttribute("roles", roleManagementService.listRoles(appId, principal.tenantId()));
+        return "manage/applications/roles/list";
+    }
+
+    @GetMapping("/new")
+    public String newForm(
+        @PathVariable String slug,
+        @PathVariable Long appId,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        Model model
+    ) {
+        Application app = applicationService.getApplication(appId, principal.tenantId());
+        model.addAttribute("slug", slug);
+        model.addAttribute("app", app);
+        return "manage/applications/roles/new";
+    }
+
+    @PostMapping
+    public String create(
+        @PathVariable String slug,
+        @PathVariable Long appId,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        @RequestParam String name,
+        @RequestParam(required = false) String description,
+        Model model
+    ) {
+        try {
+            roleManagementService.createRole(appId, principal.tenantId(), name, description);
+            return "redirect:/manage/t/" + slug + "/applications/" + appId + "/roles";
+        } catch (IllegalArgumentException e) {
+            Application app = applicationService.getApplication(appId, principal.tenantId());
+            model.addAttribute("slug", slug);
+            model.addAttribute("app", app);
+            model.addAttribute("errorMessage", e.getMessage());
+            model.addAttribute("name", name);
+            model.addAttribute("description", description);
+            return "manage/applications/roles/new";
+        }
+    }
+
+    @GetMapping("/{roleId}/edit")
+    public String editForm(
+        @PathVariable String slug,
+        @PathVariable Long appId,
+        @PathVariable Long roleId,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        Model model
+    ) {
+        Application app = applicationService.getApplication(appId, principal.tenantId());
+        model.addAttribute("slug", slug);
+        model.addAttribute("app", app);
+        model.addAttribute("role", roleManagementService.getRole(roleId, appId, principal.tenantId()));
+        return "manage/applications/roles/edit";
+    }
+
+    @PostMapping("/{roleId}/edit")
+    public String update(
+        @PathVariable String slug,
+        @PathVariable Long appId,
+        @PathVariable Long roleId,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        @RequestParam String name,
+        @RequestParam(required = false) String description,
+        Model model
+    ) {
+        try {
+            roleManagementService.updateRole(roleId, appId, principal.tenantId(), name, description);
+            return "redirect:/manage/t/" + slug + "/applications/" + appId + "/roles";
+        } catch (IllegalArgumentException e) {
+            Application app = applicationService.getApplication(appId, principal.tenantId());
+            model.addAttribute("slug", slug);
+            model.addAttribute("app", app);
+            model.addAttribute("role", roleManagementService.getRole(roleId, appId, principal.tenantId()));
+            model.addAttribute("errorMessage", e.getMessage());
+            return "manage/applications/roles/edit";
+        }
+    }
+
+    @PostMapping("/{roleId}/delete")
+    public String delete(
+        @PathVariable String slug,
+        @PathVariable Long appId,
+        @PathVariable Long roleId,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        Model model
+    ) {
+        try {
+            roleManagementService.deleteRole(roleId, appId, principal.tenantId());
+            return "redirect:/manage/t/" + slug + "/applications/" + appId + "/roles";
+        } catch (org.springframework.dao.DataIntegrityViolationException e) {
+            // Once membership-role join tables exist (later slices), the FK
+            // ON DELETE RESTRICT will surface here. Re-render the list so the
+            // admin can see which assignments to clear first.
+            Application app = applicationService.getApplication(appId, principal.tenantId());
+            model.addAttribute("slug", slug);
+            model.addAttribute("app", app);
+            model.addAttribute("roles", roleManagementService.listRoles(appId, principal.tenantId()));
+            model.addAttribute("errorMessage", "Cannot delete a role that is still assigned");
+            return "manage/applications/roles/list";
+        }
+    }
+}

--- a/src/main/resources/db/migration/V3__role_catalogue.sql
+++ b/src/main/resources/db/migration/V3__role_catalogue.sql
@@ -1,0 +1,13 @@
+-- v2 slice 1: per-Application Role catalogue. Discrete role rows replace
+-- freeform string roles, allowing typo-proof assignment, safe renames, and a
+-- natural "Manage Roles" screen on the Application. Tenant isolation is
+-- transitive via application_id → applications.tenant_id.
+
+CREATE TABLE role (
+    id             bigserial    PRIMARY KEY,
+    application_id bigint       NOT NULL REFERENCES applications(id) ON DELETE CASCADE,
+    name           varchar(64)  NOT NULL,
+    description    text         NULL,
+    created_at     timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT role_application_name_unique UNIQUE (application_id, name)
+);

--- a/src/main/resources/templates/manage/applications/list.html
+++ b/src/main/resources/templates/manage/applications/list.html
@@ -19,6 +19,7 @@
             <td>
                 <a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/edit'}">Edit</a>
                 <a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/clients'}">Clients</a>
+                <a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/roles'}">Roles</a>
                 <form method="post" th:action="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/delete'}" style="display:inline">
                     <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                     <button type="submit" onclick="return confirm('Delete this application?')">Delete</button>

--- a/src/main/resources/templates/manage/applications/roles/edit.html
+++ b/src/main/resources/templates/manage/applications/roles/edit.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head><title>Edit Role</title></head>
+<body>
+<h1>Edit Role — <span th:text="${app.name()}"></span></h1>
+<a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/roles'}">← Roles</a>
+
+<div th:if="${errorMessage}" th:text="${errorMessage}"></div>
+
+<form method="post" th:action="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/roles/' + ${role.id()} + '/edit'}">
+    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+    <div><label>Name <input type="text" name="name" th:value="${role.name()}" required maxlength="64"/></label></div>
+    <div><label>Description <textarea name="description" th:text="${role.description()}"></textarea></label></div>
+    <button type="submit">Save</button>
+</form>
+</body>
+</html>

--- a/src/main/resources/templates/manage/applications/roles/list.html
+++ b/src/main/resources/templates/manage/applications/roles/list.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head><title>Roles</title></head>
+<body>
+<h1>Roles — <span th:text="${app.name()}"></span></h1>
+<a th:href="@{'/manage/t/' + ${slug} + '/applications'}">← Applications</a>
+<a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/roles/new'}">New role</a>
+
+<div th:if="${errorMessage}" th:text="${errorMessage}"></div>
+
+<table>
+    <thead>
+        <tr><th>Name</th><th>Description</th><th>Actions</th></tr>
+    </thead>
+    <tbody>
+        <tr th:each="role : ${roles}">
+            <td th:text="${role.name()}"></td>
+            <td th:text="${role.description()}"></td>
+            <td>
+                <a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/roles/' + ${role.id()} + '/edit'}">Edit</a>
+                <form method="post" th:action="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/roles/' + ${role.id()} + '/delete'}" style="display:inline">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                    <button type="submit" onclick="return confirm('Delete this role?')">Delete</button>
+                </form>
+            </td>
+        </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/src/main/resources/templates/manage/applications/roles/new.html
+++ b/src/main/resources/templates/manage/applications/roles/new.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head><title>New Role</title></head>
+<body>
+<h1>New Role — <span th:text="${app.name()}"></span></h1>
+<a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/roles'}">← Roles</a>
+
+<div th:if="${errorMessage}" th:text="${errorMessage}"></div>
+
+<form method="post" th:action="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/roles'}">
+    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+    <div><label>Name <input type="text" name="name" th:value="${name}" autofocus required maxlength="64"/></label></div>
+    <div><label>Description <textarea name="description" th:text="${description}"></textarea></label></div>
+    <button type="submit">Create</button>
+</form>
+</body>
+</html>

--- a/src/test/java/com/stucray/limen/management/roles/RoleManagementServiceIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/roles/RoleManagementServiceIntegrationTest.java
@@ -1,0 +1,140 @@
+package com.stucray.limen.management.roles;
+
+import com.stucray.limen.TestcontainersConfiguration;
+import com.stucray.limen.management.applications.Application;
+import com.stucray.limen.management.applications.ApplicationRepository;
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.tenant.TenantStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest
+class RoleManagementServiceIntegrationTest {
+
+    @Autowired RoleManagementService roleManagementService;
+    @Autowired RoleRepository roleRepository;
+    @Autowired ApplicationRepository applicationRepository;
+    @Autowired TenantRepository tenantRepository;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    Tenant tenantA;
+    Tenant tenantB;
+    Application appA;
+    Application appB;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.execute("DELETE FROM role");
+        jdbcTemplate.execute("DELETE FROM applications");
+        jdbcTemplate.execute("DELETE FROM tenants WHERE slug IN ('roles-a', 'roles-b')");
+
+        tenantA = tenantRepository.save(new Tenant(null, "roles-a", "Roles A", TenantStatus.ACTIVE, LocalDateTime.now()));
+        tenantB = tenantRepository.save(new Tenant(null, "roles-b", "Roles B", TenantStatus.ACTIVE, LocalDateTime.now()));
+        appA = applicationRepository.save(new Application(null, tenantA.id(), "App A", null, LocalDateTime.now()));
+        appB = applicationRepository.save(new Application(null, tenantB.id(), "App B", null, LocalDateTime.now()));
+    }
+
+    @Test
+    void createRoleStoresAndReturnsRow() {
+        Role created = roleManagementService.createRole(appA.id(), tenantA.id(), "viewer", "Read-only access");
+
+        assertThat(created.id()).isNotNull();
+        assertThat(created.applicationId()).isEqualTo(appA.id());
+        assertThat(created.name()).isEqualTo("viewer");
+        assertThat(roleRepository.findByIdAndApplicationId(created.id(), appA.id())).isPresent();
+    }
+
+    @Test
+    void duplicateNameWithinSameApplicationIsRejected() {
+        roleManagementService.createRole(appA.id(), tenantA.id(), "viewer", null);
+
+        assertThatThrownBy(() -> roleManagementService.createRole(appA.id(), tenantA.id(), "viewer", null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("already exists");
+    }
+
+    @Test
+    void sameNameAcrossDifferentApplicationsIsAllowed() {
+        // Same tenant, different application — name reuse is fine because the
+        // unique key is (application_id, name), not (tenant_id, name).
+        Application secondAppInTenantA = applicationRepository.save(
+            new Application(null, tenantA.id(), "App A2", null, LocalDateTime.now())
+        );
+
+        roleManagementService.createRole(appA.id(), tenantA.id(), "viewer", null);
+        Role second = roleManagementService.createRole(secondAppInTenantA.id(), tenantA.id(), "viewer", null);
+
+        assertThat(second.id()).isNotNull();
+    }
+
+    @Test
+    void renameToExistingNameIsRejected() {
+        roleManagementService.createRole(appA.id(), tenantA.id(), "viewer", null);
+        Role editor = roleManagementService.createRole(appA.id(), tenantA.id(), "editor", null);
+
+        assertThatThrownBy(() -> roleManagementService.updateRole(editor.id(), appA.id(), tenantA.id(), "viewer", null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("already exists");
+    }
+
+    @Test
+    void renamingToOwnNameIsAllowed() {
+        Role role = roleManagementService.createRole(appA.id(), tenantA.id(), "viewer", "old desc");
+
+        roleManagementService.updateRole(role.id(), appA.id(), tenantA.id(), "viewer", "new desc");
+
+        assertThat(roleRepository.findByIdAndApplicationId(role.id(), appA.id())
+            .orElseThrow().description()).isEqualTo("new desc");
+    }
+
+    @Test
+    void crossTenantAccessRejected() {
+        // appA belongs to tenantA. Calling with tenantB's id must throw.
+        assertThatThrownBy(() -> roleManagementService.listRoles(appA.id(), tenantB.id()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Application not found");
+
+        assertThatThrownBy(() -> roleManagementService.createRole(appA.id(), tenantB.id(), "viewer", null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Application not found");
+    }
+
+    @Test
+    void crossApplicationGetRejected() {
+        // A role created in appA must not be addressable through appB even by
+        // its owning tenant.
+        Role roleInA = roleManagementService.createRole(appA.id(), tenantA.id(), "viewer", null);
+
+        assertThatThrownBy(() -> roleManagementService.getRole(roleInA.id(), appB.id(), tenantB.id()))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void deleteRemovesRow() {
+        Role role = roleManagementService.createRole(appA.id(), tenantA.id(), "viewer", null);
+
+        roleManagementService.deleteRole(role.id(), appA.id(), tenantA.id());
+
+        assertThat(roleRepository.findByIdAndApplicationId(role.id(), appA.id())).isEmpty();
+    }
+
+    @Test
+    void deletingApplicationCascadesRoles() {
+        Role role = roleManagementService.createRole(appA.id(), tenantA.id(), "viewer", null);
+
+        applicationRepository.delete(appA);
+
+        assertThat(roleRepository.findById(role.id())).isEmpty();
+    }
+}

--- a/src/test/java/com/stucray/limen/management/roles/RolesControllerIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/roles/RolesControllerIntegrationTest.java
@@ -1,0 +1,147 @@
+package com.stucray.limen.management.roles;
+
+import com.stucray.limen.TestcontainersConfiguration;
+import com.stucray.limen.management.applications.Application;
+import com.stucray.limen.management.applications.ApplicationRepository;
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.tenant.TenantStatus;
+import com.stucray.limen.user.User;
+import com.stucray.limen.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+class RolesControllerIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired TenantRepository tenantRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired ApplicationRepository applicationRepository;
+    @Autowired RoleRepository roleRepository;
+    @Autowired PasswordEncoder passwordEncoder;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    Tenant tenantA;
+    Tenant tenantB;
+    Application appA;
+    MockHttpSession sessionA;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        jdbcTemplate.execute("DELETE FROM role");
+        jdbcTemplate.execute("DELETE FROM oauth2_registered_client WHERE application_id IS NOT NULL");
+        jdbcTemplate.execute("DELETE FROM applications");
+        jdbcTemplate.execute("DELETE FROM users WHERE tenant_id IN (SELECT id FROM tenants WHERE slug != 'system')");
+        jdbcTemplate.execute("DELETE FROM tenants WHERE slug != 'system'");
+
+        tenantA = tenantRepository.save(new Tenant(null, "roles-corp-a", "Roles Corp A", TenantStatus.ACTIVE, LocalDateTime.now()));
+        tenantB = tenantRepository.save(new Tenant(null, "roles-corp-b", "Roles Corp B", TenantStatus.ACTIVE, LocalDateTime.now()));
+        userRepository.save(new User(null, tenantA.id(), "owner", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        appA = applicationRepository.save(new Application(null, tenantA.id(), "App A", "desc", LocalDateTime.now()));
+
+        MvcResult login = mockMvc.perform(post("/manage/t/roles-corp-a/login")
+                .param("username", "owner").param("password", "pass").with(csrf()))
+            .andReturn();
+        sessionA = (MockHttpSession) login.getRequest().getSession(false);
+    }
+
+    @Test
+    void ownerCanListRoles() throws Exception {
+        roleRepository.save(new Role(null, appA.id(), "viewer", "read-only", LocalDateTime.now()));
+
+        mockMvc.perform(get("/manage/t/roles-corp-a/applications/" + appA.id() + "/roles").session(sessionA))
+            .andExpect(status().isOk())
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("viewer")));
+    }
+
+    @Test
+    void ownerCanCreateRole() throws Exception {
+        mockMvc.perform(post("/manage/t/roles-corp-a/applications/" + appA.id() + "/roles")
+                .session(sessionA).with(csrf())
+                .param("name", "editor").param("description", "Can edit"))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/manage/t/roles-corp-a/applications/" + appA.id() + "/roles"));
+
+        assertThat(roleRepository.findAllByApplicationId(appA.id()))
+            .extracting(Role::name).containsExactly("editor");
+    }
+
+    @Test
+    void duplicateNameRedisplaysFormWithError() throws Exception {
+        roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
+
+        mockMvc.perform(post("/manage/t/roles-corp-a/applications/" + appA.id() + "/roles")
+                .session(sessionA).with(csrf())
+                .param("name", "viewer").param("description", "dup"))
+            .andExpect(status().isOk())
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("already exists")));
+    }
+
+    @Test
+    void ownerCanEditRole() throws Exception {
+        Role role = roleRepository.save(new Role(null, appA.id(), "old", "old desc", LocalDateTime.now()));
+
+        mockMvc.perform(post("/manage/t/roles-corp-a/applications/" + appA.id() + "/roles/" + role.id() + "/edit")
+                .session(sessionA).with(csrf())
+                .param("name", "new").param("description", "new desc"))
+            .andExpect(status().is3xxRedirection());
+
+        Role reloaded = roleRepository.findByIdAndApplicationId(role.id(), appA.id()).orElseThrow();
+        assertThat(reloaded.name()).isEqualTo("new");
+        assertThat(reloaded.description()).isEqualTo("new desc");
+    }
+
+    @Test
+    void ownerCanDeleteRole() throws Exception {
+        Role role = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
+
+        mockMvc.perform(post("/manage/t/roles-corp-a/applications/" + appA.id() + "/roles/" + role.id() + "/delete")
+                .session(sessionA).with(csrf()))
+            .andExpect(status().is3xxRedirection());
+
+        assertThat(roleRepository.findById(role.id())).isEmpty();
+    }
+
+    @Test
+    void tenantBSessionCannotReachTenantARoles() throws Exception {
+        userRepository.save(new User(null, tenantB.id(), "ownerB", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        MvcResult loginB = mockMvc.perform(post("/manage/t/roles-corp-b/login")
+                .param("username", "ownerB").param("password", "pass").with(csrf()))
+            .andReturn();
+        MockHttpSession sessionB = (MockHttpSession) loginB.getRequest().getSession(false);
+
+        // TenantAccessFilter force-logs out the cross-tenant session and
+        // redirects to the URL slug's login page.
+        mockMvc.perform(get("/manage/t/roles-corp-a/applications/" + appA.id() + "/roles").session(sessionB))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/manage/t/roles-corp-a/login"));
+    }
+
+    @Test
+    void rolesLinkAppearsOnApplicationsList() throws Exception {
+        mockMvc.perform(get("/manage/t/roles-corp-a/applications").session(sessionA))
+            .andExpect(status().isOk())
+            .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                "/manage/t/roles-corp-a/applications/" + appA.id() + "/roles"
+            )));
+    }
+}


### PR DESCRIPTION
## Summary

- V3 Flyway migration adds `role(id, application_id, name, description, created_at)` with `UNIQUE(application_id, name)` and FK ON DELETE CASCADE to `applications`.
- New `com.stucray.limen.management.roles` package: `Role` record, `RoleRepository` (Spring Data JDBC), `RoleManagementService`, `RolesController`.
- UI under `/manage/t/{slug}/applications/{appId}/roles` (list / new / edit / delete), linked from the Applications list as a "Roles" tab.

Tenant isolation is **transitive via `application_id`** as decided in PRD #39. Every service method fetches the Application by `(appId, tenantId)` first, so cross-tenant role access is rejected before any role row is touched. The `TenantAccessFilter` also force-logs-out cross-tenant URL access (covered by an integration test).

Deletion is currently free — once membership-role join tables land in slice #42 with `ON DELETE RESTRICT`, the controller already catches `DataIntegrityViolationException` and re-renders the list with an error.

Closes #40.

## Test plan

- [x] V3 migration runs cleanly on a fresh schema (Testcontainers)
- [x] Service tests cover: create, duplicate-name rejection, name reuse across different applications in same tenant, rename to existing name rejected, rename to own name allowed, cross-tenant access rejected, cross-application get rejected, delete, cascade-on-application-delete
- [x] Controller MVC tests cover: list, create, duplicate-name re-renders form with error, edit, delete, cross-tenant URL access force-logged-out by `TenantAccessFilter`, Roles link visible on Applications list
- [x] Full suite: 116 tests, 0 failures, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)