### PR TITLE
v2 slice 2: Application Membership end-to-end

### DIFF
--- a/src/main/java/com/stucray/limen/management/memberships/ApplicationMembership.java
+++ b/src/main/java/com/stucray/limen/management/memberships/ApplicationMembership.java
@@ -1,0 +1,36 @@
+package com.stucray.limen.management.memberships;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.MappedCollection;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+@Table("application_membership")
+public record ApplicationMembership(
+    @Id Long id,
+    Long userId,
+    Long applicationId,
+    LocalDateTime grantedAt,
+    Long grantedBy,
+    @MappedCollection(idColumn = "application_membership_id")
+    Set<ApplicationMembershipRole> roles
+) {
+    public ApplicationMembership withRoles(Set<Long> roleIds) {
+        Set<ApplicationMembershipRole> assignments = new LinkedHashSet<>();
+        for (Long roleId : roleIds) {
+            assignments.add(new ApplicationMembershipRole(roleId));
+        }
+        return new ApplicationMembership(id, userId, applicationId, grantedAt, grantedBy, assignments);
+    }
+
+    public Set<Long> roleIds() {
+        Set<Long> ids = new LinkedHashSet<>();
+        for (ApplicationMembershipRole r : roles) {
+            ids.add(r.roleId());
+        }
+        return ids;
+    }
+}

--- a/src/main/java/com/stucray/limen/management/memberships/ApplicationMembershipRepository.java
+++ b/src/main/java/com/stucray/limen/management/memberships/ApplicationMembershipRepository.java
@@ -1,0 +1,13 @@
+package com.stucray.limen.management.memberships;
+
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ApplicationMembershipRepository extends CrudRepository<ApplicationMembership, Long> {
+    List<ApplicationMembership> findAllByApplicationId(Long applicationId);
+    Optional<ApplicationMembership> findByIdAndApplicationId(Long id, Long applicationId);
+    Optional<ApplicationMembership> findByUserIdAndApplicationId(Long userId, Long applicationId);
+    boolean existsByUserIdAndApplicationId(Long userId, Long applicationId);
+}

--- a/src/main/java/com/stucray/limen/management/memberships/ApplicationMembershipRole.java
+++ b/src/main/java/com/stucray/limen/management/memberships/ApplicationMembershipRole.java
@@ -1,0 +1,7 @@
+package com.stucray.limen.management.memberships;
+
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table("application_membership_role")
+public record ApplicationMembershipRole(Long roleId) {
+}

--- a/src/main/java/com/stucray/limen/management/memberships/ApplicationMembershipService.java
+++ b/src/main/java/com/stucray/limen/management/memberships/ApplicationMembershipService.java
@@ -1,0 +1,113 @@
+package com.stucray.limen.management.memberships;
+
+import com.stucray.limen.management.applications.Application;
+import com.stucray.limen.management.applications.ApplicationRepository;
+import com.stucray.limen.management.roles.Role;
+import com.stucray.limen.management.roles.RoleRepository;
+import com.stucray.limen.user.User;
+import com.stucray.limen.user.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Application Memberships are transitively scoped to a Tenant via Application.
+ * Every public method requires the caller to pass `(applicationId, tenantId)`;
+ * the Application is fetched first so cross-tenant access is rejected before
+ * any membership row is touched.
+ *
+ * App Membership Roles in this slice govern only management-console authority
+ * over the Application — the JWT `roles` claim still emits `[]` (changed in
+ * slice 4 / issue #43, which sources the claim from Client Membership only).
+ */
+@Service
+public class ApplicationMembershipService {
+
+    private final ApplicationMembershipRepository membershipRepository;
+    private final ApplicationRepository applicationRepository;
+    private final UserRepository userRepository;
+    private final RoleRepository roleRepository;
+
+    public ApplicationMembershipService(
+        ApplicationMembershipRepository membershipRepository,
+        ApplicationRepository applicationRepository,
+        UserRepository userRepository,
+        RoleRepository roleRepository
+    ) {
+        this.membershipRepository = membershipRepository;
+        this.applicationRepository = applicationRepository;
+        this.userRepository = userRepository;
+        this.roleRepository = roleRepository;
+    }
+
+    public List<ApplicationMembership> listMemberships(Long applicationId, Long tenantId) {
+        requireApplication(applicationId, tenantId);
+        return membershipRepository.findAllByApplicationId(applicationId);
+    }
+
+    public ApplicationMembership getMembership(Long membershipId, Long applicationId, Long tenantId) {
+        requireApplication(applicationId, tenantId);
+        return membershipRepository.findByIdAndApplicationId(membershipId, applicationId)
+            .orElseThrow(() -> new IllegalArgumentException("Membership not found"));
+    }
+
+    public ApplicationMembership grant(Long applicationId, Long tenantId, Long userId, Long grantedByUserId) {
+        Application app = requireApplication(applicationId, tenantId);
+        User user = userRepository.findByIdAndTenantId(userId, tenantId)
+            .orElseThrow(() -> new IllegalArgumentException("User not found in this tenant"));
+        // Belt-and-braces: the lookup above already filters by tenantId, but
+        // make the cross-tenant intent explicit so this check survives any
+        // future refactor of the lookup.
+        if (!user.tenantId().equals(app.tenantId())) {
+            throw new IllegalArgumentException("User does not belong to the same tenant as this application");
+        }
+        if (membershipRepository.existsByUserIdAndApplicationId(userId, applicationId)) {
+            throw new IllegalArgumentException("User is already a member of this application");
+        }
+        return membershipRepository.save(new ApplicationMembership(
+            null, userId, applicationId, LocalDateTime.now(), grantedByUserId, Set.of()
+        ));
+    }
+
+    public void updateRoles(Long membershipId, Long applicationId, Long tenantId, Set<Long> roleIds) {
+        ApplicationMembership membership = getMembership(membershipId, applicationId, tenantId);
+        Set<Long> requested = roleIds == null ? Set.of() : new LinkedHashSet<>(roleIds);
+        for (Long roleId : requested) {
+            Role role = roleRepository.findById(roleId)
+                .orElseThrow(() -> new IllegalArgumentException("Role not found: " + roleId));
+            if (!role.applicationId().equals(applicationId)) {
+                throw new IllegalArgumentException("Role does not belong to this application");
+            }
+        }
+        membershipRepository.save(membership.withRoles(requested));
+    }
+
+    public void revoke(Long membershipId, Long applicationId, Long tenantId) {
+        ApplicationMembership membership = getMembership(membershipId, applicationId, tenantId);
+        membershipRepository.delete(membership);
+    }
+
+    /**
+     * Users in the tenant who do not yet have a Membership for this Application.
+     * Used to populate the "Add member" form's user picker.
+     */
+    public List<User> listGrantableUsers(Long applicationId, Long tenantId) {
+        requireApplication(applicationId, tenantId);
+        List<User> all = userRepository.findAllByTenantId(tenantId);
+        List<User> grantable = new java.util.ArrayList<>();
+        for (User u : all) {
+            if (!membershipRepository.existsByUserIdAndApplicationId(u.id(), applicationId)) {
+                grantable.add(u);
+            }
+        }
+        return grantable;
+    }
+
+    private Application requireApplication(Long applicationId, Long tenantId) {
+        return applicationRepository.findByIdAndTenantId(applicationId, tenantId)
+            .orElseThrow(() -> new IllegalArgumentException("Application not found"));
+    }
+}

--- a/src/main/java/com/stucray/limen/management/memberships/MembersController.java
+++ b/src/main/java/com/stucray/limen/management/memberships/MembersController.java
@@ -1,0 +1,177 @@
+package com.stucray.limen.management.memberships;
+
+import com.stucray.limen.auth.TenantUserDetails;
+import com.stucray.limen.management.applications.Application;
+import com.stucray.limen.management.applications.ApplicationService;
+import com.stucray.limen.management.roles.Role;
+import com.stucray.limen.management.roles.RoleManagementService;
+import com.stucray.limen.user.User;
+import com.stucray.limen.user.UserRepository;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Controller
+@RequestMapping("/manage/t/{slug}/applications/{appId}/members")
+public class MembersController {
+
+    private final ApplicationMembershipService membershipService;
+    private final ApplicationService applicationService;
+    private final RoleManagementService roleManagementService;
+    private final UserRepository userRepository;
+
+    public MembersController(
+        ApplicationMembershipService membershipService,
+        ApplicationService applicationService,
+        RoleManagementService roleManagementService,
+        UserRepository userRepository
+    ) {
+        this.membershipService = membershipService;
+        this.applicationService = applicationService;
+        this.roleManagementService = roleManagementService;
+        this.userRepository = userRepository;
+    }
+
+    @GetMapping
+    public String list(
+        @PathVariable String slug,
+        @PathVariable Long appId,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        Model model
+    ) {
+        Application app = applicationService.getApplication(appId, principal.tenantId());
+        List<ApplicationMembership> memberships = membershipService.listMemberships(appId, principal.tenantId());
+        List<Role> allRoles = roleManagementService.listRoles(appId, principal.tenantId());
+        model.addAttribute("slug", slug);
+        model.addAttribute("app", app);
+        model.addAttribute("memberships", memberships);
+        model.addAttribute("usernamesById", usernamesByIdFor(memberships));
+        model.addAttribute("roleNamesById", roleNamesByIdFor(allRoles));
+        return "manage/applications/members/list";
+    }
+
+    @GetMapping("/new")
+    public String newForm(
+        @PathVariable String slug,
+        @PathVariable Long appId,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        Model model
+    ) {
+        Application app = applicationService.getApplication(appId, principal.tenantId());
+        model.addAttribute("slug", slug);
+        model.addAttribute("app", app);
+        model.addAttribute("grantableUsers", membershipService.listGrantableUsers(appId, principal.tenantId()));
+        return "manage/applications/members/new";
+    }
+
+    @PostMapping
+    public String create(
+        @PathVariable String slug,
+        @PathVariable Long appId,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        @RequestParam Long userId,
+        Model model
+    ) {
+        try {
+            membershipService.grant(appId, principal.tenantId(), userId, principal.userId());
+            return "redirect:/manage/t/" + slug + "/applications/" + appId + "/members";
+        } catch (IllegalArgumentException e) {
+            Application app = applicationService.getApplication(appId, principal.tenantId());
+            model.addAttribute("slug", slug);
+            model.addAttribute("app", app);
+            model.addAttribute("grantableUsers", membershipService.listGrantableUsers(appId, principal.tenantId()));
+            model.addAttribute("errorMessage", e.getMessage());
+            return "manage/applications/members/new";
+        }
+    }
+
+    @GetMapping("/{membershipId}/edit")
+    public String editForm(
+        @PathVariable String slug,
+        @PathVariable Long appId,
+        @PathVariable Long membershipId,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        Model model
+    ) {
+        Application app = applicationService.getApplication(appId, principal.tenantId());
+        ApplicationMembership membership = membershipService.getMembership(membershipId, appId, principal.tenantId());
+        List<Role> allRoles = roleManagementService.listRoles(appId, principal.tenantId());
+        User member = userRepository.findById(membership.userId())
+            .orElseThrow(() -> new IllegalStateException("Membership references missing user"));
+        model.addAttribute("slug", slug);
+        model.addAttribute("app", app);
+        model.addAttribute("membership", membership);
+        model.addAttribute("memberUsername", member.username());
+        model.addAttribute("allRoles", allRoles);
+        model.addAttribute("assignedRoleIds", membership.roleIds());
+        return "manage/applications/members/edit";
+    }
+
+    @PostMapping("/{membershipId}/edit")
+    public String update(
+        @PathVariable String slug,
+        @PathVariable Long appId,
+        @PathVariable Long membershipId,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        @RequestParam(name = "roleIds", required = false) List<Long> roleIds,
+        Model model
+    ) {
+        try {
+            Set<Long> requested = roleIds == null ? Set.of() : new java.util.LinkedHashSet<>(roleIds);
+            membershipService.updateRoles(membershipId, appId, principal.tenantId(), requested);
+            return "redirect:/manage/t/" + slug + "/applications/" + appId + "/members";
+        } catch (IllegalArgumentException e) {
+            Application app = applicationService.getApplication(appId, principal.tenantId());
+            ApplicationMembership membership = membershipService.getMembership(membershipId, appId, principal.tenantId());
+            List<Role> allRoles = roleManagementService.listRoles(appId, principal.tenantId());
+            User member = userRepository.findById(membership.userId())
+                .orElseThrow(() -> new IllegalStateException("Membership references missing user"));
+            model.addAttribute("slug", slug);
+            model.addAttribute("app", app);
+            model.addAttribute("membership", membership);
+            model.addAttribute("memberUsername", member.username());
+            model.addAttribute("allRoles", allRoles);
+            model.addAttribute("assignedRoleIds", roleIds == null ? Set.of() : new java.util.LinkedHashSet<>(roleIds));
+            model.addAttribute("errorMessage", e.getMessage());
+            return "manage/applications/members/edit";
+        }
+    }
+
+    @PostMapping("/{membershipId}/delete")
+    public String delete(
+        @PathVariable String slug,
+        @PathVariable Long appId,
+        @PathVariable Long membershipId,
+        @AuthenticationPrincipal TenantUserDetails principal
+    ) {
+        membershipService.revoke(membershipId, appId, principal.tenantId());
+        return "redirect:/manage/t/" + slug + "/applications/" + appId + "/members";
+    }
+
+    private Map<Long, String> usernamesByIdFor(List<ApplicationMembership> memberships) {
+        Map<Long, String> map = new LinkedHashMap<>();
+        for (ApplicationMembership m : memberships) {
+            userRepository.findById(m.userId()).ifPresent(u -> map.put(u.id(), u.username()));
+        }
+        return map;
+    }
+
+    private Map<Long, String> roleNamesByIdFor(List<Role> roles) {
+        Map<Long, String> map = new HashMap<>();
+        for (Role r : roles) {
+            map.put(r.id(), r.name());
+        }
+        return map;
+    }
+}

--- a/src/main/java/com/stucray/limen/user/UserRepository.java
+++ b/src/main/java/com/stucray/limen/user/UserRepository.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 
 public interface UserRepository extends CrudRepository<User, Long> {
     Optional<User> findByUsernameAndTenantId(String username, Long tenantId);
+    Optional<User> findByIdAndTenantId(Long id, Long tenantId);
     List<User> findAllByTenantId(Long tenantId);
     boolean existsByUsernameAndTenantId(String username, Long tenantId);
 }

--- a/src/main/resources/db/migration/V4__application_membership.sql
+++ b/src/main/resources/db/migration/V4__application_membership.sql
@@ -1,0 +1,23 @@
+-- v2 slice 2: Application Membership. Grants a User access to manage an
+-- Application from the Tenant Owner console; App Membership Roles govern
+-- console authority over the Application (the JWT roles claim continues to
+-- come from Client Membership only — see PRD #39).
+-- Tenant isolation is transitive via application_id → applications.tenant_id.
+-- granted_by is nullable so deleting the granter does not cascade-destroy
+-- the audit trail; granted_at + granted_by together form the minimal forensic
+-- record (full audit log deferred to v2.5).
+
+CREATE TABLE application_membership (
+    id             bigserial    PRIMARY KEY,
+    user_id        bigint       NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    application_id bigint       NOT NULL REFERENCES applications(id) ON DELETE CASCADE,
+    granted_at     timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    granted_by     bigint       NULL REFERENCES users(id) ON DELETE SET NULL,
+    CONSTRAINT application_membership_user_app_unique UNIQUE (user_id, application_id)
+);
+
+CREATE TABLE application_membership_role (
+    application_membership_id bigint NOT NULL REFERENCES application_membership(id) ON DELETE CASCADE,
+    role_id                   bigint NOT NULL REFERENCES role(id) ON DELETE RESTRICT,
+    PRIMARY KEY (application_membership_id, role_id)
+);

--- a/src/main/resources/templates/manage/applications/list.html
+++ b/src/main/resources/templates/manage/applications/list.html
@@ -20,6 +20,7 @@
                 <a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/edit'}">Edit</a>
                 <a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/clients'}">Clients</a>
                 <a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/roles'}">Roles</a>
+                <a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/members'}">Members</a>
                 <form method="post" th:action="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/delete'}" style="display:inline">
                     <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                     <button type="submit" onclick="return confirm('Delete this application?')">Delete</button>

--- a/src/main/resources/templates/manage/applications/members/edit.html
+++ b/src/main/resources/templates/manage/applications/members/edit.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head><title>Edit Member Roles</title></head>
+<body>
+<h1>Member roles — <span th:text="${memberUsername}"></span> on <span th:text="${app.name()}"></span></h1>
+<a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/members'}">← Members</a>
+
+<div th:if="${errorMessage}" th:text="${errorMessage}"></div>
+
+<form method="post"
+      th:action="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/members/' + ${membership.id()} + '/edit'}">
+    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+    <fieldset>
+        <legend>Roles</legend>
+        <p th:if="${allRoles.isEmpty()}">No roles defined for this application yet.</p>
+        <div th:each="role : ${allRoles}">
+            <label>
+                <input type="checkbox" name="roleIds" th:value="${role.id()}"
+                       th:checked="${assignedRoleIds.contains(role.id())}"/>
+                <span th:text="${role.name()}"></span>
+            </label>
+        </div>
+    </fieldset>
+    <button type="submit">Save</button>
+</form>
+</body>
+</html>

--- a/src/main/resources/templates/manage/applications/members/list.html
+++ b/src/main/resources/templates/manage/applications/members/list.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head><title>Members</title></head>
+<body>
+<h1>Members — <span th:text="${app.name()}"></span></h1>
+<a th:href="@{'/manage/t/' + ${slug} + '/applications'}">← Applications</a>
+<a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/members/new'}">Add member</a>
+
+<div th:if="${errorMessage}" th:text="${errorMessage}"></div>
+
+<table>
+    <thead>
+        <tr><th>User</th><th>Roles</th><th>Granted at</th><th>Actions</th></tr>
+    </thead>
+    <tbody>
+        <tr th:each="m : ${memberships}">
+            <td th:text="${usernamesById.get(m.userId())}"></td>
+            <td>
+                <span th:each="rid, it : ${m.roleIds()}">
+                    <span th:text="${roleNamesById.get(rid)}"></span><span th:if="${!it.last}">, </span>
+                </span>
+            </td>
+            <td th:text="${m.grantedAt()}"></td>
+            <td>
+                <a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/members/' + ${m.id()} + '/edit'}">Edit roles</a>
+                <form method="post" th:action="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/members/' + ${m.id()} + '/delete'}" style="display:inline">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                    <button type="submit" onclick="return confirm('Revoke this membership?')">Revoke</button>
+                </form>
+            </td>
+        </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/src/main/resources/templates/manage/applications/members/new.html
+++ b/src/main/resources/templates/manage/applications/members/new.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head><title>Add Member</title></head>
+<body>
+<h1>Add Member — <span th:text="${app.name()}"></span></h1>
+<a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/members'}">← Members</a>
+
+<div th:if="${errorMessage}" th:text="${errorMessage}"></div>
+
+<form th:if="${!grantableUsers.isEmpty()}" method="post"
+      th:action="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/members'}">
+    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+    <div>
+        <label>User
+            <select name="userId" required>
+                <option th:each="u : ${grantableUsers}" th:value="${u.id()}" th:text="${u.username()}"></option>
+            </select>
+        </label>
+    </div>
+    <button type="submit">Grant membership</button>
+</form>
+<p th:if="${grantableUsers.isEmpty()}">All users in this tenant already have a membership for this application.</p>
+</body>
+</html>

--- a/src/test/java/com/stucray/limen/management/memberships/ApplicationMembershipServiceIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/memberships/ApplicationMembershipServiceIntegrationTest.java
@@ -1,0 +1,261 @@
+package com.stucray.limen.management.memberships;
+
+import com.stucray.limen.TestcontainersConfiguration;
+import com.stucray.limen.management.applications.Application;
+import com.stucray.limen.management.applications.ApplicationRepository;
+import com.stucray.limen.management.roles.Role;
+import com.stucray.limen.management.roles.RoleRepository;
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.tenant.TenantStatus;
+import com.stucray.limen.user.User;
+import com.stucray.limen.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest
+class ApplicationMembershipServiceIntegrationTest {
+
+    @Autowired ApplicationMembershipService membershipService;
+    @Autowired ApplicationMembershipRepository membershipRepository;
+    @Autowired ApplicationRepository applicationRepository;
+    @Autowired RoleRepository roleRepository;
+    @Autowired TenantRepository tenantRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    Tenant tenantA;
+    Tenant tenantB;
+    Application appA;
+    Application appB;
+    User aliceA;
+    User bobA;
+    User adminA;
+    User carolB;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.execute("DELETE FROM application_membership_role");
+        jdbcTemplate.execute("DELETE FROM application_membership");
+        jdbcTemplate.execute("DELETE FROM role");
+        jdbcTemplate.execute("DELETE FROM applications");
+        jdbcTemplate.execute("DELETE FROM users WHERE tenant_id IN (SELECT id FROM tenants WHERE slug IN ('mem-a', 'mem-b'))");
+        jdbcTemplate.execute("DELETE FROM tenants WHERE slug IN ('mem-a', 'mem-b')");
+
+        tenantA = tenantRepository.save(new Tenant(null, "mem-a", "Mem A", TenantStatus.ACTIVE, LocalDateTime.now()));
+        tenantB = tenantRepository.save(new Tenant(null, "mem-b", "Mem B", TenantStatus.ACTIVE, LocalDateTime.now()));
+        appA = applicationRepository.save(new Application(null, tenantA.id(), "App A", null, LocalDateTime.now()));
+        appB = applicationRepository.save(new Application(null, tenantB.id(), "App B", null, LocalDateTime.now()));
+        aliceA = userRepository.save(new User(null, tenantA.id(), "alice", "x", true, false, false, LocalDateTime.now()));
+        bobA = userRepository.save(new User(null, tenantA.id(), "bob",   "x", true, false, false, LocalDateTime.now()));
+        adminA = userRepository.save(new User(null, tenantA.id(), "admin", "x", true, false, true,  LocalDateTime.now()));
+        carolB = userRepository.save(new User(null, tenantB.id(), "carol", "x", true, false, false, LocalDateTime.now()));
+    }
+
+    @Test
+    void grantStoresRowWithGrantedAtAndGrantedBy() {
+        ApplicationMembership m = membershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+
+        assertThat(m.id()).isNotNull();
+        assertThat(m.userId()).isEqualTo(aliceA.id());
+        assertThat(m.applicationId()).isEqualTo(appA.id());
+        assertThat(m.grantedAt()).isNotNull();
+        assertThat(m.grantedBy()).isEqualTo(adminA.id());
+        assertThat(m.roleIds()).isEmpty();
+    }
+
+    @Test
+    void duplicateUserApplicationRejected() {
+        membershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+
+        assertThatThrownBy(() -> membershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("already a member");
+    }
+
+    @Test
+    void crossTenantApplicationAccessRejected() {
+        // Caller claims tenantA but appB belongs to tenantB.
+        assertThatThrownBy(() -> membershipService.listMemberships(appB.id(), tenantA.id()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Application not found");
+
+        assertThatThrownBy(() -> membershipService.grant(appB.id(), tenantA.id(), aliceA.id(), adminA.id()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Application not found");
+    }
+
+    @Test
+    void grantingUserFromAnotherTenantRejected() {
+        // carolB is in tenantB; appA is in tenantA. Even though the caller
+        // legitimately controls tenantA, granting a foreign User must fail.
+        assertThatThrownBy(() -> membershipService.grant(appA.id(), tenantA.id(), carolB.id(), adminA.id()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("User not found");
+    }
+
+    @Test
+    void uniqueConstraintHonouredAtRepositoryLevel() {
+        membershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+
+        assertThatThrownBy(() -> membershipRepository.save(
+            new ApplicationMembership(null, aliceA.id(), appA.id(), LocalDateTime.now(), adminA.id(), Set.of())
+        )).isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void updateRolesAssignsSet() {
+        ApplicationMembership m = membershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+        Role viewer = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
+        Role editor = roleRepository.save(new Role(null, appA.id(), "editor", null, LocalDateTime.now()));
+
+        membershipService.updateRoles(m.id(), appA.id(), tenantA.id(), Set.of(viewer.id(), editor.id()));
+
+        ApplicationMembership reloaded = membershipService.getMembership(m.id(), appA.id(), tenantA.id());
+        assertThat(reloaded.roleIds()).containsExactlyInAnyOrder(viewer.id(), editor.id());
+    }
+
+    @Test
+    void updateRolesReplacesExistingSet() {
+        ApplicationMembership m = membershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+        Role viewer = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
+        Role editor = roleRepository.save(new Role(null, appA.id(), "editor", null, LocalDateTime.now()));
+
+        membershipService.updateRoles(m.id(), appA.id(), tenantA.id(), Set.of(viewer.id(), editor.id()));
+        membershipService.updateRoles(m.id(), appA.id(), tenantA.id(), Set.of(editor.id()));
+
+        ApplicationMembership reloaded = membershipService.getMembership(m.id(), appA.id(), tenantA.id());
+        assertThat(reloaded.roleIds()).containsExactly(editor.id());
+    }
+
+    @Test
+    void updateRolesEmptyClearsSet() {
+        ApplicationMembership m = membershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+        Role viewer = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
+        membershipService.updateRoles(m.id(), appA.id(), tenantA.id(), Set.of(viewer.id()));
+
+        membershipService.updateRoles(m.id(), appA.id(), tenantA.id(), Set.of());
+
+        assertThat(membershipService.getMembership(m.id(), appA.id(), tenantA.id()).roleIds()).isEmpty();
+    }
+
+    @Test
+    void cannotAssignRoleFromAnotherApplication() {
+        ApplicationMembership m = membershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+        // Role belongs to a *different* tenant's application — clearly not assignable.
+        Role foreign = roleRepository.save(new Role(null, appB.id(), "viewer", null, LocalDateTime.now()));
+
+        assertThatThrownBy(() -> membershipService.updateRoles(m.id(), appA.id(), tenantA.id(), Set.of(foreign.id())))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("does not belong to this application");
+    }
+
+    @Test
+    void cannotAssignRoleFromAnotherAppInSameTenant() {
+        // Same tenant, different app — still must be rejected.
+        Application appA2 = applicationRepository.save(new Application(null, tenantA.id(), "App A2", null, LocalDateTime.now()));
+        Role roleInA2 = roleRepository.save(new Role(null, appA2.id(), "viewer", null, LocalDateTime.now()));
+        ApplicationMembership m = membershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+
+        assertThatThrownBy(() -> membershipService.updateRoles(m.id(), appA.id(), tenantA.id(), Set.of(roleInA2.id())))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("does not belong to this application");
+    }
+
+    @Test
+    void revokeRemovesRowAndRoleAssignments() {
+        Role viewer = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
+        ApplicationMembership m = membershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+        membershipService.updateRoles(m.id(), appA.id(), tenantA.id(), Set.of(viewer.id()));
+
+        membershipService.revoke(m.id(), appA.id(), tenantA.id());
+
+        assertThat(membershipRepository.findById(m.id())).isEmpty();
+        Integer joinCount = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM application_membership_role WHERE application_membership_id = ?",
+            Integer.class, m.id()
+        );
+        assertThat(joinCount).isZero();
+        // The Role itself remains — only the assignment is gone.
+        assertThat(roleRepository.findById(viewer.id())).isPresent();
+    }
+
+    @Test
+    void roleAssignedToMembershipCannotBeDeleted() {
+        Role viewer = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
+        ApplicationMembership m = membershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+        membershipService.updateRoles(m.id(), appA.id(), tenantA.id(), Set.of(viewer.id()));
+
+        // ON DELETE RESTRICT on application_membership_role.role_id surfaces
+        // as a DataIntegrityViolationException — exactly what RolesController
+        // already catches and translates into a user-facing error.
+        assertThatThrownBy(() -> roleRepository.delete(viewer))
+            .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void deletingApplicationCascadesMembershipWithoutRoleAssignments() {
+        ApplicationMembership m = membershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+
+        applicationRepository.delete(appA);
+
+        assertThat(membershipRepository.findById(m.id())).isEmpty();
+    }
+
+    @Test
+    void deletingApplicationWithAssignedRolesFailsRestrict() {
+        // The PRD #39 RESTRICT on application_membership_role.role_id protects
+        // against silent role-assignment loss. As a side effect, an Application
+        // cannot be deleted while any of its Roles are still assigned to a
+        // Membership — the role-cascade fires before the membership-cascade
+        // and Postgres rejects the role delete. Admin must clear assignments
+        // (or revoke the membership) first, mirroring the existing
+        // "cannot delete an Application with attached Clients" rule.
+        Role viewer = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
+        ApplicationMembership m = membershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+        membershipService.updateRoles(m.id(), appA.id(), tenantA.id(), Set.of(viewer.id()));
+
+        assertThatThrownBy(() -> applicationRepository.delete(appA))
+            .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void deletingUserCascadesMembership() {
+        membershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+
+        userRepository.delete(aliceA);
+
+        assertThat(membershipRepository.findAllByApplicationId(appA.id())).isEmpty();
+    }
+
+    @Test
+    void deletingGranterNullifiesGrantedBy() {
+        ApplicationMembership m = membershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+
+        userRepository.delete(adminA);
+
+        ApplicationMembership reloaded = membershipRepository.findById(m.id()).orElseThrow();
+        assertThat(reloaded.grantedBy()).isNull();
+    }
+
+    @Test
+    void listGrantableUsersExcludesExistingMembers() {
+        membershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+
+        var grantable = membershipService.listGrantableUsers(appA.id(), tenantA.id());
+
+        assertThat(grantable).extracting(User::username).containsExactlyInAnyOrder("bob", "admin");
+    }
+}

--- a/src/test/java/com/stucray/limen/management/memberships/MembersControllerIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/memberships/MembersControllerIntegrationTest.java
@@ -1,0 +1,188 @@
+package com.stucray.limen.management.memberships;
+
+import com.stucray.limen.TestcontainersConfiguration;
+import com.stucray.limen.management.applications.Application;
+import com.stucray.limen.management.applications.ApplicationRepository;
+import com.stucray.limen.management.roles.Role;
+import com.stucray.limen.management.roles.RoleRepository;
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.tenant.TenantStatus;
+import com.stucray.limen.user.User;
+import com.stucray.limen.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+class MembersControllerIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired TenantRepository tenantRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired ApplicationRepository applicationRepository;
+    @Autowired RoleRepository roleRepository;
+    @Autowired ApplicationMembershipRepository membershipRepository;
+    @Autowired PasswordEncoder passwordEncoder;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    Tenant tenantA;
+    Tenant tenantB;
+    Application appA;
+    User ownerA;
+    User aliceA;
+    MockHttpSession sessionA;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        jdbcTemplate.execute("DELETE FROM application_membership_role");
+        jdbcTemplate.execute("DELETE FROM application_membership");
+        jdbcTemplate.execute("DELETE FROM role");
+        jdbcTemplate.execute("DELETE FROM oauth2_registered_client WHERE application_id IS NOT NULL");
+        jdbcTemplate.execute("DELETE FROM applications");
+        jdbcTemplate.execute("DELETE FROM users WHERE tenant_id IN (SELECT id FROM tenants WHERE slug != 'system')");
+        jdbcTemplate.execute("DELETE FROM tenants WHERE slug != 'system'");
+
+        tenantA = tenantRepository.save(new Tenant(null, "members-corp-a", "Members Corp A", TenantStatus.ACTIVE, LocalDateTime.now()));
+        tenantB = tenantRepository.save(new Tenant(null, "members-corp-b", "Members Corp B", TenantStatus.ACTIVE, LocalDateTime.now()));
+        ownerA = userRepository.save(new User(null, tenantA.id(), "owner", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        aliceA = userRepository.save(new User(null, tenantA.id(), "alice", passwordEncoder.encode("pass"), true, false, false, LocalDateTime.now()));
+        appA = applicationRepository.save(new Application(null, tenantA.id(), "App A", "desc", LocalDateTime.now()));
+
+        MvcResult login = mockMvc.perform(post("/manage/t/members-corp-a/login")
+                .param("username", "owner").param("password", "pass").with(csrf()))
+            .andReturn();
+        sessionA = (MockHttpSession) login.getRequest().getSession(false);
+    }
+
+    @Test
+    void ownerCanListMembers() throws Exception {
+        membershipRepository.save(new ApplicationMembership(
+            null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), java.util.Set.of()
+        ));
+
+        mockMvc.perform(get("/manage/t/members-corp-a/applications/" + appA.id() + "/members").session(sessionA))
+            .andExpect(status().isOk())
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("alice")));
+    }
+
+    @Test
+    void ownerCanGrantMembership() throws Exception {
+        mockMvc.perform(post("/manage/t/members-corp-a/applications/" + appA.id() + "/members")
+                .session(sessionA).with(csrf())
+                .param("userId", aliceA.id().toString()))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/manage/t/members-corp-a/applications/" + appA.id() + "/members"));
+
+        var memberships = membershipRepository.findAllByApplicationId(appA.id());
+        assertThat(memberships).hasSize(1);
+        ApplicationMembership saved = memberships.get(0);
+        assertThat(saved.userId()).isEqualTo(aliceA.id());
+        // granted_by should be the authenticated owner.
+        assertThat(saved.grantedBy()).isEqualTo(ownerA.id());
+        assertThat(saved.grantedAt()).isNotNull();
+    }
+
+    @Test
+    void duplicateGrantRedisplaysFormWithError() throws Exception {
+        membershipRepository.save(new ApplicationMembership(
+            null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), java.util.Set.of()
+        ));
+
+        mockMvc.perform(post("/manage/t/members-corp-a/applications/" + appA.id() + "/members")
+                .session(sessionA).with(csrf())
+                .param("userId", aliceA.id().toString()))
+            .andExpect(status().isOk())
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("already a member")));
+    }
+
+    @Test
+    void ownerCanAssignRolesViaEditForm() throws Exception {
+        ApplicationMembership m = membershipRepository.save(new ApplicationMembership(
+            null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), java.util.Set.of()
+        ));
+        Role viewer = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
+        Role editor = roleRepository.save(new Role(null, appA.id(), "editor", null, LocalDateTime.now()));
+
+        mockMvc.perform(post("/manage/t/members-corp-a/applications/" + appA.id() + "/members/" + m.id() + "/edit")
+                .session(sessionA).with(csrf())
+                .param("roleIds", viewer.id().toString())
+                .param("roleIds", editor.id().toString()))
+            .andExpect(status().is3xxRedirection());
+
+        ApplicationMembership reloaded = membershipRepository.findById(m.id()).orElseThrow();
+        assertThat(reloaded.roleIds()).containsExactlyInAnyOrder(viewer.id(), editor.id());
+    }
+
+    @Test
+    void editFormSubmitWithNoRoleIdsClearsAssignments() throws Exception {
+        Role viewer = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
+        ApplicationMembership m = membershipRepository.save(new ApplicationMembership(
+            null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(),
+            java.util.Set.of(new ApplicationMembershipRole(viewer.id()))
+        ));
+
+        mockMvc.perform(post("/manage/t/members-corp-a/applications/" + appA.id() + "/members/" + m.id() + "/edit")
+                .session(sessionA).with(csrf()))
+            .andExpect(status().is3xxRedirection());
+
+        assertThat(membershipRepository.findById(m.id()).orElseThrow().roleIds()).isEmpty();
+    }
+
+    @Test
+    void ownerCanRevokeMembership() throws Exception {
+        ApplicationMembership m = membershipRepository.save(new ApplicationMembership(
+            null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), java.util.Set.of()
+        ));
+
+        mockMvc.perform(post("/manage/t/members-corp-a/applications/" + appA.id() + "/members/" + m.id() + "/delete")
+                .session(sessionA).with(csrf()))
+            .andExpect(status().is3xxRedirection());
+
+        assertThat(membershipRepository.findById(m.id())).isEmpty();
+    }
+
+    @Test
+    void tenantBSessionCannotReachTenantAMembers() throws Exception {
+        userRepository.save(new User(null, tenantB.id(), "ownerB", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        MvcResult loginB = mockMvc.perform(post("/manage/t/members-corp-b/login")
+                .param("username", "ownerB").param("password", "pass").with(csrf()))
+            .andReturn();
+        MockHttpSession sessionB = (MockHttpSession) loginB.getRequest().getSession(false);
+
+        // TenantAccessFilter force-logs out the cross-tenant session and
+        // redirects to the URL slug's login page.
+        mockMvc.perform(get("/manage/t/members-corp-a/applications/" + appA.id() + "/members").session(sessionB))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/manage/t/members-corp-a/login"));
+    }
+
+    @Test
+    void membersLinkAppearsOnApplicationsList() throws Exception {
+        mockMvc.perform(get("/manage/t/members-corp-a/applications").session(sessionA))
+            .andExpect(status().isOk())
+            .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                "/manage/t/members-corp-a/applications/" + appA.id() + "/members"
+            )));
+    }
+}


### PR DESCRIPTION
## Summary

- V4 Flyway migration adds `application_membership(id, user_id, application_id, granted_at, granted_by)` with `UNIQUE(user_id, application_id)` and `application_membership_role(application_membership_id, role_id)` with `role_id ON DELETE RESTRICT`.
- New `com.stucray.limen.management.memberships` package: `ApplicationMembership` aggregate (record + `@MappedCollection` role assignment set), `ApplicationMembershipRepository`, `ApplicationMembershipService`, `MembersController`.
- UI under `/manage/t/{slug}/applications/{appId}/members` (list / grant / edit roles / revoke), linked from the Applications list as a "Members" tab.

Tenant isolation is **transitive via `application_id`**, mirroring slice 1: every service method fetches the Application by `(appId, tenantId)` first, so cross-tenant access is rejected before any membership row is touched. Granting a User from a foreign Tenant is also rejected at service level. The `TenantAccessFilter` force-logs-out cross-tenant URL access (covered by an integration test).

App Membership Roles in this slice govern only management-console authority over the Application — the JWT `roles` claim still emits `[]` (changed in slice 4 / #43, which sources the claim from Client Membership only).

`granted_by` is `ON DELETE SET NULL` so deleting the granter preserves the membership's forensic trail. The `role_id` `RESTRICT` means an Application with assigned-Role memberships cannot be deleted in one shot — admin must clear assignments or revoke memberships first, mirroring the existing "cannot delete an Application with attached Clients" rule in `ApplicationService`.

Closes #41.

## Test plan

- [x] V4 migration runs cleanly on a fresh schema (Testcontainers)
- [x] Service tests cover: grant happy path (`granted_at`, `granted_by` populated), duplicate `(user, app)` rejected, uniqueness enforced at DB level, cross-tenant Application access rejected, granting a User from another Tenant rejected, role assignment within the App, role replacement, role clear, role from another App rejected (both same-tenant and cross-tenant), revoke removes membership + join rows, role assigned to a Membership cannot be deleted (`RESTRICT`), App delete cascades a membership without role assignments, App delete with assigned roles fails `RESTRICT`, User delete cascades the membership, granter delete nullifies `granted_by`, `listGrantableUsers` excludes existing members
- [x] Controller MVC tests cover: list, grant happy path (`granted_by` = current authenticated user), duplicate-grant re-renders form with error, role assignment via edit form, edit form submit with no `roleIds` clears assignments, revoke, cross-tenant URL access force-logged-out by `TenantAccessFilter`, Members link visible on Applications list
- [x] Full suite: 141 tests, 0 failures, 0 errors (up from 116 in slice 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)