### PR TITLE
v2 slice 4: JWT roles claim wiring (#43)

### DIFF
--- a/src/main/java/com/stucray/limen/management/memberships/ClientMembershipQuery.java
+++ b/src/main/java/com/stucray/limen/management/memberships/ClientMembershipQuery.java
@@ -1,0 +1,65 @@
+package com.stucray.limen.management.memberships;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Narrow read-side module for the JWT customizer and the (slice 5)
+ * /oauth2/authorize gate. Two methods, one SQL shape per method.
+ *
+ * The {@code tenant_id} predicate is redundant — the FK chain
+ * {@code client_membership → client_metadata → tenant} already enforces
+ * containment — but it is kept explicit as defence-in-depth, matching the
+ * existing TenantAware* decorator pattern. A stray cross-tenant join cannot
+ * leak Roles even if a future bug feeds the wrong tenant id.
+ */
+@Component
+public class ClientMembershipQuery {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public ClientMembershipQuery(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public List<String> rolesFor(Long userId, String registeredClientId, Long tenantId) {
+        if (userId == null || registeredClientId == null || tenantId == null) {
+            return List.of();
+        }
+        return jdbcTemplate.query(
+            """
+            SELECT r.name
+              FROM client_membership cm
+              JOIN client_membership_role cmr ON cmr.client_membership_id = cm.id
+              JOIN role r                     ON r.id = cmr.role_id
+              JOIN client_metadata m          ON m.id = cm.client_metadata_id
+             WHERE cm.user_id = ?
+               AND m.registered_client_id = ?
+               AND m.tenant_id = ?
+             ORDER BY r.name
+            """,
+            (rs, i) -> rs.getString("name"),
+            userId, registeredClientId, tenantId
+        );
+    }
+
+    public boolean hasMembership(Long userId, String registeredClientId, Long tenantId) {
+        if (userId == null || registeredClientId == null || tenantId == null) {
+            return false;
+        }
+        Integer count = jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*)
+              FROM client_membership cm
+              JOIN client_metadata m ON m.id = cm.client_metadata_id
+             WHERE cm.user_id = ?
+               AND m.registered_client_id = ?
+               AND m.tenant_id = ?
+            """,
+            Integer.class, userId, registeredClientId, tenantId
+        );
+        return count != null && count > 0;
+    }
+}

--- a/src/main/java/com/stucray/limen/security/SasConfig.java
+++ b/src/main/java/com/stucray/limen/security/SasConfig.java
@@ -3,7 +3,9 @@ package com.stucray.limen.security;
 import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.proc.SecurityContext;
 import com.stucray.limen.auth.SasJsonMapperFactory;
+import com.stucray.limen.auth.TenantUserDetails;
 import com.stucray.limen.management.clients.TenantClientRepository;
+import com.stucray.limen.management.memberships.ClientMembershipQuery;
 import com.stucray.limen.oauth2.TenantAwareOAuth2AuthorizationConsentService;
 import com.stucray.limen.oauth2.TenantAwareOAuth2AuthorizationService;
 import com.stucray.limen.oauth2.TenantAwareRegisteredClientRepository;
@@ -20,6 +22,7 @@ import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
 import org.springframework.security.oauth2.server.authorization.JdbcOAuth2AuthorizationService;
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsentService;
@@ -36,8 +39,7 @@ import org.springframework.security.web.util.matcher.MediaTypeRequestMatcher;
 import org.springframework.security.web.util.matcher.OrRequestMatcher;
 import tools.jackson.databind.json.JsonMapper;
 
-import java.util.ArrayList;
-
+import java.util.List;
 import java.util.Set;
 
 @Configuration
@@ -121,15 +123,34 @@ public class SasConfig {
     }
 
     @Bean
-    public OAuth2TokenCustomizer<JwtEncodingContext> jwtTokenCustomizer() {
+    public OAuth2TokenCustomizer<JwtEncodingContext> jwtTokenCustomizer(
+        ClientMembershipQuery clientMembershipQuery
+    ) {
         return context -> {
             if (!OAuth2TokenType.ACCESS_TOKEN.equals(context.getTokenType())) return;
             String slug = TenantScope.slug();
             if (slug != null) {
                 context.getClaims().claim("tenant", slug);
             }
-            context.getClaims().claim("roles", new ArrayList<>());
+            context.getClaims().claim("roles", resolveRoles(context, clientMembershipQuery));
         };
+    }
+
+    // End-user flows (authorization_code) carry a TenantUserDetails principal —
+    // resolve the user's Client Membership Roles. Non-end-user flows
+    // (client_credentials) have no User behind the token, so roles is empty.
+    private static List<String> resolveRoles(
+        JwtEncodingContext context, ClientMembershipQuery clientMembershipQuery
+    ) {
+        Long tenantId = TenantScope.tenantId();
+        if (tenantId == null) return List.of();
+        Authentication auth = context.getPrincipal();
+        if (auth == null || !(auth.getPrincipal() instanceof TenantUserDetails details)) {
+            return List.of();
+        }
+        return clientMembershipQuery.rolesFor(
+            details.userId(), context.getRegisteredClient().getId(), tenantId
+        );
     }
 
     private static MediaTypeRequestMatcher htmlRequestMatcher() {

--- a/src/test/java/com/stucray/limen/management/ManagementLoginIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/ManagementLoginIntegrationTest.java
@@ -40,6 +40,10 @@ class ManagementLoginIntegrationTest {
 
     @BeforeEach
     void setUp() {
+        jdbcTemplate.execute("DELETE FROM client_membership");
+        jdbcTemplate.execute("DELETE FROM application_membership_role");
+        jdbcTemplate.execute("DELETE FROM application_membership");
+        jdbcTemplate.execute("DELETE FROM role");
         jdbcTemplate.execute("DELETE FROM oauth2_registered_client WHERE application_id IS NOT NULL");
         jdbcTemplate.execute("DELETE FROM applications");
         jdbcTemplate.execute("DELETE FROM users");

--- a/src/test/java/com/stucray/limen/management/applications/ApplicationManagementIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/applications/ApplicationManagementIntegrationTest.java
@@ -43,6 +43,10 @@ class ApplicationManagementIntegrationTest {
 
     @BeforeEach
     void setUp() throws Exception {
+        jdbcTemplate.execute("DELETE FROM client_membership");
+        jdbcTemplate.execute("DELETE FROM application_membership_role");
+        jdbcTemplate.execute("DELETE FROM application_membership");
+        jdbcTemplate.execute("DELETE FROM role");
         jdbcTemplate.execute("DELETE FROM oauth2_registered_client WHERE application_id IS NOT NULL");
         jdbcTemplate.execute("DELETE FROM applications");
         jdbcTemplate.execute("DELETE FROM users WHERE tenant_id IN (SELECT id FROM tenants WHERE slug != 'system')");

--- a/src/test/java/com/stucray/limen/management/clients/ClientTokenSettingsIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/clients/ClientTokenSettingsIntegrationTest.java
@@ -63,6 +63,13 @@ class ClientTokenSettingsIntegrationTest {
 
     @BeforeEach
     void setUp() {
+        // Order matters: client_membership_role → role uses ON DELETE RESTRICT,
+        // so any rows left from earlier tests must be cleared before deleting
+        // applications would cascade through role.
+        jdbcTemplate.execute("DELETE FROM client_membership");
+        jdbcTemplate.execute("DELETE FROM application_membership_role");
+        jdbcTemplate.execute("DELETE FROM application_membership");
+        jdbcTemplate.execute("DELETE FROM role");
         jdbcTemplate.execute("DELETE FROM oauth2_registered_client WHERE application_id IS NOT NULL");
         jdbcTemplate.execute("DELETE FROM applications");
         jdbcTemplate.execute("DELETE FROM users WHERE tenant_id != (SELECT id FROM tenants WHERE slug = 'system')");

--- a/src/test/java/com/stucray/limen/management/memberships/ClientMembershipQueryIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/memberships/ClientMembershipQueryIntegrationTest.java
@@ -1,0 +1,228 @@
+package com.stucray.limen.management.memberships;
+
+import com.stucray.limen.TestcontainersConfiguration;
+import com.stucray.limen.management.applications.Application;
+import com.stucray.limen.management.applications.ApplicationRepository;
+import com.stucray.limen.management.clients.ClientManagementService;
+import com.stucray.limen.management.clients.TenantClient;
+import com.stucray.limen.management.roles.Role;
+import com.stucray.limen.management.roles.RoleRepository;
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.tenant.TenantStatus;
+import com.stucray.limen.user.User;
+import com.stucray.limen.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest
+class ClientMembershipQueryIntegrationTest {
+
+    @Autowired ClientMembershipQuery clientMembershipQuery;
+    @Autowired ClientMembershipService clientMembershipService;
+    @Autowired ApplicationMembershipService applicationMembershipService;
+    @Autowired ApplicationRepository applicationRepository;
+    @Autowired ClientManagementService clientManagementService;
+    @Autowired RoleRepository roleRepository;
+    @Autowired TenantRepository tenantRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    Tenant tenantA;
+    Tenant tenantB;
+    Application appA;
+    Application appB;
+    TenantClient clientA;
+    TenantClient clientB;
+    User aliceA;
+    User adminA;
+    User carolB;
+    User adminB;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.execute("DELETE FROM client_membership");
+        jdbcTemplate.execute("DELETE FROM application_membership_role");
+        jdbcTemplate.execute("DELETE FROM application_membership");
+        jdbcTemplate.execute("DELETE FROM role");
+        jdbcTemplate.execute("DELETE FROM oauth2_registered_client WHERE application_id IS NOT NULL");
+        jdbcTemplate.execute("DELETE FROM applications");
+        jdbcTemplate.execute("DELETE FROM users WHERE tenant_id IN (SELECT id FROM tenants WHERE slug IN ('cmq-a', 'cmq-b'))");
+        jdbcTemplate.execute("DELETE FROM tenants WHERE slug IN ('cmq-a', 'cmq-b')");
+
+        tenantA = tenantRepository.save(new Tenant(null, "cmq-a", "CMQ A", TenantStatus.ACTIVE, LocalDateTime.now()));
+        tenantB = tenantRepository.save(new Tenant(null, "cmq-b", "CMQ B", TenantStatus.ACTIVE, LocalDateTime.now()));
+        appA = applicationRepository.save(new Application(null, tenantA.id(), "App A", null, LocalDateTime.now()));
+        appB = applicationRepository.save(new Application(null, tenantB.id(), "App B", null, LocalDateTime.now()));
+        aliceA = userRepository.save(new User(null, tenantA.id(), "alice", "x", true, false, false, LocalDateTime.now()));
+        adminA = userRepository.save(new User(null, tenantA.id(), "admin", "x", true, false, true,  LocalDateTime.now()));
+        carolB = userRepository.save(new User(null, tenantB.id(), "carol", "x", true, false, false, LocalDateTime.now()));
+        adminB = userRepository.save(new User(null, tenantB.id(), "admin-b", "x", true, false, true, LocalDateTime.now()));
+
+        clientA = createClient(appA.id(), tenantA.id(), "client-a");
+        clientB = createClient(appB.id(), tenantB.id(), "client-b");
+    }
+
+    private TenantClient createClient(Long applicationId, Long tenantId, String name) {
+        ClientManagementService.ClientCreationResult result = clientManagementService.createClient(
+            applicationId, tenantId, name,
+            Set.of(AuthorizationGrantType.AUTHORIZATION_CODE),
+            Set.of("http://localhost/callback"), Set.of(), Set.of("openid"),
+            false, true, 5, 30, false
+        );
+        return result.client();
+    }
+
+    @Test
+    void rolesForReturnsAssignedRolesAlphabetical() {
+        Role viewer = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
+        Role editor = roleRepository.save(new Role(null, appA.id(), "editor", null, LocalDateTime.now()));
+        Role admin  = roleRepository.save(new Role(null, appA.id(), "admin",  null, LocalDateTime.now()));
+        applicationMembershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+        ClientMembership cm = clientMembershipService.grant(
+            clientA.registeredClientId(), appA.id(), tenantA.id(), aliceA.id(), adminA.id()
+        );
+        clientMembershipService.updateRoles(
+            cm.id(), clientA.registeredClientId(), appA.id(), tenantA.id(),
+            Set.of(viewer.id(), editor.id(), admin.id())
+        );
+
+        List<String> roles = clientMembershipQuery.rolesFor(
+            aliceA.id(), clientA.registeredClientId(), tenantA.id()
+        );
+
+        assertThat(roles).containsExactly("admin", "editor", "viewer");
+    }
+
+    @Test
+    void rolesForReturnsEmptyWhenNoMembership() {
+        List<String> roles = clientMembershipQuery.rolesFor(
+            aliceA.id(), clientA.registeredClientId(), tenantA.id()
+        );
+        assertThat(roles).isEmpty();
+    }
+
+    @Test
+    void rolesForReturnsEmptyWhenMembershipExistsButNoRolesAssigned() {
+        applicationMembershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+        clientMembershipService.grant(
+            clientA.registeredClientId(), appA.id(), tenantA.id(), aliceA.id(), adminA.id()
+        );
+
+        List<String> roles = clientMembershipQuery.rolesFor(
+            aliceA.id(), clientA.registeredClientId(), tenantA.id()
+        );
+
+        assertThat(roles).isEmpty();
+    }
+
+    @Test
+    void rolesForIsCrossTenantSafe() {
+        // carol is in tenantB and has full Membership + Role for clientB.
+        Role role = roleRepository.save(new Role(null, appB.id(), "viewer", null, LocalDateTime.now()));
+        applicationMembershipService.grant(appB.id(), tenantB.id(), carolB.id(), adminB.id());
+        ClientMembership cm = clientMembershipService.grant(
+            clientB.registeredClientId(), appB.id(), tenantB.id(), carolB.id(), adminB.id()
+        );
+        clientMembershipService.updateRoles(
+            cm.id(), clientB.registeredClientId(), appB.id(), tenantB.id(), Set.of(role.id())
+        );
+
+        // Caller asks for carol's Roles on clientB but with the WRONG tenant id
+        // (tenantA). The defensive tenant_id predicate must reject the row even
+        // though the FK chain alone would already match.
+        List<String> rolesWithWrongTenant = clientMembershipQuery.rolesFor(
+            carolB.id(), clientB.registeredClientId(), tenantA.id()
+        );
+
+        assertThat(rolesWithWrongTenant).isEmpty();
+    }
+
+    @Test
+    void rolesForRejectsForeignTenantUser() {
+        // alice (tenantA) has no Membership for clientB (tenantB) — must be empty
+        // even when caller passes tenantB id, simulating a stray cross-tenant query.
+        List<String> roles = clientMembershipQuery.rolesFor(
+            aliceA.id(), clientB.registeredClientId(), tenantB.id()
+        );
+        assertThat(roles).isEmpty();
+    }
+
+    @Test
+    void hasMembershipReturnsTrueForExistingMembership() {
+        applicationMembershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+        clientMembershipService.grant(
+            clientA.registeredClientId(), appA.id(), tenantA.id(), aliceA.id(), adminA.id()
+        );
+
+        boolean has = clientMembershipQuery.hasMembership(
+            aliceA.id(), clientA.registeredClientId(), tenantA.id()
+        );
+
+        assertThat(has).isTrue();
+    }
+
+    @Test
+    void hasMembershipReturnsTrueEvenWithNoRoles() {
+        // Membership-without-Roles is still a Membership — slice 5's gate
+        // depends on this distinction (presence of row, not Roles count).
+        applicationMembershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
+        clientMembershipService.grant(
+            clientA.registeredClientId(), appA.id(), tenantA.id(), aliceA.id(), adminA.id()
+        );
+
+        boolean has = clientMembershipQuery.hasMembership(
+            aliceA.id(), clientA.registeredClientId(), tenantA.id()
+        );
+
+        assertThat(has).isTrue();
+    }
+
+    @Test
+    void hasMembershipReturnsFalseWhenAbsent() {
+        boolean has = clientMembershipQuery.hasMembership(
+            aliceA.id(), clientA.registeredClientId(), tenantA.id()
+        );
+        assertThat(has).isFalse();
+    }
+
+    @Test
+    void hasMembershipIsCrossTenantSafe() {
+        applicationMembershipService.grant(appB.id(), tenantB.id(), carolB.id(), adminB.id());
+        clientMembershipService.grant(
+            clientB.registeredClientId(), appB.id(), tenantB.id(), carolB.id(), adminB.id()
+        );
+
+        boolean has = clientMembershipQuery.hasMembership(
+            carolB.id(), clientB.registeredClientId(), tenantA.id()
+        );
+
+        assertThat(has).isFalse();
+    }
+
+    @Test
+    void rolesForToleratesNullArgs() {
+        assertThat(clientMembershipQuery.rolesFor(null, "any", tenantA.id())).isEmpty();
+        assertThat(clientMembershipQuery.rolesFor(aliceA.id(), null, tenantA.id())).isEmpty();
+        assertThat(clientMembershipQuery.rolesFor(aliceA.id(), "any", null)).isEmpty();
+    }
+
+    @Test
+    void hasMembershipToleratesNullArgs() {
+        assertThat(clientMembershipQuery.hasMembership(null, "any", tenantA.id())).isFalse();
+        assertThat(clientMembershipQuery.hasMembership(aliceA.id(), null, tenantA.id())).isFalse();
+        assertThat(clientMembershipQuery.hasMembership(aliceA.id(), "any", null)).isFalse();
+    }
+}

--- a/src/test/java/com/stucray/limen/management/system/SystemAdminIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/system/SystemAdminIntegrationTest.java
@@ -41,6 +41,10 @@ class SystemAdminIntegrationTest {
 
     @BeforeEach
     void setUp() throws Exception {
+        jdbcTemplate.execute("DELETE FROM client_membership");
+        jdbcTemplate.execute("DELETE FROM application_membership_role");
+        jdbcTemplate.execute("DELETE FROM application_membership");
+        jdbcTemplate.execute("DELETE FROM role");
         jdbcTemplate.execute("DELETE FROM applications");
         jdbcTemplate.execute("DELETE FROM users WHERE tenant_id IN (SELECT id FROM tenants WHERE slug != 'system')");
         jdbcTemplate.execute("DELETE FROM tenants WHERE slug != 'system'");

--- a/src/test/java/com/stucray/limen/oauth2/OAuth2ForcedPasswordChangeIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/OAuth2ForcedPasswordChangeIntegrationTest.java
@@ -62,6 +62,10 @@ class OAuth2ForcedPasswordChangeIntegrationTest {
 
     @BeforeEach
     void setUp() {
+        jdbcTemplate.execute("DELETE FROM client_membership");
+        jdbcTemplate.execute("DELETE FROM application_membership_role");
+        jdbcTemplate.execute("DELETE FROM application_membership");
+        jdbcTemplate.execute("DELETE FROM role");
         jdbcTemplate.execute("DELETE FROM oauth2_registered_client WHERE application_id IS NOT NULL");
         jdbcTemplate.execute("DELETE FROM applications");
         jdbcTemplate.execute("DELETE FROM users WHERE tenant_id != (SELECT id FROM tenants WHERE slug = 'system')");

--- a/src/test/java/com/stucray/limen/oauth2/OAuth2JwtRolesClaimIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/OAuth2JwtRolesClaimIntegrationTest.java
@@ -1,0 +1,228 @@
+package com.stucray.limen.oauth2;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jwt.SignedJWT;
+import com.stucray.limen.TestcontainersConfiguration;
+import com.stucray.limen.management.applications.Application;
+import com.stucray.limen.management.applications.ApplicationRepository;
+import com.stucray.limen.management.clients.TenantClient;
+import com.stucray.limen.management.clients.TenantClientRepository;
+import com.stucray.limen.management.memberships.ApplicationMembershipService;
+import com.stucray.limen.management.memberships.ClientMembership;
+import com.stucray.limen.management.memberships.ClientMembershipService;
+import com.stucray.limen.management.roles.Role;
+import com.stucray.limen.management.roles.RoleRepository;
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantProvisioningService;
+import com.stucray.limen.user.User;
+import com.stucray.limen.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.oidc.OidcScopes;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Slice 4 (#43) end-to-end: a User with an Application Membership and a Client
+ * Membership carrying Roles completes the authorization code + PKCE flow, and
+ * the resulting JWT carries the Roles in the {@code roles} claim. Also covers
+ * the negative branch — a User without Client Membership still issues a token
+ * with empty {@code roles} (slice 5 / #44 is what later turns this into a gate).
+ */
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+class OAuth2JwtRolesClaimIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired TenantProvisioningService tenantProvisioningService;
+    @Autowired ApplicationRepository applicationRepository;
+    @Autowired RoleRepository roleRepository;
+    @Autowired ApplicationMembershipService applicationMembershipService;
+    @Autowired ClientMembershipService clientMembershipService;
+    @Autowired RegisteredClientRepository registeredClientRepository;
+    @Autowired TenantClientRepository tenantClientRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired PasswordEncoder passwordEncoder;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    Tenant tenant;
+    Application app;
+    User alice;
+    User admin;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.execute("DELETE FROM client_membership");
+        jdbcTemplate.execute("DELETE FROM application_membership_role");
+        jdbcTemplate.execute("DELETE FROM application_membership");
+        jdbcTemplate.execute("DELETE FROM role");
+        jdbcTemplate.execute("DELETE FROM oauth2_registered_client WHERE application_id IS NOT NULL");
+        jdbcTemplate.execute("DELETE FROM applications");
+        jdbcTemplate.execute("DELETE FROM users WHERE tenant_id != (SELECT id FROM tenants WHERE slug = 'system')");
+        jdbcTemplate.execute("DELETE FROM tenants WHERE slug != 'system'");
+
+        tenant = tenantProvisioningService.createTenant("acme", "Acme");
+        app = applicationRepository.save(new Application(
+            null, tenant.id(), "Acme Web", "End-to-end test app", LocalDateTime.now()
+        ));
+        alice = userRepository.save(new User(
+            null, tenant.id(), "alice",
+            passwordEncoder.encode("password"),
+            true, false, false, LocalDateTime.now()
+        ));
+        admin = userRepository.save(new User(
+            null, tenant.id(), "admin",
+            passwordEncoder.encode("password"),
+            true, false, true, LocalDateTime.now()
+        ));
+    }
+
+    @Test
+    void jwtCarriesClientMembershipRolesForEndUser() throws Exception {
+        // 1. Define Roles and a public PKCE Client.
+        Role viewer = roleRepository.save(new Role(null, app.id(), "viewer", null, LocalDateTime.now()));
+        Role editor = roleRepository.save(new Role(null, app.id(), "editor", null, LocalDateTime.now()));
+        TenantClient client = createPkceClient("acme-spa");
+
+        // 2. Grant Application + Client Membership and assign the Roles.
+        applicationMembershipService.grant(app.id(), tenant.id(), alice.id(), admin.id());
+        ClientMembership cm = clientMembershipService.grant(
+            client.registeredClientId(), app.id(), tenant.id(), alice.id(), admin.id()
+        );
+        clientMembershipService.updateRoles(
+            cm.id(), client.registeredClientId(), app.id(), tenant.id(),
+            Set.of(viewer.id(), editor.id())
+        );
+
+        // 3. Run the authorization code + PKCE flow as alice.
+        Map<String, Object> claims = runAuthorizationCodeFlow(client, "alice");
+
+        // 4. Verify JWT claims.
+        assertThat(claims.get("tenant")).isEqualTo("acme");
+        assertThat(claims.get("roles")).isInstanceOf(List.class);
+        @SuppressWarnings("unchecked")
+        List<String> roles = (List<String>) claims.get("roles");
+        assertThat(roles).containsExactly("editor", "viewer");
+        assertThat(claims.get("iss")).asString().isEqualTo("http://localhost/t/acme");
+    }
+
+    @Test
+    void jwtCarriesEmptyRolesWhenUserHasNoClientMembership() throws Exception {
+        // No Memberships granted — slice 4 still issues the token (the gate is
+        // slice 5). roles must be the empty list.
+        TenantClient client = createPkceClient("acme-spa-no-membership");
+
+        Map<String, Object> claims = runAuthorizationCodeFlow(client, "alice");
+
+        assertThat(claims.get("tenant")).isEqualTo("acme");
+        assertThat((List<?>) claims.get("roles")).isEmpty();
+    }
+
+    private TenantClient createPkceClient(String name) {
+        String internalId = UUID.randomUUID().toString();
+        String clientId = UUID.randomUUID().toString();
+        RegisteredClient rc = RegisteredClient.withId(internalId)
+            .clientId(clientId)
+            .clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .redirectUri("http://localhost/callback")
+            .scope(OidcScopes.OPENID)
+            .clientSettings(ClientSettings.builder()
+                .requireProofKey(true)
+                .requireAuthorizationConsent(false)
+                .build())
+            .build();
+        registeredClientRepository.save(rc);
+        return tenantClientRepository.save(new TenantClient(
+            null, internalId, app.id(), tenant.id(), name, false
+        ));
+    }
+
+    private Map<String, Object> runAuthorizationCodeFlow(TenantClient client, String username) throws Exception {
+        String oauthClientId = jdbcTemplate.queryForObject(
+            "SELECT client_id FROM oauth2_registered_client WHERE id = ?",
+            String.class, client.registeredClientId()
+        );
+
+        byte[] verifierBytes = new byte[32];
+        new SecureRandom().nextBytes(verifierBytes);
+        String codeVerifier = Base64.getUrlEncoder().withoutPadding().encodeToString(verifierBytes);
+        byte[] hash = MessageDigest.getInstance("SHA-256").digest(codeVerifier.getBytes(StandardCharsets.US_ASCII));
+        String codeChallenge = Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+
+        String authzUri = UriComponentsBuilder.fromPath("/t/acme/oauth2/authorize")
+            .queryParam("response_type", "code")
+            .queryParam("client_id", oauthClientId)
+            .queryParam("redirect_uri", "http://localhost/callback")
+            .queryParam("scope", OidcScopes.OPENID)
+            .queryParam("state", "s1")
+            .queryParam("code_challenge", codeChallenge)
+            .queryParam("code_challenge_method", "S256")
+            .build().toUriString();
+
+        MockHttpSession session = new MockHttpSession();
+        MvcResult authzResult = mockMvc.perform(get(authzUri).session(session))
+            .andExpect(status().is3xxRedirection())
+            .andReturn();
+        assertThat(authzResult.getResponse().getHeader("Location")).contains("/t/acme/login");
+
+        mockMvc.perform(post("/t/acme/login")
+                .param("username", username)
+                .param("password", "password")
+                .session(session)
+                .with(csrf()))
+            .andExpect(status().is3xxRedirection());
+
+        MvcResult codeResult = mockMvc.perform(get(authzUri).session(session))
+            .andExpect(status().is3xxRedirection())
+            .andReturn();
+
+        String code = UriComponentsBuilder.fromUriString(codeResult.getResponse().getHeader("Location"))
+            .build().getQueryParams().getFirst("code");
+        assertThat(code).isNotBlank();
+
+        String tokenJson = mockMvc.perform(post("/t/acme/oauth2/token")
+                .param("grant_type", "authorization_code")
+                .param("code", code)
+                .param("redirect_uri", "http://localhost/callback")
+                .param("code_verifier", codeVerifier)
+                .param("client_id", oauthClientId))
+            .andExpect(status().isOk())
+            .andReturn().getResponse().getContentAsString();
+
+        String accessToken = objectMapper.readTree(tokenJson).get("access_token").asText();
+        return SignedJWT.parse(accessToken).getJWTClaimsSet().getClaims();
+    }
+}

--- a/src/test/java/com/stucray/limen/oauth2/TenantAwareOAuth2AuthorizationConsentServiceIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/TenantAwareOAuth2AuthorizationConsentServiceIntegrationTest.java
@@ -46,6 +46,10 @@ class TenantAwareOAuth2AuthorizationConsentServiceIntegrationTest {
 
     @BeforeEach
     void setUp() {
+        jdbcTemplate.execute("DELETE FROM client_membership");
+        jdbcTemplate.execute("DELETE FROM application_membership_role");
+        jdbcTemplate.execute("DELETE FROM application_membership");
+        jdbcTemplate.execute("DELETE FROM role");
         jdbcTemplate.execute("DELETE FROM oauth2_authorization_consent");
         jdbcTemplate.execute("DELETE FROM client_metadata");
         jdbcTemplate.execute("DELETE FROM oauth2_registered_client");

--- a/src/test/java/com/stucray/limen/oauth2/TenantAwareOAuth2AuthorizationServiceIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/TenantAwareOAuth2AuthorizationServiceIntegrationTest.java
@@ -49,6 +49,10 @@ class TenantAwareOAuth2AuthorizationServiceIntegrationTest {
 
     @BeforeEach
     void setUp() {
+        jdbcTemplate.execute("DELETE FROM client_membership");
+        jdbcTemplate.execute("DELETE FROM application_membership_role");
+        jdbcTemplate.execute("DELETE FROM application_membership");
+        jdbcTemplate.execute("DELETE FROM role");
         jdbcTemplate.execute("DELETE FROM oauth2_authorization");
         jdbcTemplate.execute("DELETE FROM client_metadata");
         jdbcTemplate.execute("DELETE FROM oauth2_registered_client");

--- a/src/test/java/com/stucray/limen/oauth2/TenantOAuth2RoutingIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/TenantOAuth2RoutingIntegrationTest.java
@@ -81,6 +81,13 @@ class TenantOAuth2RoutingIntegrationTest {
 
     @BeforeEach
     void setUp() {
+        // Order matters: client_membership_role → role uses ON DELETE RESTRICT,
+        // so any rows left from earlier tests must be cleared before deleting
+        // applications would cascade through role.
+        jdbcTemplate.execute("DELETE FROM client_membership");
+        jdbcTemplate.execute("DELETE FROM application_membership_role");
+        jdbcTemplate.execute("DELETE FROM application_membership");
+        jdbcTemplate.execute("DELETE FROM role");
         jdbcTemplate.execute("DELETE FROM oauth2_registered_client WHERE application_id IS NOT NULL");
         jdbcTemplate.execute("DELETE FROM applications");
         jdbcTemplate.execute("DELETE FROM users WHERE tenant_id != (SELECT id FROM tenants WHERE slug = 'system')");


### PR DESCRIPTION
## Summary
- New deep module `ClientMembershipQuery` (`rolesFor`, `hasMembership`) — narrow read-side over the `client_membership → client_membership_role → role → client_metadata` join, with a redundant `tenant_id` predicate as defence-in-depth.
- `SasConfig.jwtTokenCustomizer` rewired: end-user JWTs (auth-code flow) now carry the real `roles` claim from Client Membership; client-credentials JWTs continue to emit `roles: []` because no end-user is behind the token.
- Eight pre-existing integration tests' `setUp` methods tightened to clean up the new membership tables before `applications` (the `client_membership_role → role` `ON DELETE RESTRICT` would otherwise break cross-test cascades).

Closes #43.

## Test plan
- [x] `mvn test` — full Testcontainers suite green (180/180)
- [x] `ClientMembershipQueryIntegrationTest` — 11 cases (alphabetical role order, empty/no-membership, empty/no-roles, cross-tenant safety on both methods, null-arg tolerance)
- [x] `OAuth2JwtRolesClaimIntegrationTest` — end-to-end PKCE flow with Membership + Roles → JWT carries them; without Membership → `roles: []` (slice 5 / #44 turns this into a gate)
- [ ] Manual verify: log in as a User with Client Membership Roles, decode the resulting JWT, confirm `roles` populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)