### PR TITLE
v2 slice 3: Client Membership UI + schema

### DIFF
--- a/src/main/java/com/stucray/limen/management/clients/ClientManagementController.java
+++ b/src/main/java/com/stucray/limen/management/clients/ClientManagementController.java
@@ -36,7 +36,7 @@ public class ClientManagementController {
         Model model
     ) {
         model.addAttribute("slug", slug);
-        model.addAttribute("application", applicationService.getApplication(appId, principal.tenantId()));
+        model.addAttribute("app", applicationService.getApplication(appId, principal.tenantId()));
         model.addAttribute("clients", clientManagementService.listClients(appId, principal.tenantId()));
         return "manage/clients/list";
     }
@@ -49,7 +49,7 @@ public class ClientManagementController {
         Model model
     ) {
         model.addAttribute("slug", slug);
-        model.addAttribute("application", applicationService.getApplication(appId, principal.tenantId()));
+        model.addAttribute("app", applicationService.getApplication(appId, principal.tenantId()));
         return "manage/clients/new";
     }
 
@@ -101,7 +101,7 @@ public class ClientManagementController {
         Model model
     ) {
         model.addAttribute("slug", slug);
-        model.addAttribute("application", applicationService.getApplication(appId, principal.tenantId()));
+        model.addAttribute("app", applicationService.getApplication(appId, principal.tenantId()));
         model.addAttribute("clientSettings", clientManagementService.getClientWithSettings(registeredClientId, principal.tenantId()));
         return "manage/clients/edit";
     }

--- a/src/main/java/com/stucray/limen/management/memberships/ClientMembersController.java
+++ b/src/main/java/com/stucray/limen/management/memberships/ClientMembersController.java
@@ -1,0 +1,201 @@
+package com.stucray.limen.management.memberships;
+
+import com.stucray.limen.auth.TenantUserDetails;
+import com.stucray.limen.management.applications.Application;
+import com.stucray.limen.management.applications.ApplicationService;
+import com.stucray.limen.management.clients.ClientManagementService;
+import com.stucray.limen.management.clients.TenantClient;
+import com.stucray.limen.management.roles.Role;
+import com.stucray.limen.management.roles.RoleManagementService;
+import com.stucray.limen.user.User;
+import com.stucray.limen.user.UserRepository;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Controller
+@RequestMapping("/manage/t/{slug}/applications/{appId}/clients/{registeredClientId}/members")
+public class ClientMembersController {
+
+    private final ClientMembershipService membershipService;
+    private final ApplicationService applicationService;
+    private final ClientManagementService clientManagementService;
+    private final RoleManagementService roleManagementService;
+    private final UserRepository userRepository;
+
+    public ClientMembersController(
+        ClientMembershipService membershipService,
+        ApplicationService applicationService,
+        ClientManagementService clientManagementService,
+        RoleManagementService roleManagementService,
+        UserRepository userRepository
+    ) {
+        this.membershipService = membershipService;
+        this.applicationService = applicationService;
+        this.clientManagementService = clientManagementService;
+        this.roleManagementService = roleManagementService;
+        this.userRepository = userRepository;
+    }
+
+    @GetMapping
+    public String list(
+        @PathVariable String slug,
+        @PathVariable Long appId,
+        @PathVariable String registeredClientId,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        Model model
+    ) {
+        Application app = applicationService.getApplication(appId, principal.tenantId());
+        TenantClient client = clientManagementService.getClient(registeredClientId, principal.tenantId());
+        List<ClientMembership> memberships = membershipService.listMemberships(registeredClientId, appId, principal.tenantId());
+        List<Role> allRoles = roleManagementService.listRoles(appId, principal.tenantId());
+        model.addAttribute("slug", slug);
+        model.addAttribute("app", app);
+        model.addAttribute("client", client);
+        model.addAttribute("memberships", memberships);
+        model.addAttribute("usernamesById", usernamesByIdFor(memberships));
+        model.addAttribute("roleNamesById", roleNamesByIdFor(allRoles));
+        return "manage/clients/members/list";
+    }
+
+    @GetMapping("/new")
+    public String newForm(
+        @PathVariable String slug,
+        @PathVariable Long appId,
+        @PathVariable String registeredClientId,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        Model model
+    ) {
+        Application app = applicationService.getApplication(appId, principal.tenantId());
+        TenantClient client = clientManagementService.getClient(registeredClientId, principal.tenantId());
+        model.addAttribute("slug", slug);
+        model.addAttribute("app", app);
+        model.addAttribute("client", client);
+        model.addAttribute("grantableUsers",
+            membershipService.listGrantableUsers(registeredClientId, appId, principal.tenantId()));
+        return "manage/clients/members/new";
+    }
+
+    @PostMapping
+    public String create(
+        @PathVariable String slug,
+        @PathVariable Long appId,
+        @PathVariable String registeredClientId,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        @RequestParam Long userId,
+        Model model
+    ) {
+        try {
+            membershipService.grant(registeredClientId, appId, principal.tenantId(), userId, principal.userId());
+            return "redirect:/manage/t/" + slug + "/applications/" + appId + "/clients/" + registeredClientId + "/members";
+        } catch (IllegalArgumentException e) {
+            Application app = applicationService.getApplication(appId, principal.tenantId());
+            TenantClient client = clientManagementService.getClient(registeredClientId, principal.tenantId());
+            model.addAttribute("slug", slug);
+            model.addAttribute("app", app);
+            model.addAttribute("client", client);
+            model.addAttribute("grantableUsers",
+                membershipService.listGrantableUsers(registeredClientId, appId, principal.tenantId()));
+            model.addAttribute("errorMessage", e.getMessage());
+            return "manage/clients/members/new";
+        }
+    }
+
+    @GetMapping("/{membershipId}/edit")
+    public String editForm(
+        @PathVariable String slug,
+        @PathVariable Long appId,
+        @PathVariable String registeredClientId,
+        @PathVariable Long membershipId,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        Model model
+    ) {
+        Application app = applicationService.getApplication(appId, principal.tenantId());
+        TenantClient client = clientManagementService.getClient(registeredClientId, principal.tenantId());
+        ClientMembership membership = membershipService.getMembership(membershipId, registeredClientId, appId, principal.tenantId());
+        List<Role> allRoles = roleManagementService.listRoles(appId, principal.tenantId());
+        User member = userRepository.findById(membership.userId())
+            .orElseThrow(() -> new IllegalStateException("Membership references missing user"));
+        model.addAttribute("slug", slug);
+        model.addAttribute("app", app);
+        model.addAttribute("client", client);
+        model.addAttribute("membership", membership);
+        model.addAttribute("memberUsername", member.username());
+        model.addAttribute("allRoles", allRoles);
+        model.addAttribute("assignedRoleIds", membership.roleIds());
+        return "manage/clients/members/edit";
+    }
+
+    @PostMapping("/{membershipId}/edit")
+    public String update(
+        @PathVariable String slug,
+        @PathVariable Long appId,
+        @PathVariable String registeredClientId,
+        @PathVariable Long membershipId,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        @RequestParam(name = "roleIds", required = false) List<Long> roleIds,
+        Model model
+    ) {
+        try {
+            Set<Long> requested = roleIds == null ? Set.of() : new LinkedHashSet<>(roleIds);
+            membershipService.updateRoles(membershipId, registeredClientId, appId, principal.tenantId(), requested);
+            return "redirect:/manage/t/" + slug + "/applications/" + appId + "/clients/" + registeredClientId + "/members";
+        } catch (IllegalArgumentException e) {
+            Application app = applicationService.getApplication(appId, principal.tenantId());
+            TenantClient client = clientManagementService.getClient(registeredClientId, principal.tenantId());
+            ClientMembership membership = membershipService.getMembership(membershipId, registeredClientId, appId, principal.tenantId());
+            List<Role> allRoles = roleManagementService.listRoles(appId, principal.tenantId());
+            User member = userRepository.findById(membership.userId())
+                .orElseThrow(() -> new IllegalStateException("Membership references missing user"));
+            model.addAttribute("slug", slug);
+            model.addAttribute("app", app);
+            model.addAttribute("client", client);
+            model.addAttribute("membership", membership);
+            model.addAttribute("memberUsername", member.username());
+            model.addAttribute("allRoles", allRoles);
+            model.addAttribute("assignedRoleIds", roleIds == null ? Set.of() : new LinkedHashSet<>(roleIds));
+            model.addAttribute("errorMessage", e.getMessage());
+            return "manage/clients/members/edit";
+        }
+    }
+
+    @PostMapping("/{membershipId}/delete")
+    public String delete(
+        @PathVariable String slug,
+        @PathVariable Long appId,
+        @PathVariable String registeredClientId,
+        @PathVariable Long membershipId,
+        @AuthenticationPrincipal TenantUserDetails principal
+    ) {
+        membershipService.revoke(membershipId, registeredClientId, appId, principal.tenantId());
+        return "redirect:/manage/t/" + slug + "/applications/" + appId + "/clients/" + registeredClientId + "/members";
+    }
+
+    private Map<Long, String> usernamesByIdFor(List<ClientMembership> memberships) {
+        Map<Long, String> map = new LinkedHashMap<>();
+        for (ClientMembership m : memberships) {
+            userRepository.findById(m.userId()).ifPresent(u -> map.put(u.id(), u.username()));
+        }
+        return map;
+    }
+
+    private Map<Long, String> roleNamesByIdFor(List<Role> roles) {
+        Map<Long, String> map = new HashMap<>();
+        for (Role r : roles) {
+            map.put(r.id(), r.name());
+        }
+        return map;
+    }
+}

--- a/src/main/java/com/stucray/limen/management/memberships/ClientMembership.java
+++ b/src/main/java/com/stucray/limen/management/memberships/ClientMembership.java
@@ -1,0 +1,40 @@
+package com.stucray.limen.management.memberships;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.MappedCollection;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+@Table("client_membership")
+public record ClientMembership(
+    @Id Long id,
+    Long userId,
+    Long clientMetadataId,
+    Long applicationMembershipId,
+    LocalDateTime grantedAt,
+    Long grantedBy,
+    @MappedCollection(idColumn = "client_membership_id")
+    Set<ClientMembershipRole> roles
+) {
+    public ClientMembership withRoles(Set<Long> roleIds) {
+        Set<ClientMembershipRole> assignments = new LinkedHashSet<>();
+        for (Long roleId : roleIds) {
+            assignments.add(new ClientMembershipRole(roleId));
+        }
+        return new ClientMembership(
+            id, userId, clientMetadataId, applicationMembershipId,
+            grantedAt, grantedBy, assignments
+        );
+    }
+
+    public Set<Long> roleIds() {
+        Set<Long> ids = new LinkedHashSet<>();
+        for (ClientMembershipRole r : roles) {
+            ids.add(r.roleId());
+        }
+        return ids;
+    }
+}

--- a/src/main/java/com/stucray/limen/management/memberships/ClientMembershipRepository.java
+++ b/src/main/java/com/stucray/limen/management/memberships/ClientMembershipRepository.java
@@ -1,0 +1,12 @@
+package com.stucray.limen.management.memberships;
+
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ClientMembershipRepository extends CrudRepository<ClientMembership, Long> {
+    List<ClientMembership> findAllByClientMetadataId(Long clientMetadataId);
+    Optional<ClientMembership> findByIdAndClientMetadataId(Long id, Long clientMetadataId);
+    boolean existsByUserIdAndClientMetadataId(Long userId, Long clientMetadataId);
+}

--- a/src/main/java/com/stucray/limen/management/memberships/ClientMembershipRole.java
+++ b/src/main/java/com/stucray/limen/management/memberships/ClientMembershipRole.java
@@ -1,0 +1,7 @@
+package com.stucray.limen.management.memberships;
+
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table("client_membership_role")
+public record ClientMembershipRole(Long roleId) {
+}

--- a/src/main/java/com/stucray/limen/management/memberships/ClientMembershipService.java
+++ b/src/main/java/com/stucray/limen/management/memberships/ClientMembershipService.java
@@ -1,0 +1,141 @@
+package com.stucray.limen.management.memberships;
+
+import com.stucray.limen.management.clients.TenantClient;
+import com.stucray.limen.management.clients.TenantClientRepository;
+import com.stucray.limen.management.roles.Role;
+import com.stucray.limen.management.roles.RoleRepository;
+import com.stucray.limen.user.User;
+import com.stucray.limen.user.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Client Memberships are the explicit grant — without a row here a User cannot
+ * complete /oauth2/authorize for a Client (the gate lands in slice 5 / #44).
+ * Tenant isolation is transitive via Client (client_metadata.tenant_id).
+ *
+ * Every public method requires the caller to pass `(registeredClientId,
+ * applicationId, tenantId)`; the Client is fetched first and its parent
+ * Application is asserted to match `applicationId` so that the URL hierarchy
+ * `/applications/{appId}/clients/{registeredClientId}/...` cannot be subverted.
+ *
+ * Eligibility-gate enforcement: grant looks up an existing App Membership for
+ * `(userId, applicationId)` where `applicationId` is the Client's parent App.
+ * If absent, grant fails — there is no path to attach an App Membership from
+ * a different Application, so the cross-table invariant from PRD #39 is
+ * structurally enforced rather than checked after the fact.
+ *
+ * The JWT `roles` claim still emits `[]` after this slice — slice 4 (#43)
+ * sources it from Client Membership rows.
+ */
+@Service
+public class ClientMembershipService {
+
+    private final ClientMembershipRepository membershipRepository;
+    private final ApplicationMembershipRepository applicationMembershipRepository;
+    private final TenantClientRepository tenantClientRepository;
+    private final UserRepository userRepository;
+    private final RoleRepository roleRepository;
+
+    public ClientMembershipService(
+        ClientMembershipRepository membershipRepository,
+        ApplicationMembershipRepository applicationMembershipRepository,
+        TenantClientRepository tenantClientRepository,
+        UserRepository userRepository,
+        RoleRepository roleRepository
+    ) {
+        this.membershipRepository = membershipRepository;
+        this.applicationMembershipRepository = applicationMembershipRepository;
+        this.tenantClientRepository = tenantClientRepository;
+        this.userRepository = userRepository;
+        this.roleRepository = roleRepository;
+    }
+
+    public List<ClientMembership> listMemberships(String registeredClientId, Long applicationId, Long tenantId) {
+        TenantClient client = requireClient(registeredClientId, applicationId, tenantId);
+        return membershipRepository.findAllByClientMetadataId(client.id());
+    }
+
+    public ClientMembership getMembership(Long membershipId, String registeredClientId, Long applicationId, Long tenantId) {
+        TenantClient client = requireClient(registeredClientId, applicationId, tenantId);
+        return membershipRepository.findByIdAndClientMetadataId(membershipId, client.id())
+            .orElseThrow(() -> new IllegalArgumentException("Client membership not found"));
+    }
+
+    public ClientMembership grant(
+        String registeredClientId, Long applicationId, Long tenantId,
+        Long userId, Long grantedByUserId
+    ) {
+        TenantClient client = requireClient(registeredClientId, applicationId, tenantId);
+        User user = userRepository.findByIdAndTenantId(userId, tenantId)
+            .orElseThrow(() -> new IllegalArgumentException("User not found in this tenant"));
+        // Eligibility gate: App Membership for the *Client's parent application*
+        // must already exist. Looking up by applicationId (the Client's parent)
+        // makes it impossible to attach an App Membership from a different App.
+        ApplicationMembership appMembership = applicationMembershipRepository
+            .findByUserIdAndApplicationId(user.id(), applicationId)
+            .orElseThrow(() -> new IllegalArgumentException(
+                "User is not a member of this application; grant Application Membership first"
+            ));
+        if (membershipRepository.existsByUserIdAndClientMetadataId(userId, client.id())) {
+            throw new IllegalArgumentException("User is already a member of this client");
+        }
+        return membershipRepository.save(new ClientMembership(
+            null, userId, client.id(), appMembership.id(),
+            LocalDateTime.now(), grantedByUserId, Set.of()
+        ));
+    }
+
+    public void updateRoles(
+        Long membershipId, String registeredClientId, Long applicationId, Long tenantId,
+        Set<Long> roleIds
+    ) {
+        ClientMembership membership = getMembership(membershipId, registeredClientId, applicationId, tenantId);
+        Set<Long> requested = roleIds == null ? Set.of() : new LinkedHashSet<>(roleIds);
+        for (Long roleId : requested) {
+            Role role = roleRepository.findById(roleId)
+                .orElseThrow(() -> new IllegalArgumentException("Role not found: " + roleId));
+            if (!role.applicationId().equals(applicationId)) {
+                throw new IllegalArgumentException("Role does not belong to this application");
+            }
+        }
+        membershipRepository.save(membership.withRoles(requested));
+    }
+
+    public void revoke(Long membershipId, String registeredClientId, Long applicationId, Long tenantId) {
+        ClientMembership membership = getMembership(membershipId, registeredClientId, applicationId, tenantId);
+        membershipRepository.delete(membership);
+    }
+
+    /**
+     * Users in the tenant who already have an Application Membership for the
+     * Client's parent App but do not yet have a Client Membership for this
+     * specific Client. Drives the "Add Client Member" form's user picker.
+     */
+    public List<User> listGrantableUsers(String registeredClientId, Long applicationId, Long tenantId) {
+        TenantClient client = requireClient(registeredClientId, applicationId, tenantId);
+        List<ApplicationMembership> appMembers = applicationMembershipRepository.findAllByApplicationId(applicationId);
+        List<User> grantable = new ArrayList<>();
+        for (ApplicationMembership am : appMembers) {
+            if (membershipRepository.existsByUserIdAndClientMetadataId(am.userId(), client.id())) continue;
+            userRepository.findById(am.userId()).ifPresent(grantable::add);
+        }
+        return grantable;
+    }
+
+    private TenantClient requireClient(String registeredClientId, Long applicationId, Long tenantId) {
+        TenantClient client = tenantClientRepository.findByRegisteredClientIdAndTenantId(registeredClientId, tenantId)
+            .orElseThrow(() -> new IllegalArgumentException("Client not found"));
+        if (!client.applicationId().equals(applicationId)) {
+            // The URL claims this Client lives under {appId}, but it doesn't.
+            // Treat as not found rather than leaking the real parent.
+            throw new IllegalArgumentException("Client not found");
+        }
+        return client;
+    }
+}

--- a/src/main/resources/db/migration/V5__client_membership.sql
+++ b/src/main/resources/db/migration/V5__client_membership.sql
@@ -1,0 +1,35 @@
+-- v2 slice 3: Client Membership. The explicit grant — Membership is the
+-- authorization grant; without a Client Membership row a User cannot complete
+-- /oauth2/authorize for a Client (gate lands in slice 5 / issue #44).
+-- This slice adds the schema; the JWT customizer still emits roles: [] until
+-- slice 4 (#43) wires the read query.
+--
+-- Tenant isolation is transitive: client_metadata already carries tenant_id,
+-- application_membership.application_id resolves through applications.tenant_id.
+--
+-- Eligibility-gate enforcement (PRD #39 decision 4): client_membership has a
+-- hard FK + ON DELETE CASCADE to application_membership. Revoking an App
+-- Membership atomically revokes every derived Client Membership. user_id is
+-- denormalized for read efficiency (JWT lookup keys on user_id) — service
+-- enforces the consistency invariant cm.user_id == am.user_id at grant time.
+--
+-- The cross-table invariant cm.application_membership.application_id ==
+-- cm.client_metadata.application_id is enforced in the service layer (DB-level
+-- check would need a trigger; integration test enforces it). granted_by is
+-- ON DELETE SET NULL, mirroring application_membership.
+
+CREATE TABLE client_membership (
+    id                        bigserial    PRIMARY KEY,
+    user_id                   bigint       NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    client_metadata_id        bigint       NOT NULL REFERENCES client_metadata(id) ON DELETE CASCADE,
+    application_membership_id bigint       NOT NULL REFERENCES application_membership(id) ON DELETE CASCADE,
+    granted_at                timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    granted_by                bigint       NULL REFERENCES users(id) ON DELETE SET NULL,
+    CONSTRAINT client_membership_user_client_unique UNIQUE (user_id, client_metadata_id)
+);
+
+CREATE TABLE client_membership_role (
+    client_membership_id bigint NOT NULL REFERENCES client_membership(id) ON DELETE CASCADE,
+    role_id              bigint NOT NULL REFERENCES role(id) ON DELETE RESTRICT,
+    PRIMARY KEY (client_membership_id, role_id)
+);

--- a/src/main/resources/templates/manage/clients/edit.html
+++ b/src/main/resources/templates/manage/clients/edit.html
@@ -3,9 +3,10 @@
 <head><title>Edit Client</title></head>
 <body>
 <h1>Edit Client — <span th:text="${clientSettings.tenantClient().displayName()}"></span></h1>
-<a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${application.id()} + '/clients'}">← Clients</a>
+<a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/clients'}">← Clients</a>
+<a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/clients/' + ${clientSettings.tenantClient().registeredClientId()} + '/members'}">Members</a>
 
-<form method="post" th:action="@{'/manage/t/' + ${slug} + '/applications/' + ${application.id()} + '/clients/' + ${clientSettings.tenantClient().registeredClientId()} + '/edit'}">
+<form method="post" th:action="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/clients/' + ${clientSettings.tenantClient().registeredClientId()} + '/edit'}">
     <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
 
     <fieldset>

--- a/src/main/resources/templates/manage/clients/list.html
+++ b/src/main/resources/templates/manage/clients/list.html
@@ -2,9 +2,9 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head><title>Clients</title></head>
 <body>
-<h1>Clients — <span th:text="${application.name()}"></span></h1>
+<h1>Clients — <span th:text="${app.name()}"></span></h1>
 <a th:href="@{'/manage/t/' + ${slug} + '/applications'}">← Applications</a>
-<a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${application.id()} + '/clients/new'}">New client</a>
+<a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/clients/new'}">New client</a>
 
 <div th:if="${clientSecret}">
     <strong>Client secret (shown once):</strong> <code th:text="${clientSecret}"></code><br/>
@@ -20,12 +20,13 @@
             <td th:text="${client.displayName()}"></td>
             <td th:text="${client.confidential() ? 'Confidential' : 'Public'}"></td>
             <td>
-                <a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${application.id()} + '/clients/' + ${client.registeredClientId()} + '/edit'}">Edit</a>
-                <form method="post" th:action="@{'/manage/t/' + ${slug} + '/applications/' + ${application.id()} + '/clients/' + ${client.registeredClientId()} + '/rotate-secret'}" style="display:inline" th:if="${client.confidential()}">
+                <a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/clients/' + ${client.registeredClientId()} + '/edit'}">Edit</a>
+                <a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/clients/' + ${client.registeredClientId()} + '/members'}">Members</a>
+                <form method="post" th:action="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/clients/' + ${client.registeredClientId()} + '/rotate-secret'}" style="display:inline" th:if="${client.confidential()}">
                     <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                     <button type="submit">Rotate secret</button>
                 </form>
-                <form method="post" th:action="@{'/manage/t/' + ${slug} + '/applications/' + ${application.id()} + '/clients/' + ${client.registeredClientId()} + '/delete'}" style="display:inline">
+                <form method="post" th:action="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/clients/' + ${client.registeredClientId()} + '/delete'}" style="display:inline">
                     <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                     <button type="submit" onclick="return confirm('Delete this client?')">Delete</button>
                 </form>

--- a/src/main/resources/templates/manage/clients/members/edit.html
+++ b/src/main/resources/templates/manage/clients/members/edit.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head><title>Edit Client Member Roles</title></head>
+<body>
+<h1>Client member roles — <span th:text="${memberUsername}"></span> on <span th:text="${client.displayName()}"></span></h1>
+<a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/clients/' + ${client.registeredClientId()} + '/members'}">← Members</a>
+
+<div th:if="${errorMessage}" th:text="${errorMessage}"></div>
+
+<form method="post"
+      th:action="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/clients/' + ${client.registeredClientId()} + '/members/' + ${membership.id()} + '/edit'}">
+    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+    <fieldset>
+        <legend>Roles</legend>
+        <p th:if="${allRoles.isEmpty()}">No roles defined for this application yet.</p>
+        <div th:each="role : ${allRoles}">
+            <label>
+                <input type="checkbox" name="roleIds" th:value="${role.id()}"
+                       th:checked="${assignedRoleIds.contains(role.id())}"/>
+                <span th:text="${role.name()}"></span>
+            </label>
+        </div>
+    </fieldset>
+    <button type="submit">Save</button>
+</form>
+</body>
+</html>

--- a/src/main/resources/templates/manage/clients/members/list.html
+++ b/src/main/resources/templates/manage/clients/members/list.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head><title>Client Members</title></head>
+<body>
+<h1>Members — <span th:text="${client.displayName()}"></span> <small>on <span th:text="${app.name()}"></span></small></h1>
+<a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/clients'}">← Clients</a>
+<a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/clients/' + ${client.registeredClientId()} + '/members/new'}">Add member</a>
+
+<div th:if="${errorMessage}" th:text="${errorMessage}"></div>
+
+<table>
+    <thead>
+        <tr><th>User</th><th>Roles</th><th>Granted at</th><th>Actions</th></tr>
+    </thead>
+    <tbody>
+        <tr th:each="m : ${memberships}">
+            <td th:text="${usernamesById.get(m.userId())}"></td>
+            <td>
+                <span th:each="rid, it : ${m.roleIds()}">
+                    <span th:text="${roleNamesById.get(rid)}"></span><span th:if="${!it.last}">, </span>
+                </span>
+            </td>
+            <td th:text="${m.grantedAt()}"></td>
+            <td>
+                <a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/clients/' + ${client.registeredClientId()} + '/members/' + ${m.id()} + '/edit'}">Edit roles</a>
+                <form method="post" th:action="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/clients/' + ${client.registeredClientId()} + '/members/' + ${m.id()} + '/delete'}" style="display:inline">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                    <button type="submit" onclick="return confirm('Revoke this client membership?')">Revoke</button>
+                </form>
+            </td>
+        </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/src/main/resources/templates/manage/clients/members/new.html
+++ b/src/main/resources/templates/manage/clients/members/new.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head><title>Add Client Member</title></head>
+<body>
+<h1>Add Member — <span th:text="${client.displayName()}"></span> <small>on <span th:text="${app.name()}"></span></small></h1>
+<a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/clients/' + ${client.registeredClientId()} + '/members'}">← Members</a>
+
+<div th:if="${errorMessage}" th:text="${errorMessage}"></div>
+
+<form th:if="${!grantableUsers.isEmpty()}" method="post"
+      th:action="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/clients/' + ${client.registeredClientId()} + '/members'}">
+    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+    <div>
+        <label>User
+            <select name="userId" required>
+                <option th:each="u : ${grantableUsers}" th:value="${u.id()}" th:text="${u.username()}"></option>
+            </select>
+        </label>
+    </div>
+    <button type="submit">Grant client membership</button>
+</form>
+<p th:if="${grantableUsers.isEmpty()}">No eligible users. Application Membership for this app is required first; once granted, users will appear here.</p>
+</body>
+</html>

--- a/src/main/resources/templates/manage/clients/new.html
+++ b/src/main/resources/templates/manage/clients/new.html
@@ -2,10 +2,10 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head><title>New Client</title></head>
 <body>
-<h1>New Client — <span th:text="${application.name()}"></span></h1>
-<a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${application.id()} + '/clients'}">← Clients</a>
+<h1>New Client — <span th:text="${app.name()}"></span></h1>
+<a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/clients'}">← Clients</a>
 
-<form method="post" th:action="@{'/manage/t/' + ${slug} + '/applications/' + ${application.id()} + '/clients'}">
+<form method="post" th:action="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/clients'}">
     <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
 
     <div><label>Name <input type="text" name="displayName" autofocus required/></label></div>

--- a/src/test/java/com/stucray/limen/management/memberships/ApplicationMembershipServiceIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/memberships/ApplicationMembershipServiceIntegrationTest.java
@@ -47,6 +47,10 @@ class ApplicationMembershipServiceIntegrationTest {
 
     @BeforeEach
     void setUp() {
+        // client_membership rows (from ClientMembership tests) FK back into
+        // application_membership and role; clear them first so the existing
+        // DELETEs below don't trip ON DELETE RESTRICT on role.
+        jdbcTemplate.execute("DELETE FROM client_membership");
         jdbcTemplate.execute("DELETE FROM application_membership_role");
         jdbcTemplate.execute("DELETE FROM application_membership");
         jdbcTemplate.execute("DELETE FROM role");

--- a/src/test/java/com/stucray/limen/management/memberships/ClientMembersControllerIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/memberships/ClientMembersControllerIntegrationTest.java
@@ -3,6 +3,8 @@ package com.stucray.limen.management.memberships;
 import com.stucray.limen.TestcontainersConfiguration;
 import com.stucray.limen.management.applications.Application;
 import com.stucray.limen.management.applications.ApplicationRepository;
+import com.stucray.limen.management.clients.ClientManagementService;
+import com.stucray.limen.management.clients.TenantClient;
 import com.stucray.limen.management.roles.Role;
 import com.stucray.limen.management.roles.RoleRepository;
 import com.stucray.limen.tenant.Tenant;
@@ -19,10 +21,12 @@ import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 import java.time.LocalDateTime;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -35,14 +39,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
 @AutoConfigureMockMvc
-class MembersControllerIntegrationTest {
+class ClientMembersControllerIntegrationTest {
 
     @Autowired MockMvc mockMvc;
     @Autowired TenantRepository tenantRepository;
     @Autowired UserRepository userRepository;
     @Autowired ApplicationRepository applicationRepository;
     @Autowired RoleRepository roleRepository;
-    @Autowired ApplicationMembershipRepository membershipRepository;
+    @Autowired ApplicationMembershipRepository appMembershipRepository;
+    @Autowired ClientMembershipRepository clientMembershipRepository;
+    @Autowired ClientManagementService clientManagementService;
     @Autowired PasswordEncoder passwordEncoder;
     @Autowired JdbcTemplate jdbcTemplate;
 
@@ -51,13 +57,11 @@ class MembersControllerIntegrationTest {
     Application appA;
     User ownerA;
     User aliceA;
+    TenantClient clientA;
     MockHttpSession sessionA;
 
     @BeforeEach
     void setUp() throws Exception {
-        // client_membership rows (from ClientMembership tests) FK back into
-        // application_membership and role; clear them first so the existing
-        // DELETEs below don't trip ON DELETE RESTRICT on role.
         jdbcTemplate.execute("DELETE FROM client_membership");
         jdbcTemplate.execute("DELETE FROM application_membership_role");
         jdbcTemplate.execute("DELETE FROM application_membership");
@@ -67,126 +71,146 @@ class MembersControllerIntegrationTest {
         jdbcTemplate.execute("DELETE FROM users WHERE tenant_id IN (SELECT id FROM tenants WHERE slug != 'system')");
         jdbcTemplate.execute("DELETE FROM tenants WHERE slug != 'system'");
 
-        tenantA = tenantRepository.save(new Tenant(null, "members-corp-a", "Members Corp A", TenantStatus.ACTIVE, LocalDateTime.now()));
-        tenantB = tenantRepository.save(new Tenant(null, "members-corp-b", "Members Corp B", TenantStatus.ACTIVE, LocalDateTime.now()));
-        ownerA = userRepository.save(new User(null, tenantA.id(), "owner", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        tenantA = tenantRepository.save(new Tenant(null, "client-mem-a", "Client Mem A", TenantStatus.ACTIVE, LocalDateTime.now()));
+        tenantB = tenantRepository.save(new Tenant(null, "client-mem-b", "Client Mem B", TenantStatus.ACTIVE, LocalDateTime.now()));
+        ownerA = userRepository.save(new User(null, tenantA.id(), "owner", passwordEncoder.encode("pass"), true, false, true,  LocalDateTime.now()));
         aliceA = userRepository.save(new User(null, tenantA.id(), "alice", passwordEncoder.encode("pass"), true, false, false, LocalDateTime.now()));
         appA = applicationRepository.save(new Application(null, tenantA.id(), "App A", "desc", LocalDateTime.now()));
+        clientA = clientManagementService.createClient(
+            appA.id(), tenantA.id(), "client-a",
+            Set.of(AuthorizationGrantType.AUTHORIZATION_CODE),
+            Set.of("http://localhost/callback"), Set.of(), Set.of("openid"),
+            false, true, 5, 30, false
+        ).client();
 
-        MvcResult login = mockMvc.perform(post("/manage/t/members-corp-a/login")
+        MvcResult login = mockMvc.perform(post("/manage/t/client-mem-a/login")
                 .param("username", "owner").param("password", "pass").with(csrf()))
             .andReturn();
         sessionA = (MockHttpSession) login.getRequest().getSession(false);
     }
 
+    private String url(String suffix) {
+        return "/manage/t/client-mem-a/applications/" + appA.id() + "/clients/" + clientA.registeredClientId() + suffix;
+    }
+
     @Test
-    void ownerCanListMembers() throws Exception {
-        membershipRepository.save(new ApplicationMembership(
-            null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), java.util.Set.of()
+    void ownerCanListClientMembers() throws Exception {
+        ApplicationMembership am = appMembershipRepository.save(new ApplicationMembership(
+            null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), Set.of()
+        ));
+        clientMembershipRepository.save(new ClientMembership(
+            null, aliceA.id(), clientA.id(), am.id(), LocalDateTime.now(), ownerA.id(), Set.of()
         ));
 
-        mockMvc.perform(get("/manage/t/members-corp-a/applications/" + appA.id() + "/members").session(sessionA))
+        mockMvc.perform(get(url("/members")).session(sessionA))
             .andExpect(status().isOk())
             .andExpect(content().string(org.hamcrest.Matchers.containsString("alice")));
     }
 
     @Test
-    void ownerCanGrantMembership() throws Exception {
-        mockMvc.perform(post("/manage/t/members-corp-a/applications/" + appA.id() + "/members")
+    void ownerCanGrantClientMembership() throws Exception {
+        appMembershipRepository.save(new ApplicationMembership(
+            null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), Set.of()
+        ));
+
+        mockMvc.perform(post(url("/members"))
                 .session(sessionA).with(csrf())
                 .param("userId", aliceA.id().toString()))
             .andExpect(status().is3xxRedirection())
-            .andExpect(redirectedUrl("/manage/t/members-corp-a/applications/" + appA.id() + "/members"));
+            .andExpect(redirectedUrl(url("/members")));
 
-        var memberships = membershipRepository.findAllByApplicationId(appA.id());
+        var memberships = clientMembershipRepository.findAllByClientMetadataId(clientA.id());
         assertThat(memberships).hasSize(1);
-        ApplicationMembership saved = memberships.get(0);
+        ClientMembership saved = memberships.get(0);
         assertThat(saved.userId()).isEqualTo(aliceA.id());
-        // granted_by should be the authenticated owner.
         assertThat(saved.grantedBy()).isEqualTo(ownerA.id());
         assertThat(saved.grantedAt()).isNotNull();
     }
 
     @Test
-    void duplicateGrantRedisplaysFormWithError() throws Exception {
-        membershipRepository.save(new ApplicationMembership(
-            null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), java.util.Set.of()
-        ));
-
-        mockMvc.perform(post("/manage/t/members-corp-a/applications/" + appA.id() + "/members")
+    void grantWithoutAppMembershipRedisplaysFormWithError() throws Exception {
+        // alice has no App Membership for appA, so the eligibility gate fires.
+        mockMvc.perform(post(url("/members"))
                 .session(sessionA).with(csrf())
                 .param("userId", aliceA.id().toString()))
             .andExpect(status().isOk())
-            .andExpect(content().string(org.hamcrest.Matchers.containsString("already a member")));
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("not a member of this application")));
     }
 
     @Test
     void ownerCanAssignRolesViaEditForm() throws Exception {
-        ApplicationMembership m = membershipRepository.save(new ApplicationMembership(
-            null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), java.util.Set.of()
+        ApplicationMembership am = appMembershipRepository.save(new ApplicationMembership(
+            null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), Set.of()
+        ));
+        ClientMembership cm = clientMembershipRepository.save(new ClientMembership(
+            null, aliceA.id(), clientA.id(), am.id(), LocalDateTime.now(), ownerA.id(), Set.of()
         ));
         Role viewer = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
         Role editor = roleRepository.save(new Role(null, appA.id(), "editor", null, LocalDateTime.now()));
 
-        mockMvc.perform(post("/manage/t/members-corp-a/applications/" + appA.id() + "/members/" + m.id() + "/edit")
+        mockMvc.perform(post(url("/members/" + cm.id() + "/edit"))
                 .session(sessionA).with(csrf())
                 .param("roleIds", viewer.id().toString())
                 .param("roleIds", editor.id().toString()))
             .andExpect(status().is3xxRedirection());
 
-        ApplicationMembership reloaded = membershipRepository.findById(m.id()).orElseThrow();
+        ClientMembership reloaded = clientMembershipRepository.findById(cm.id()).orElseThrow();
         assertThat(reloaded.roleIds()).containsExactlyInAnyOrder(viewer.id(), editor.id());
     }
 
     @Test
     void editFormSubmitWithNoRoleIdsClearsAssignments() throws Exception {
+        ApplicationMembership am = appMembershipRepository.save(new ApplicationMembership(
+            null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), Set.of()
+        ));
         Role viewer = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
-        ApplicationMembership m = membershipRepository.save(new ApplicationMembership(
-            null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(),
-            java.util.Set.of(new ApplicationMembershipRole(viewer.id()))
+        ClientMembership cm = clientMembershipRepository.save(new ClientMembership(
+            null, aliceA.id(), clientA.id(), am.id(), LocalDateTime.now(), ownerA.id(),
+            Set.of(new ClientMembershipRole(viewer.id()))
         ));
 
-        mockMvc.perform(post("/manage/t/members-corp-a/applications/" + appA.id() + "/members/" + m.id() + "/edit")
+        mockMvc.perform(post(url("/members/" + cm.id() + "/edit"))
                 .session(sessionA).with(csrf()))
             .andExpect(status().is3xxRedirection());
 
-        assertThat(membershipRepository.findById(m.id()).orElseThrow().roleIds()).isEmpty();
+        assertThat(clientMembershipRepository.findById(cm.id()).orElseThrow().roleIds()).isEmpty();
     }
 
     @Test
-    void ownerCanRevokeMembership() throws Exception {
-        ApplicationMembership m = membershipRepository.save(new ApplicationMembership(
-            null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), java.util.Set.of()
+    void ownerCanRevokeClientMembership() throws Exception {
+        ApplicationMembership am = appMembershipRepository.save(new ApplicationMembership(
+            null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), Set.of()
+        ));
+        ClientMembership cm = clientMembershipRepository.save(new ClientMembership(
+            null, aliceA.id(), clientA.id(), am.id(), LocalDateTime.now(), ownerA.id(), Set.of()
         ));
 
-        mockMvc.perform(post("/manage/t/members-corp-a/applications/" + appA.id() + "/members/" + m.id() + "/delete")
+        mockMvc.perform(post(url("/members/" + cm.id() + "/delete"))
                 .session(sessionA).with(csrf()))
             .andExpect(status().is3xxRedirection());
 
-        assertThat(membershipRepository.findById(m.id())).isEmpty();
+        assertThat(clientMembershipRepository.findById(cm.id())).isEmpty();
     }
 
     @Test
-    void tenantBSessionCannotReachTenantAMembers() throws Exception {
+    void tenantBSessionCannotReachTenantAClientMembers() throws Exception {
         userRepository.save(new User(null, tenantB.id(), "ownerB", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
-        MvcResult loginB = mockMvc.perform(post("/manage/t/members-corp-b/login")
+        MvcResult loginB = mockMvc.perform(post("/manage/t/client-mem-b/login")
                 .param("username", "ownerB").param("password", "pass").with(csrf()))
             .andReturn();
         MockHttpSession sessionB = (MockHttpSession) loginB.getRequest().getSession(false);
 
-        // TenantAccessFilter force-logs out the cross-tenant session and
-        // redirects to the URL slug's login page.
-        mockMvc.perform(get("/manage/t/members-corp-a/applications/" + appA.id() + "/members").session(sessionB))
+        mockMvc.perform(get(url("/members")).session(sessionB))
             .andExpect(status().is3xxRedirection())
-            .andExpect(redirectedUrl("/manage/t/members-corp-a/login"));
+            .andExpect(redirectedUrl("/manage/t/client-mem-a/login"));
     }
 
     @Test
-    void membersLinkAppearsOnApplicationsList() throws Exception {
-        mockMvc.perform(get("/manage/t/members-corp-a/applications").session(sessionA))
+    void clientMembersLinkAppearsOnClientsList() throws Exception {
+        mockMvc.perform(get("/manage/t/client-mem-a/applications/" + appA.id() + "/clients").session(sessionA))
             .andExpect(status().isOk())
             .andExpect(content().string(org.hamcrest.Matchers.containsString(
-                "/manage/t/members-corp-a/applications/" + appA.id() + "/members"
+                url("/members")
             )));
     }
 }

--- a/src/test/java/com/stucray/limen/management/memberships/ClientMembershipServiceIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/memberships/ClientMembershipServiceIntegrationTest.java
@@ -1,0 +1,319 @@
+package com.stucray.limen.management.memberships;
+
+import com.stucray.limen.TestcontainersConfiguration;
+import com.stucray.limen.management.applications.Application;
+import com.stucray.limen.management.applications.ApplicationRepository;
+import com.stucray.limen.management.clients.ClientManagementService;
+import com.stucray.limen.management.clients.TenantClient;
+import com.stucray.limen.management.clients.TenantClientRepository;
+import com.stucray.limen.management.roles.Role;
+import com.stucray.limen.management.roles.RoleRepository;
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.tenant.TenantStatus;
+import com.stucray.limen.user.User;
+import com.stucray.limen.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest
+class ClientMembershipServiceIntegrationTest {
+
+    @Autowired ClientMembershipService clientMembershipService;
+    @Autowired ClientMembershipRepository clientMembershipRepository;
+    @Autowired ApplicationMembershipService applicationMembershipService;
+    @Autowired ApplicationMembershipRepository applicationMembershipRepository;
+    @Autowired ApplicationRepository applicationRepository;
+    @Autowired ClientManagementService clientManagementService;
+    @Autowired TenantClientRepository tenantClientRepository;
+    @Autowired RoleRepository roleRepository;
+    @Autowired TenantRepository tenantRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    Tenant tenantA;
+    Tenant tenantB;
+    Application appA;
+    Application appA2;       // same tenant, different app — used for cross-app checks
+    Application appB;        // foreign tenant — used for cross-tenant checks
+    TenantClient clientA;    // child of appA in tenantA
+    TenantClient clientA2;   // child of appA2 in tenantA
+    TenantClient clientB;    // child of appB in tenantB
+    User aliceA;
+    User bobA;
+    User adminA;
+    User carolB;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.execute("DELETE FROM client_membership");
+        jdbcTemplate.execute("DELETE FROM application_membership_role");
+        jdbcTemplate.execute("DELETE FROM application_membership");
+        jdbcTemplate.execute("DELETE FROM role");
+        jdbcTemplate.execute("DELETE FROM oauth2_registered_client WHERE application_id IS NOT NULL");
+        jdbcTemplate.execute("DELETE FROM applications");
+        jdbcTemplate.execute("DELETE FROM users WHERE tenant_id IN (SELECT id FROM tenants WHERE slug IN ('cm-a', 'cm-b'))");
+        jdbcTemplate.execute("DELETE FROM tenants WHERE slug IN ('cm-a', 'cm-b')");
+
+        tenantA = tenantRepository.save(new Tenant(null, "cm-a", "CM A", TenantStatus.ACTIVE, LocalDateTime.now()));
+        tenantB = tenantRepository.save(new Tenant(null, "cm-b", "CM B", TenantStatus.ACTIVE, LocalDateTime.now()));
+        appA  = applicationRepository.save(new Application(null, tenantA.id(), "App A",  null, LocalDateTime.now()));
+        appA2 = applicationRepository.save(new Application(null, tenantA.id(), "App A2", null, LocalDateTime.now()));
+        appB  = applicationRepository.save(new Application(null, tenantB.id(), "App B",  null, LocalDateTime.now()));
+        aliceA = userRepository.save(new User(null, tenantA.id(), "alice", "x", true, false, false, LocalDateTime.now()));
+        bobA   = userRepository.save(new User(null, tenantA.id(), "bob",   "x", true, false, false, LocalDateTime.now()));
+        adminA = userRepository.save(new User(null, tenantA.id(), "admin", "x", true, false, true,  LocalDateTime.now()));
+        carolB = userRepository.save(new User(null, tenantB.id(), "carol", "x", true, false, false, LocalDateTime.now()));
+
+        clientA  = createClient(appA.id(),  tenantA.id(), "client-a");
+        clientA2 = createClient(appA2.id(), tenantA.id(), "client-a2");
+        clientB  = createClient(appB.id(),  tenantB.id(), "client-b");
+    }
+
+    private TenantClient createClient(Long applicationId, Long tenantId, String name) {
+        ClientManagementService.ClientCreationResult result = clientManagementService.createClient(
+            applicationId, tenantId, name,
+            Set.of(AuthorizationGrantType.AUTHORIZATION_CODE),
+            Set.of("http://localhost/callback"), Set.of(), Set.of("openid"),
+            false, true, 5, 30, false
+        );
+        return result.client();
+    }
+
+    @Test
+    void grantStoresRowWithGrantedAtGrantedByAndAppMembershipFk() {
+        ApplicationMembership am = applicationMembershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+
+        ClientMembership cm = clientMembershipService.grant(
+            clientA.registeredClientId(), appA.id(), tenantA.id(), aliceA.id(), adminA.id()
+        );
+
+        assertThat(cm.id()).isNotNull();
+        assertThat(cm.userId()).isEqualTo(aliceA.id());
+        assertThat(cm.clientMetadataId()).isEqualTo(clientA.id());
+        assertThat(cm.applicationMembershipId()).isEqualTo(am.id());
+        assertThat(cm.grantedAt()).isNotNull();
+        assertThat(cm.grantedBy()).isEqualTo(adminA.id());
+        assertThat(cm.roleIds()).isEmpty();
+    }
+
+    @Test
+    void grantRequiresExistingApplicationMembership() {
+        // alice has no App Membership for appA.
+        assertThatThrownBy(() -> clientMembershipService.grant(
+            clientA.registeredClientId(), appA.id(), tenantA.id(), aliceA.id(), adminA.id()
+        )).isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("not a member of this application");
+    }
+
+    @Test
+    void grantRejectedIfUserOnlyHasAppMembershipForDifferentApp() {
+        // Cross-table invariant: alice has App Membership for appA only, but
+        // tries to be granted Client Membership on a Client of appA2. The
+        // service looks up App Membership for (alice, appA2) — finds none,
+        // rejects. There is no service-call shape that could attach alice's
+        // appA membership to a Client of appA2.
+        applicationMembershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+
+        assertThatThrownBy(() -> clientMembershipService.grant(
+            clientA2.registeredClientId(), appA2.id(), tenantA.id(), aliceA.id(), adminA.id()
+        )).isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("not a member of this application");
+    }
+
+    @Test
+    void duplicateUserClientRejected() {
+        applicationMembershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+        clientMembershipService.grant(clientA.registeredClientId(), appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+
+        assertThatThrownBy(() -> clientMembershipService.grant(
+            clientA.registeredClientId(), appA.id(), tenantA.id(), aliceA.id(), adminA.id()
+        )).isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("already a member");
+    }
+
+    @Test
+    void crossTenantClientAccessRejected() {
+        // Caller claims tenantA but clientB belongs to tenantB.
+        assertThatThrownBy(() -> clientMembershipService.listMemberships(clientB.registeredClientId(), appA.id(), tenantA.id()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Client not found");
+
+        assertThatThrownBy(() -> clientMembershipService.grant(
+            clientB.registeredClientId(), appA.id(), tenantA.id(), aliceA.id(), adminA.id()
+        )).isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Client not found");
+    }
+
+    @Test
+    void mismatchedClientApplicationPathRejected() {
+        // URL claims clientA2 (which belongs to appA2) hangs off appA. Reject
+        // even within the same tenant — the URL hierarchy must be honest.
+        assertThatThrownBy(() -> clientMembershipService.listMemberships(clientA2.registeredClientId(), appA.id(), tenantA.id()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Client not found");
+    }
+
+    @Test
+    void grantingUserFromAnotherTenantRejected() {
+        applicationMembershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+
+        assertThatThrownBy(() -> clientMembershipService.grant(
+            clientA.registeredClientId(), appA.id(), tenantA.id(), carolB.id(), adminA.id()
+        )).isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("User not found");
+    }
+
+    @Test
+    void uniqueConstraintHonouredAtRepositoryLevel() {
+        applicationMembershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+        ApplicationMembership am = applicationMembershipRepository.findByUserIdAndApplicationId(aliceA.id(), appA.id()).orElseThrow();
+        clientMembershipService.grant(clientA.registeredClientId(), appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+
+        assertThatThrownBy(() -> clientMembershipRepository.save(new ClientMembership(
+            null, aliceA.id(), clientA.id(), am.id(), LocalDateTime.now(), adminA.id(), Set.of()
+        ))).isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void updateRolesAssignsSet() {
+        applicationMembershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+        ClientMembership cm = clientMembershipService.grant(clientA.registeredClientId(), appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+        Role viewer = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
+        Role editor = roleRepository.save(new Role(null, appA.id(), "editor", null, LocalDateTime.now()));
+
+        clientMembershipService.updateRoles(cm.id(), clientA.registeredClientId(), appA.id(), tenantA.id(), Set.of(viewer.id(), editor.id()));
+
+        ClientMembership reloaded = clientMembershipService.getMembership(cm.id(), clientA.registeredClientId(), appA.id(), tenantA.id());
+        assertThat(reloaded.roleIds()).containsExactlyInAnyOrder(viewer.id(), editor.id());
+    }
+
+    @Test
+    void updateRolesEmptyClearsSet() {
+        applicationMembershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+        ClientMembership cm = clientMembershipService.grant(clientA.registeredClientId(), appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+        Role viewer = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
+        clientMembershipService.updateRoles(cm.id(), clientA.registeredClientId(), appA.id(), tenantA.id(), Set.of(viewer.id()));
+
+        clientMembershipService.updateRoles(cm.id(), clientA.registeredClientId(), appA.id(), tenantA.id(), Set.of());
+
+        assertThat(clientMembershipService.getMembership(cm.id(), clientA.registeredClientId(), appA.id(), tenantA.id())
+            .roleIds()).isEmpty();
+    }
+
+    @Test
+    void cannotAssignRoleFromAnotherApplication() {
+        applicationMembershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+        ClientMembership cm = clientMembershipService.grant(clientA.registeredClientId(), appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+        // Role belongs to appA2 (same tenant, different app) — must be rejected.
+        Role foreign = roleRepository.save(new Role(null, appA2.id(), "viewer", null, LocalDateTime.now()));
+
+        assertThatThrownBy(() -> clientMembershipService.updateRoles(
+            cm.id(), clientA.registeredClientId(), appA.id(), tenantA.id(), Set.of(foreign.id())
+        )).isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("does not belong to this application");
+    }
+
+    @Test
+    void revokeRemovesRowAndRoleAssignments() {
+        Role viewer = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
+        applicationMembershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+        ClientMembership cm = clientMembershipService.grant(clientA.registeredClientId(), appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+        clientMembershipService.updateRoles(cm.id(), clientA.registeredClientId(), appA.id(), tenantA.id(), Set.of(viewer.id()));
+
+        clientMembershipService.revoke(cm.id(), clientA.registeredClientId(), appA.id(), tenantA.id());
+
+        assertThat(clientMembershipRepository.findById(cm.id())).isEmpty();
+        Integer joinCount = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM client_membership_role WHERE client_membership_id = ?",
+            Integer.class, cm.id()
+        );
+        assertThat(joinCount).isZero();
+        assertThat(roleRepository.findById(viewer.id())).isPresent();
+    }
+
+    @Test
+    void roleAssignedToClientMembershipCannotBeDeleted() {
+        Role viewer = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
+        applicationMembershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+        ClientMembership cm = clientMembershipService.grant(clientA.registeredClientId(), appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+        clientMembershipService.updateRoles(cm.id(), clientA.registeredClientId(), appA.id(), tenantA.id(), Set.of(viewer.id()));
+
+        assertThatThrownBy(() -> roleRepository.delete(viewer))
+            .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void revokingApplicationMembershipCascadesClientMemberships() {
+        // PRD #39 decision 4: hard FK + CASCADE from client_membership.application_membership_id
+        // means revoking App Membership atomically revokes all derived Client Memberships.
+        applicationMembershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+        ApplicationMembership am = applicationMembershipRepository
+            .findByUserIdAndApplicationId(aliceA.id(), appA.id()).orElseThrow();
+        ClientMembership cm = clientMembershipService.grant(clientA.registeredClientId(), appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+
+        applicationMembershipService.revoke(am.id(), appA.id(), tenantA.id());
+
+        assertThat(clientMembershipRepository.findById(cm.id())).isEmpty();
+        assertThat(clientMembershipRepository.findAllByClientMetadataId(clientA.id())).isEmpty();
+    }
+
+    @Test
+    void deletingClientCascadesClientMembership() {
+        applicationMembershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+        ClientMembership cm = clientMembershipService.grant(clientA.registeredClientId(), appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+
+        clientManagementService.deleteClient(clientA.registeredClientId(), tenantA.id());
+
+        assertThat(clientMembershipRepository.findById(cm.id())).isEmpty();
+    }
+
+    @Test
+    void deletingUserCascadesClientMembership() {
+        applicationMembershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+        clientMembershipService.grant(clientA.registeredClientId(), appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+
+        userRepository.delete(aliceA);
+
+        assertThat(clientMembershipRepository.findAllByClientMetadataId(clientA.id())).isEmpty();
+    }
+
+    @Test
+    void deletingGranterNullifiesGrantedBy() {
+        applicationMembershipService.grant(appA.id(), tenantA.id(), bobA.id(), adminA.id());
+        ClientMembership cm = clientMembershipService.grant(
+            clientA.registeredClientId(), appA.id(), tenantA.id(), bobA.id(), adminA.id()
+        );
+
+        userRepository.delete(adminA);
+
+        ClientMembership reloaded = clientMembershipRepository.findById(cm.id()).orElseThrow();
+        assertThat(reloaded.grantedBy()).isNull();
+    }
+
+    @Test
+    void listGrantableUsersOnlyIncludesAppMembersWithoutClientMembership() {
+        // alice & bob both have App Membership for appA; alice already has Client Membership.
+        applicationMembershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+        applicationMembershipService.grant(appA.id(), tenantA.id(), bobA.id(),   adminA.id());
+        clientMembershipService.grant(clientA.registeredClientId(), appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+
+        var grantable = clientMembershipService.listGrantableUsers(clientA.registeredClientId(), appA.id(), tenantA.id());
+
+        // admin has no App Membership → not eligible. alice has Client Membership → not eligible.
+        assertThat(grantable).extracting(User::username).containsExactly("bob");
+    }
+}

--- a/src/test/java/com/stucray/limen/management/roles/RoleManagementServiceIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/roles/RoleManagementServiceIntegrationTest.java
@@ -35,6 +35,11 @@ class RoleManagementServiceIntegrationTest {
 
     @BeforeEach
     void setUp() {
+        // Clear any membership-role assignments from membership tests so the
+        // role delete below is not blocked by ON DELETE RESTRICT.
+        jdbcTemplate.execute("DELETE FROM client_membership");
+        jdbcTemplate.execute("DELETE FROM application_membership_role");
+        jdbcTemplate.execute("DELETE FROM application_membership");
         jdbcTemplate.execute("DELETE FROM role");
         jdbcTemplate.execute("DELETE FROM applications");
         jdbcTemplate.execute("DELETE FROM tenants WHERE slug IN ('roles-a', 'roles-b')");

--- a/src/test/java/com/stucray/limen/management/roles/RolesControllerIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/roles/RolesControllerIntegrationTest.java
@@ -47,6 +47,11 @@ class RolesControllerIntegrationTest {
 
     @BeforeEach
     void setUp() throws Exception {
+        // Clear any membership-role assignments from membership tests so the
+        // role delete below is not blocked by ON DELETE RESTRICT.
+        jdbcTemplate.execute("DELETE FROM client_membership");
+        jdbcTemplate.execute("DELETE FROM application_membership_role");
+        jdbcTemplate.execute("DELETE FROM application_membership");
         jdbcTemplate.execute("DELETE FROM role");
         jdbcTemplate.execute("DELETE FROM oauth2_registered_client WHERE application_id IS NOT NULL");
         jdbcTemplate.execute("DELETE FROM applications");


### PR DESCRIPTION
## Summary

Closes #42 — adds Client Membership, the explicit grant from PRD #39. The JWT `roles` claim and the `/oauth2/authorize` gate stay unchanged this slice (those land in #43 and #44 respectively); after this slice the data is in place but not yet visible in tokens.

- V5 migration: `client_membership` (hard FK + `ON DELETE CASCADE` from `application_membership_id`; `granted_at`/`granted_by` for the minimal forensic trail) and `client_membership_role` (`role_id` with `ON DELETE RESTRICT`).
- `ClientMembershipService` enforces the cross-table invariant *structurally*: `grant` looks up the App Membership by `(userId, applicationId-from-URL)`, so there is no service-call shape that could attach a foreign App Membership to a Client of a different App.
- Tenant Owner UI at `/manage/t/{slug}/applications/{appId}/clients/{registeredClientId}/members` parallels slice 2's App Members UI; linked from both the Client list row and the Client edit page.
- Latent fix: `manage/clients/*.html` referenced `${application}`, which Thymeleaf resolves to the reserved ServletContext scope rather than the model attribute. Renamed to `app` (slice 2's convention). Surfaced the first time a test actually rendered `clients/list.html`.

## Test plan

- [x] `mvn test` — 167 tests, all green (18 new service tests, 8 new controller tests).
- [x] Eligibility gate: granting a Client Membership without a parent App Membership rejected with "not a member of this application".
- [x] Cross-tenant: Tenant B session cannot reach Tenant A's `/clients/.../members` (force-logged-out by `TenantAccessFilter`).
- [x] Cross-app invariant: Client Membership grant on Client of App-A2 fails when the User has only an App Membership for App-A.
- [x] Eligibility-gate cascade: revoking App Membership atomically deletes derived Client Memberships (verified by row count).
- [x] `RESTRICT`: deleting a Role that is assigned to any Client Membership raises `DataIntegrityViolationException`.
- [x] Slice 4 (#43) is unblocked; this slice does not modify `SasConfig.jwtTokenCustomizer` — `roles` claim still emits `[]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)