### PR TITLE
v2 slice 5: /oauth2/authorize Client Membership gate (#44)

### DIFF
--- a/src/main/java/com/stucray/limen/oauth2/MembershipGateFilter.java
+++ b/src/main/java/com/stucray/limen/oauth2/MembershipGateFilter.java
@@ -1,0 +1,148 @@
+package com.stucray.limen.oauth2;
+
+import com.stucray.limen.auth.TenantUserDetails;
+import com.stucray.limen.management.memberships.ClientMembershipQuery;
+import com.stucray.limen.tenant.TenantScope;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.security.web.DefaultRedirectStrategy;
+import org.springframework.security.web.RedirectStrategy;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.web.util.UriUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Enforces Client Membership at /oauth2/authorize. Sits inside the Spring
+ * Authorization Server security chain after the SAS pre-validation filter and
+ * before {@code OAuth2AuthorizationEndpointFilter}, so the request shape and
+ * {@code redirect_uri} are already validated by the time we run.
+ *
+ * <p>End-User Login at /t/&#123;slug&#125;/login is unchanged; credentials
+ * still validate against the Tenant's User pool. The gate sits one step
+ * downstream so authentication and authorization remain separable failures —
+ * an authenticated User without a {@code client_membership} row for the
+ * Client is rejected with {@code error=access_denied} per RFC 6749 §4.1.2.1.
+ *
+ * <p>Membership presence (not Role count) is the gate: a User with a Client
+ * Membership and zero Roles passes (the JWT carries {@code roles: []}).
+ *
+ * <p>Implementation note — this is a Filter rather than an
+ * {@code AuthenticationProvider} decorator on
+ * {@code OAuth2AuthorizationCodeRequestAuthenticationProvider}: SAS's
+ * configurer captures internal state from the original provider via
+ * reflection on an {@code instanceof} check, so a wrapping decorator
+ * silently breaks the validating-filter wiring; replacing the provider in
+ * the list breaks it the same way; inserting alongside causes the SAS
+ * provider to issue a code anyway (Spring's {@code ProviderManager} catches
+ * the gate's {@code AuthenticationException} and falls through to the next
+ * provider). A pre-endpoint filter is the clean integration point.
+ */
+public final class MembershipGateFilter extends OncePerRequestFilter {
+
+    private static final RequestMatcher AUTHORIZE_MATCHER =
+        PathPatternRequestMatcher.withDefaults().matcher("/oauth2/authorize");
+
+    private final RegisteredClientRepository registeredClientRepository;
+    private final ClientMembershipQuery clientMembershipQuery;
+    private final RedirectStrategy redirectStrategy = new DefaultRedirectStrategy();
+
+    public MembershipGateFilter(
+        RegisteredClientRepository registeredClientRepository,
+        ClientMembershipQuery clientMembershipQuery
+    ) {
+        this.registeredClientRepository = registeredClientRepository;
+        this.clientMembershipQuery = clientMembershipQuery;
+    }
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request, HttpServletResponse response, FilterChain chain
+    ) throws ServletException, IOException {
+        if (!AUTHORIZE_MATCHER.matches(request)) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        // Anonymous / unauthenticated requests fall through to the SAS chain,
+        // which redirects to the tenant login. The gate only fires for an
+        // authenticated end-user.
+        if (authentication == null
+            || !authentication.isAuthenticated()
+            || !(authentication.getPrincipal() instanceof TenantUserDetails details)
+        ) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        String clientIdParam = request.getParameter(OAuth2ParameterNames.CLIENT_ID);
+        if (!StringUtils.hasText(clientIdParam)) {
+            chain.doFilter(request, response);
+            return;
+        }
+        RegisteredClient registeredClient = registeredClientRepository.findByClientId(clientIdParam);
+        if (registeredClient == null) {
+            // Let SAS handle invalid_client — its filter has the canonical
+            // error response for this case.
+            chain.doFilter(request, response);
+            return;
+        }
+
+        Long tenantId = TenantScope.tenantId();
+        if (tenantId != null
+            && clientMembershipQuery.hasMembership(details.userId(), registeredClient.getId(), tenantId)
+        ) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        sendAccessDenied(request, response, registeredClient);
+    }
+
+    private void sendAccessDenied(
+        HttpServletRequest request, HttpServletResponse response, RegisteredClient registeredClient
+    ) throws IOException {
+        String redirectUri = resolveRedirectUri(request, registeredClient);
+        if (redirectUri == null) {
+            response.sendError(HttpStatus.FORBIDDEN.value(), "access_denied");
+            return;
+        }
+        UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(redirectUri)
+            .queryParam(OAuth2ParameterNames.ERROR, OAuth2ErrorCodes.ACCESS_DENIED);
+        String state = request.getParameter(OAuth2ParameterNames.STATE);
+        if (StringUtils.hasText(state)) {
+            builder.queryParam(OAuth2ParameterNames.STATE,
+                UriUtils.encode(state, StandardCharsets.UTF_8));
+        }
+        redirectStrategy.sendRedirect(request, response, builder.build(true).toUriString());
+    }
+
+    private static String resolveRedirectUri(HttpServletRequest request, RegisteredClient registeredClient) {
+        String requested = request.getParameter(OAuth2ParameterNames.REDIRECT_URI);
+        if (StringUtils.hasText(requested) && registeredClient.getRedirectUris().contains(requested)) {
+            return requested;
+        }
+        // The OAuth2 spec allows omitting redirect_uri when the client has
+        // exactly one registered. Fall back to it; otherwise refuse to redirect
+        // (sending a 403 instead of a guess is safer than picking arbitrarily).
+        if (registeredClient.getRedirectUris().size() == 1) {
+            return registeredClient.getRedirectUris().iterator().next();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/stucray/limen/security/SasConfig.java
+++ b/src/main/java/com/stucray/limen/security/SasConfig.java
@@ -6,6 +6,7 @@ import com.stucray.limen.auth.SasJsonMapperFactory;
 import com.stucray.limen.auth.TenantUserDetails;
 import com.stucray.limen.management.clients.TenantClientRepository;
 import com.stucray.limen.management.memberships.ClientMembershipQuery;
+import com.stucray.limen.oauth2.MembershipGateFilter;
 import com.stucray.limen.oauth2.TenantAwareOAuth2AuthorizationConsentService;
 import com.stucray.limen.oauth2.TenantAwareOAuth2AuthorizationService;
 import com.stucray.limen.oauth2.TenantAwareRegisteredClientRepository;
@@ -33,6 +34,7 @@ import org.springframework.security.oauth2.server.authorization.settings.Authori
 import org.springframework.security.oauth2.server.authorization.token.JwtEncodingContext;
 import org.springframework.security.oauth2.server.authorization.token.OAuth2TokenCustomizer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.intercept.AuthorizationFilter;
 import org.springframework.security.web.csrf.CsrfFilter;
 import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.security.web.util.matcher.MediaTypeRequestMatcher;
@@ -47,7 +49,11 @@ public class SasConfig {
 
     @Bean
     @Order(Ordered.HIGHEST_PRECEDENCE)
-    public SecurityFilterChain authorizationServerSecurityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain authorizationServerSecurityFilterChain(
+        HttpSecurity http,
+        RegisteredClientRepository registeredClientRepository,
+        ClientMembershipQuery clientMembershipQuery
+    ) throws Exception {
         http.oauth2AuthorizationServer(authorizationServer -> {
             http.securityMatcher(authorizationServer.getEndpointsMatcher());
             authorizationServer.oidc(Customizer.withDefaults());
@@ -65,6 +71,16 @@ public class SasConfig {
             .addFilterBefore(
                 new TenantIssuerContextFilter(authorizationServerSettings()),
                 CsrfFilter.class
+            )
+            // Anchor the gate after AuthorizationFilter — the SAS authorization
+            // endpoint filter is itself registered with addFilterAfter on the
+            // same class, so the gate sits adjacent to it in the chain. By that
+            // point the SecurityContext has been hydrated from session and the
+            // request is allowed past `authorizeHttpRequests(...).authenticated()`,
+            // so we know there is an authenticated principal to gate on.
+            .addFilterAfter(
+                new MembershipGateFilter(registeredClientRepository, clientMembershipQuery),
+                AuthorizationFilter.class
             );
         return http.build();
     }

--- a/src/test/java/com/stucray/limen/management/clients/ClientTokenSettingsIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/clients/ClientTokenSettingsIntegrationTest.java
@@ -5,6 +5,9 @@ import com.nimbusds.jwt.SignedJWT;
 import com.stucray.limen.TestcontainersConfiguration;
 import com.stucray.limen.management.applications.Application;
 import com.stucray.limen.management.applications.ApplicationRepository;
+import com.stucray.limen.management.memberships.ApplicationMembershipService;
+import com.stucray.limen.management.memberships.ClientMembershipService;
+import com.stucray.limen.management.memberships.ClientMembershipTestFixture;
 import com.stucray.limen.tenant.Tenant;
 import com.stucray.limen.tenant.TenantProvisioningService;
 import com.stucray.limen.tenant.TenantRepository;
@@ -53,6 +56,8 @@ class ClientTokenSettingsIntegrationTest {
     @Autowired ClientManagementService clientManagementService;
     @Autowired TenantClientRepository tenantClientRepository;
     @Autowired UserRepository userRepository;
+    @Autowired ApplicationMembershipService applicationMembershipService;
+    @Autowired ClientMembershipService clientMembershipService;
     @Autowired PasswordEncoder passwordEncoder;
     @Autowired JdbcTemplate jdbcTemplate;
 
@@ -60,6 +65,7 @@ class ClientTokenSettingsIntegrationTest {
 
     Tenant tenant;
     Application app;
+    User alice;
 
     @BeforeEach
     void setUp() {
@@ -77,7 +83,15 @@ class ClientTokenSettingsIntegrationTest {
 
         tenant = tenantProvisioningService.createTenant("token-test", "Token Test");
         app = applicationRepository.save(new Application(null, tenant.id(), "Test App", null, LocalDateTime.now()));
-        userRepository.save(new User(null, tenant.id(), "alice", passwordEncoder.encode("password"), true, false, false, LocalDateTime.now()));
+        alice = userRepository.save(new User(null, tenant.id(), "alice", passwordEncoder.encode("password"), true, false, false, LocalDateTime.now()));
+    }
+
+    private void grantMembership(String registeredClientId) {
+        ClientMembershipTestFixture.grant(
+            applicationMembershipService, clientMembershipService,
+            app.id(), tenant.id(), alice.id(), alice.id(),
+            registeredClientId, Set.of()
+        );
     }
 
     @Test
@@ -120,6 +134,7 @@ class ClientTokenSettingsIntegrationTest {
             Set.of("http://localhost/callback"), Set.of(), Set.of(OidcScopes.OPENID),
             true, true, 5, 30, false
         );
+        grantMembership(result.client().registeredClientId());
 
         String oauthClientId = jdbcTemplate.queryForObject(
             "SELECT client_id FROM oauth2_registered_client WHERE id = ?",
@@ -183,6 +198,7 @@ class ClientTokenSettingsIntegrationTest {
             Set.of("http://localhost/callback"), Set.of(), Set.of(OidcScopes.OPENID),
             false, true, 5, 30, false  // reuseRefreshTokens=false → rotation
         );
+        grantMembership(result.client().registeredClientId());
 
         String oauthClientId = jdbcTemplate.queryForObject(
             "SELECT client_id FROM oauth2_registered_client WHERE id = ?",
@@ -221,6 +237,7 @@ class ClientTokenSettingsIntegrationTest {
             Set.of("http://localhost/callback"), Set.of(), Set.of(OidcScopes.OPENID),
             false, true, 5, 30, true  // reuseRefreshTokens=true
         );
+        grantMembership(result.client().registeredClientId());
 
         String oauthClientId = jdbcTemplate.queryForObject(
             "SELECT client_id FROM oauth2_registered_client WHERE id = ?",

--- a/src/test/java/com/stucray/limen/management/memberships/ClientMembershipTestFixture.java
+++ b/src/test/java/com/stucray/limen/management/memberships/ClientMembershipTestFixture.java
@@ -1,0 +1,41 @@
+package com.stucray.limen.management.memberships;
+
+import java.util.Set;
+
+/**
+ * Single-call helper that grants the App Membership prerequisite and the
+ * Client Membership in one shot, optionally with a Role set. Used by the
+ * /oauth2/authorize integration tests so each test does not re-encode the
+ * three-step grant + updateRoles boilerplate.
+ *
+ * Mirrors the production grant order: App Membership first (eligibility
+ * gate), then Client Membership; updateRoles is only invoked when a non-empty
+ * set is supplied so the "Membership without Roles" path is exercised
+ * naturally by passing {@link Set#of()}.
+ */
+public final class ClientMembershipTestFixture {
+
+    private ClientMembershipTestFixture() {}
+
+    public static ClientMembership grant(
+        ApplicationMembershipService applicationMembershipService,
+        ClientMembershipService clientMembershipService,
+        Long applicationId,
+        Long tenantId,
+        Long userId,
+        Long granterId,
+        String registeredClientId,
+        Set<Long> roleIds
+    ) {
+        applicationMembershipService.grant(applicationId, tenantId, userId, granterId);
+        ClientMembership membership = clientMembershipService.grant(
+            registeredClientId, applicationId, tenantId, userId, granterId
+        );
+        if (roleIds != null && !roleIds.isEmpty()) {
+            clientMembershipService.updateRoles(
+                membership.id(), registeredClientId, applicationId, tenantId, roleIds
+            );
+        }
+        return membership;
+    }
+}

--- a/src/test/java/com/stucray/limen/oauth2/OAuth2AuthorizeMembershipGateIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/OAuth2AuthorizeMembershipGateIntegrationTest.java
@@ -1,0 +1,328 @@
+package com.stucray.limen.oauth2;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jwt.SignedJWT;
+import com.stucray.limen.TestcontainersConfiguration;
+import com.stucray.limen.management.applications.Application;
+import com.stucray.limen.management.applications.ApplicationRepository;
+import com.stucray.limen.management.clients.TenantClient;
+import com.stucray.limen.management.clients.TenantClientRepository;
+import com.stucray.limen.management.memberships.ApplicationMembershipService;
+import com.stucray.limen.management.memberships.ClientMembershipService;
+import com.stucray.limen.management.memberships.ClientMembershipTestFixture;
+import com.stucray.limen.management.roles.Role;
+import com.stucray.limen.management.roles.RoleRepository;
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantProvisioningService;
+import com.stucray.limen.user.User;
+import com.stucray.limen.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.oidc.OidcScopes;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * /oauth2/authorize Client Membership gate (slice 5 / #44). End-User Login
+ * succeeds in every test — the gate sits one step downstream and rejects the
+ * authorization code request with {@code access_denied} when no
+ * {@code client_membership} row exists for {@code (user, registeredClient,
+ * tenant)}. Membership presence (not Role count) is the gate; cross-tenant
+ * isolation is checked by attempting a flow with a User authenticated against
+ * a different Tenant's URL.
+ */
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+class OAuth2AuthorizeMembershipGateIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired TenantProvisioningService tenantProvisioningService;
+    @Autowired ApplicationRepository applicationRepository;
+    @Autowired RoleRepository roleRepository;
+    @Autowired ApplicationMembershipService applicationMembershipService;
+    @Autowired ClientMembershipService clientMembershipService;
+    @Autowired RegisteredClientRepository registeredClientRepository;
+    @Autowired TenantClientRepository tenantClientRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired PasswordEncoder passwordEncoder;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    Tenant alphaTenant;
+    Tenant betaTenant;
+    Application alphaApp;
+    Application betaApp;
+    User aliceAlpha;
+    User adminAlpha;
+    User bobBeta;
+    User adminBeta;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.execute("DELETE FROM client_membership");
+        jdbcTemplate.execute("DELETE FROM application_membership_role");
+        jdbcTemplate.execute("DELETE FROM application_membership");
+        jdbcTemplate.execute("DELETE FROM role");
+        jdbcTemplate.execute("DELETE FROM oauth2_registered_client WHERE application_id IS NOT NULL");
+        jdbcTemplate.execute("DELETE FROM applications");
+        jdbcTemplate.execute("DELETE FROM users WHERE tenant_id != (SELECT id FROM tenants WHERE slug = 'system')");
+        jdbcTemplate.execute("DELETE FROM tenants WHERE slug != 'system'");
+
+        alphaTenant = tenantProvisioningService.createTenant("gate-alpha", "Gate Alpha");
+        betaTenant = tenantProvisioningService.createTenant("gate-beta", "Gate Beta");
+        alphaApp = applicationRepository.save(new Application(
+            null, alphaTenant.id(), "Alpha App", null, LocalDateTime.now()
+        ));
+        betaApp = applicationRepository.save(new Application(
+            null, betaTenant.id(), "Beta App", null, LocalDateTime.now()
+        ));
+        aliceAlpha = userRepository.save(new User(
+            null, alphaTenant.id(), "alice",
+            passwordEncoder.encode("password"),
+            true, false, false, LocalDateTime.now()
+        ));
+        adminAlpha = userRepository.save(new User(
+            null, alphaTenant.id(), "alpha-admin",
+            passwordEncoder.encode("password"),
+            true, false, true, LocalDateTime.now()
+        ));
+        bobBeta = userRepository.save(new User(
+            null, betaTenant.id(), "bob",
+            passwordEncoder.encode("password"),
+            true, false, false, LocalDateTime.now()
+        ));
+        adminBeta = userRepository.save(new User(
+            null, betaTenant.id(), "beta-admin",
+            passwordEncoder.encode("password"),
+            true, false, true, LocalDateTime.now()
+        ));
+    }
+
+    @Test
+    void userWithoutClientMembershipIsDeniedAtAuthorize() throws Exception {
+        TenantClient client = createPkceClient(alphaApp, alphaTenant, "no-membership-client");
+
+        // alice authenticates successfully; the gate rejects the authorization
+        // request with access_denied (302 to redirect_uri).
+        String location = runFlowToAuthorizeRedirect(alphaTenant.slug(), client, "alice", "password");
+
+        Map<String, String> params = queryParams(location);
+        assertThat(params.get("error")).isEqualTo("access_denied");
+        assertThat(params.get("state")).isEqualTo("s1");
+        assertThat(params).doesNotContainKey("code");
+    }
+
+    @Test
+    void userWithMembershipAndZeroRolesPassesGate() throws Exception {
+        TenantClient client = createPkceClient(alphaApp, alphaTenant, "zero-roles-client");
+        ClientMembershipTestFixture.grant(
+            applicationMembershipService, clientMembershipService,
+            alphaApp.id(), alphaTenant.id(), aliceAlpha.id(), adminAlpha.id(),
+            client.registeredClientId(), Set.of()
+        );
+
+        Map<String, Object> claims = runFlowAndExtractJwtClaims(
+            alphaTenant.slug(), client, "alice", "password"
+        );
+
+        assertThat(claims.get("tenant")).isEqualTo("gate-alpha");
+        assertThat((List<?>) claims.get("roles")).isEmpty();
+    }
+
+    @Test
+    void userWithMembershipAndRolesGetsJwtWithRoles() throws Exception {
+        TenantClient client = createPkceClient(alphaApp, alphaTenant, "with-roles-client");
+        Role viewer = roleRepository.save(new Role(null, alphaApp.id(), "viewer", null, LocalDateTime.now()));
+        Role editor = roleRepository.save(new Role(null, alphaApp.id(), "editor", null, LocalDateTime.now()));
+        ClientMembershipTestFixture.grant(
+            applicationMembershipService, clientMembershipService,
+            alphaApp.id(), alphaTenant.id(), aliceAlpha.id(), adminAlpha.id(),
+            client.registeredClientId(), Set.of(viewer.id(), editor.id())
+        );
+
+        Map<String, Object> claims = runFlowAndExtractJwtClaims(
+            alphaTenant.slug(), client, "alice", "password"
+        );
+
+        assertThat(claims.get("tenant")).isEqualTo("gate-alpha");
+        @SuppressWarnings("unchecked")
+        List<String> roles = (List<String>) claims.get("roles");
+        assertThat(roles).containsExactly("editor", "viewer");
+    }
+
+    @Test
+    void crossTenantUserIsRejectedBeforeReachingGate() throws Exception {
+        // bob (Tenant Beta) attempting to login against Tenant Alpha's URL is
+        // force-logged-out by TenantAccessFilter from v1 — login fails outright,
+        // so the gate never gets to evaluate. We assert the failure so the
+        // existing isolation contract is documented alongside the new gate.
+        TenantClient alphaClient = createPkceClient(alphaApp, alphaTenant, "cross-tenant-client");
+        ClientMembershipTestFixture.grant(
+            applicationMembershipService, clientMembershipService,
+            betaApp.id(), betaTenant.id(), bobBeta.id(), adminBeta.id(),
+            createPkceClient(betaApp, betaTenant, "beta-client").registeredClientId(),
+            Set.of()
+        );
+
+        MockHttpSession session = new MockHttpSession();
+        String authzUri = authorizeUri(alphaTenant.slug(), alphaClient, pkceChallenge());
+        mockMvc.perform(get(authzUri).session(session))
+            .andExpect(status().is3xxRedirection());
+
+        // bob's credentials don't validate against Tenant Alpha's User pool.
+        mockMvc.perform(post("/t/" + alphaTenant.slug() + "/login")
+                .param("username", "bob").param("password", "password")
+                .session(session).with(csrf()))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(result ->
+                assertThat(result.getResponse().getHeader("Location")).contains("error")
+            );
+    }
+
+    private TenantClient createPkceClient(Application application, Tenant tenant, String name) {
+        String internalId = UUID.randomUUID().toString();
+        String clientId = UUID.randomUUID().toString();
+        RegisteredClient rc = RegisteredClient.withId(internalId)
+            .clientId(clientId)
+            .clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .redirectUri("http://localhost/callback")
+            .scope(OidcScopes.OPENID)
+            .clientSettings(ClientSettings.builder()
+                .requireProofKey(true)
+                .requireAuthorizationConsent(false)
+                .build())
+            .build();
+        registeredClientRepository.save(rc);
+        return tenantClientRepository.save(new TenantClient(
+            null, internalId, application.id(), tenant.id(), name, false
+        ));
+    }
+
+    private String runFlowToAuthorizeRedirect(
+        String slug, TenantClient client, String username, String password
+    ) throws Exception {
+        Pkce pkce = pkce();
+        MockHttpSession session = new MockHttpSession();
+        String authzUri = authorizeUri(slug, client, pkce.challenge());
+
+        mockMvc.perform(get(authzUri).session(session))
+            .andExpect(status().is3xxRedirection());
+
+        mockMvc.perform(post("/t/" + slug + "/login")
+                .param("username", username).param("password", password)
+                .session(session).with(csrf()))
+            .andExpect(status().is3xxRedirection());
+
+        MvcResult result = mockMvc.perform(get(authzUri).session(session))
+            .andExpect(status().is3xxRedirection())
+            .andReturn();
+
+        return result.getResponse().getHeader("Location");
+    }
+
+    private Map<String, Object> runFlowAndExtractJwtClaims(
+        String slug, TenantClient client, String username, String password
+    ) throws Exception {
+        Pkce pkce = pkce();
+        MockHttpSession session = new MockHttpSession();
+        String authzUri = authorizeUri(slug, client, pkce.challenge());
+
+        mockMvc.perform(get(authzUri).session(session))
+            .andExpect(status().is3xxRedirection());
+        mockMvc.perform(post("/t/" + slug + "/login")
+                .param("username", username).param("password", password)
+                .session(session).with(csrf()))
+            .andExpect(status().is3xxRedirection());
+        MvcResult codeResult = mockMvc.perform(get(authzUri).session(session))
+            .andExpect(status().is3xxRedirection())
+            .andReturn();
+        String code = queryParams(codeResult.getResponse().getHeader("Location")).get("code");
+        assertThat(code).isNotBlank();
+
+        String oauthClientId = jdbcTemplate.queryForObject(
+            "SELECT client_id FROM oauth2_registered_client WHERE id = ?",
+            String.class, client.registeredClientId()
+        );
+        String tokenJson = mockMvc.perform(post("/t/" + slug + "/oauth2/token")
+                .param("grant_type", "authorization_code")
+                .param("code", code)
+                .param("redirect_uri", "http://localhost/callback")
+                .param("code_verifier", pkce.verifier())
+                .param("client_id", oauthClientId))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.access_token").exists())
+            .andReturn().getResponse().getContentAsString();
+
+        String accessToken = objectMapper.readTree(tokenJson).get("access_token").asText();
+        return SignedJWT.parse(accessToken).getJWTClaimsSet().getClaims();
+    }
+
+    private String authorizeUri(String slug, TenantClient client, String challenge) {
+        String oauthClientId = jdbcTemplate.queryForObject(
+            "SELECT client_id FROM oauth2_registered_client WHERE id = ?",
+            String.class, client.registeredClientId()
+        );
+        return UriComponentsBuilder.fromPath("/t/" + slug + "/oauth2/authorize")
+            .queryParam("response_type", "code")
+            .queryParam("client_id", oauthClientId)
+            .queryParam("redirect_uri", "http://localhost/callback")
+            .queryParam("scope", OidcScopes.OPENID)
+            .queryParam("state", "s1")
+            .queryParam("code_challenge", challenge)
+            .queryParam("code_challenge_method", "S256")
+            .build().toUriString();
+    }
+
+    private static Map<String, String> queryParams(String location) {
+        return UriComponentsBuilder.fromUriString(location).build()
+            .getQueryParams().toSingleValueMap();
+    }
+
+    private static Pkce pkce() throws Exception {
+        byte[] verifierBytes = new byte[32];
+        new SecureRandom().nextBytes(verifierBytes);
+        String verifier = Base64.getUrlEncoder().withoutPadding().encodeToString(verifierBytes);
+        byte[] hash = MessageDigest.getInstance("SHA-256").digest(verifier.getBytes(StandardCharsets.US_ASCII));
+        String challenge = Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+        return new Pkce(verifier, challenge);
+    }
+
+    private static String pkceChallenge() throws Exception {
+        return pkce().challenge();
+    }
+
+    private record Pkce(String verifier, String challenge) {}
+}

--- a/src/test/java/com/stucray/limen/oauth2/OAuth2ForcedPasswordChangeIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/OAuth2ForcedPasswordChangeIntegrationTest.java
@@ -5,6 +5,9 @@ import com.stucray.limen.management.applications.Application;
 import com.stucray.limen.management.applications.ApplicationRepository;
 import com.stucray.limen.management.clients.TenantClient;
 import com.stucray.limen.management.clients.TenantClientRepository;
+import com.stucray.limen.management.memberships.ApplicationMembershipService;
+import com.stucray.limen.management.memberships.ClientMembershipService;
+import com.stucray.limen.management.memberships.ClientMembershipTestFixture;
 import com.stucray.limen.tenant.Tenant;
 import com.stucray.limen.tenant.TenantRepository;
 import com.stucray.limen.tenant.TenantStatus;
@@ -34,6 +37,7 @@ import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.time.LocalDateTime;
 import java.util.Base64;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -53,12 +57,15 @@ class OAuth2ForcedPasswordChangeIntegrationTest {
     @Autowired RegisteredClientRepository registeredClientRepository;
     @Autowired TenantClientRepository tenantClientRepository;
     @Autowired UserRepository userRepository;
+    @Autowired ApplicationMembershipService applicationMembershipService;
+    @Autowired ClientMembershipService clientMembershipService;
     @Autowired PasswordEncoder passwordEncoder;
     @Autowired JdbcTemplate jdbcTemplate;
 
     Tenant tenant;
     Application app;
     String oauthClientId;
+    String registeredClientId;
 
     @BeforeEach
     void setUp() {
@@ -76,9 +83,9 @@ class OAuth2ForcedPasswordChangeIntegrationTest {
         app = applicationRepository.save(new Application(
             null, tenant.id(), "Alpha App", "Test app", LocalDateTime.now()));
 
-        String internalId = UUID.randomUUID().toString();
+        registeredClientId = UUID.randomUUID().toString();
         oauthClientId = UUID.randomUUID().toString();
-        RegisteredClient rc = RegisteredClient.withId(internalId)
+        RegisteredClient rc = RegisteredClient.withId(registeredClientId)
             .clientId(oauthClientId)
             .clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
             .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
@@ -91,7 +98,7 @@ class OAuth2ForcedPasswordChangeIntegrationTest {
             .build();
         registeredClientRepository.save(rc);
         tenantClientRepository.save(new TenantClient(
-            null, internalId, app.id(), tenant.id(), "Test Client", false));
+            null, registeredClientId, app.id(), tenant.id(), "Test Client", false));
     }
 
     @Test
@@ -119,6 +126,11 @@ class OAuth2ForcedPasswordChangeIntegrationTest {
             null, tenant.id(), "alice",
             passwordEncoder.encode("temp"),
             true, true, false, LocalDateTime.now()));
+        ClientMembershipTestFixture.grant(
+            applicationMembershipService, clientMembershipService,
+            app.id(), tenant.id(), original.id(), original.id(),
+            registeredClientId, Set.of()
+        );
 
         MockHttpSession session = startAuthorize(newPkce().challenge());
 

--- a/src/test/java/com/stucray/limen/oauth2/OAuth2JwtRolesClaimIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/OAuth2JwtRolesClaimIntegrationTest.java
@@ -8,8 +8,8 @@ import com.stucray.limen.management.applications.ApplicationRepository;
 import com.stucray.limen.management.clients.TenantClient;
 import com.stucray.limen.management.clients.TenantClientRepository;
 import com.stucray.limen.management.memberships.ApplicationMembershipService;
-import com.stucray.limen.management.memberships.ClientMembership;
 import com.stucray.limen.management.memberships.ClientMembershipService;
+import com.stucray.limen.management.memberships.ClientMembershipTestFixture;
 import com.stucray.limen.management.roles.Role;
 import com.stucray.limen.management.roles.RoleRepository;
 import com.stucray.limen.tenant.Tenant;
@@ -52,11 +52,12 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
- * Slice 4 (#43) end-to-end: a User with an Application Membership and a Client
- * Membership carrying Roles completes the authorization code + PKCE flow, and
- * the resulting JWT carries the Roles in the {@code roles} claim. Also covers
- * the negative branch — a User without Client Membership still issues a token
- * with empty {@code roles} (slice 5 / #44 is what later turns this into a gate).
+ * End-to-end: a User with an Application Membership and a Client Membership
+ * carrying Roles completes the authorization code + PKCE flow, and the
+ * resulting JWT carries the Roles in the {@code roles} claim. The
+ * Membership-without-Roles branch still issues a token with empty
+ * {@code roles}; the no-Membership branch is rejected by the gate (slice 5 /
+ * #44) and is covered in {@link OAuth2AuthorizeMembershipGateIntegrationTest}.
  */
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
@@ -117,13 +118,10 @@ class OAuth2JwtRolesClaimIntegrationTest {
         TenantClient client = createPkceClient("acme-spa");
 
         // 2. Grant Application + Client Membership and assign the Roles.
-        applicationMembershipService.grant(app.id(), tenant.id(), alice.id(), admin.id());
-        ClientMembership cm = clientMembershipService.grant(
-            client.registeredClientId(), app.id(), tenant.id(), alice.id(), admin.id()
-        );
-        clientMembershipService.updateRoles(
-            cm.id(), client.registeredClientId(), app.id(), tenant.id(),
-            Set.of(viewer.id(), editor.id())
+        ClientMembershipTestFixture.grant(
+            applicationMembershipService, clientMembershipService,
+            app.id(), tenant.id(), alice.id(), admin.id(),
+            client.registeredClientId(), Set.of(viewer.id(), editor.id())
         );
 
         // 3. Run the authorization code + PKCE flow as alice.
@@ -139,10 +137,15 @@ class OAuth2JwtRolesClaimIntegrationTest {
     }
 
     @Test
-    void jwtCarriesEmptyRolesWhenUserHasNoClientMembership() throws Exception {
-        // No Memberships granted — slice 4 still issues the token (the gate is
-        // slice 5). roles must be the empty list.
-        TenantClient client = createPkceClient("acme-spa-no-membership");
+    void jwtCarriesEmptyRolesWhenMembershipHasNoRolesAssigned() throws Exception {
+        // Membership presence (not Role count) is the gate — Membership without
+        // Roles passes the gate and yields a JWT with roles: [].
+        TenantClient client = createPkceClient("acme-spa-no-roles");
+        ClientMembershipTestFixture.grant(
+            applicationMembershipService, clientMembershipService,
+            app.id(), tenant.id(), alice.id(), admin.id(),
+            client.registeredClientId(), Set.of()
+        );
 
         Map<String, Object> claims = runAuthorizationCodeFlow(client, "alice");
 

--- a/src/test/java/com/stucray/limen/oauth2/TenantOAuth2RoutingIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/TenantOAuth2RoutingIntegrationTest.java
@@ -14,6 +14,9 @@ import com.stucray.limen.management.clients.ClientManagementService;
 import com.stucray.limen.management.clients.ClientManagementService.ClientCreationResult;
 import com.stucray.limen.management.clients.TenantClient;
 import com.stucray.limen.management.clients.TenantClientRepository;
+import com.stucray.limen.management.memberships.ApplicationMembershipService;
+import com.stucray.limen.management.memberships.ClientMembershipService;
+import com.stucray.limen.management.memberships.ClientMembershipTestFixture;
 import com.stucray.limen.tenant.Tenant;
 import com.stucray.limen.tenant.TenantProvisioningService;
 import com.stucray.limen.tenant.TenantRepository;
@@ -70,6 +73,8 @@ class TenantOAuth2RoutingIntegrationTest {
     @Autowired RegisteredClientRepository registeredClientRepository;
     @Autowired TenantClientRepository tenantClientRepository;
     @Autowired UserRepository userRepository;
+    @Autowired ApplicationMembershipService applicationMembershipService;
+    @Autowired ClientMembershipService clientMembershipService;
     @Autowired PasswordEncoder passwordEncoder;
     @Autowired JdbcTemplate jdbcTemplate;
 
@@ -78,6 +83,7 @@ class TenantOAuth2RoutingIntegrationTest {
     Tenant alphaCorpTenant;
     Tenant betaCorpTenant;
     Application alphaApp;
+    User alphaAdmin;
 
     @BeforeEach
     void setUp() {
@@ -97,6 +103,11 @@ class TenantOAuth2RoutingIntegrationTest {
         betaCorpTenant = tenantProvisioningService.createTenant("beta-corp", "Beta Corp");
         alphaApp = applicationRepository.save(new Application(
             null, alphaCorpTenant.id(), "Alpha App", "Test app", LocalDateTime.now()
+        ));
+        alphaAdmin = userRepository.save(new User(
+            null, alphaCorpTenant.id(), "alpha-admin",
+            passwordEncoder.encode("password"),
+            true, false, true, LocalDateTime.now()
         ));
     }
 
@@ -218,7 +229,7 @@ class TenantOAuth2RoutingIntegrationTest {
 
     @Test
     void authorizationCodePkceFlowProducesTokenWithTenantClaims() throws Exception {
-        userRepository.save(new User(
+        User alice = userRepository.save(new User(
             null, alphaCorpTenant.id(), "alice",
             passwordEncoder.encode("password"),
             true, false, false, LocalDateTime.now()
@@ -242,6 +253,11 @@ class TenantOAuth2RoutingIntegrationTest {
         tenantClientRepository.save(new TenantClient(
             null, internalId, alphaApp.id(), alphaCorpTenant.id(), "PKCE Test Client", false
         ));
+        ClientMembershipTestFixture.grant(
+            applicationMembershipService, clientMembershipService,
+            alphaApp.id(), alphaCorpTenant.id(), alice.id(), alphaAdmin.id(),
+            internalId, Set.of()
+        );
 
         // PKCE code verifier + challenge
         byte[] verifierBytes = new byte[32];
@@ -360,7 +376,7 @@ class TenantOAuth2RoutingIntegrationTest {
 
     @Test
     void userinfoEndpointReturnsClaimsForTenantUser() throws Exception {
-        userRepository.save(new User(
+        User bob = userRepository.save(new User(
             null, alphaCorpTenant.id(), "bob",
             passwordEncoder.encode("password"),
             true, false, false, LocalDateTime.now()
@@ -383,6 +399,11 @@ class TenantOAuth2RoutingIntegrationTest {
         tenantClientRepository.save(new TenantClient(
             null, internalId, alphaApp.id(), alphaCorpTenant.id(), "UserInfo Test Client", false
         ));
+        ClientMembershipTestFixture.grant(
+            applicationMembershipService, clientMembershipService,
+            alphaApp.id(), alphaCorpTenant.id(), bob.id(), alphaAdmin.id(),
+            internalId, Set.of()
+        );
 
         byte[] verifierBytes = new byte[32];
         new SecureRandom().nextBytes(verifierBytes);


### PR DESCRIPTION
## Summary

Closes #44 — final backend slice of v2 (PRD #39).

- `MembershipGateFilter` enforces `client_membership` at `/oauth2/authorize`. Authenticated User without a Membership row → 302 with `error=access_denied&state=...` to the Client's `redirect_uri` per RFC 6749 §4.1.2.1.
- End-User Login at `/t/{slug}/login` is unchanged — credentials still validate against the Tenant's User pool. AuthN and AuthZ remain separable failures.
- Membership presence is the gate (not Role count). A User with a Client Membership and zero Roles passes; the JWT carries `roles: []`.

## Implementation note (research-spike outcome)

The PRD's preferred approach was an `AuthenticationProvider` decorator on `OAuth2AuthorizationCodeRequestAuthenticationProvider`. The spike showed it doesn't work in SAS 7.0:

- **Wrapping or replacing** the original provider breaks SAS's `OAuth2AuthorizationEndpointConfigurer.init()`, which captures the validator composite via reflection on the *original* class via an `instanceof` check after the `authenticationProviders(consumer)` callback runs. Without the composite, `OAuth2AuthorizationCodeRequestValidatingFilter` fails its constructor's `Assert.notNull(authenticationValidator)`.
- **Inserting alongside** the original provider lets both run. Spring's `ProviderManager` catches our gate's `AuthenticationException` and falls through to the original provider, which then issues an authorization code anyway.

A pre-endpoint filter has none of these failure modes. The PRD explicitly allowed for "AuthenticationProvider decorator (or pre-flight filter)"; filter wins. There is a comment block on `MembershipGateFilter` documenting the same.

## Tests

`OAuth2AuthorizeMembershipGateIntegrationTest` covers the four AC branches:
- No Membership → `access_denied` redirect with original `state`, no `code`
- Membership with zero Roles passes the gate, JWT carries `roles: []`
- Membership with Roles passes the gate, JWT carries the Roles
- Cross-tenant User is force-logged-out by v1's `TenantAccessFilter` before reaching the gate

Five pre-existing OAuth2-flow tests (`TenantOAuth2RoutingIntegrationTest`, `OAuth2JwtRolesClaimIntegrationTest`, `OAuth2ForcedPasswordChangeIntegrationTest`, `ClientTokenSettingsIntegrationTest`) now grant Memberships in setup via the new `ClientMembershipTestFixture` helper, satisfying the AC line about a single fixture utility for grant-Membership boilerplate.

Full suite: 184 tests, 0 failures.

## Test plan

- [x] `./mvnw test` — 184/184 green
- [x] No-Membership User attempts `/oauth2/authorize` → `access_denied` 302 to `redirect_uri`
- [x] Membership-with-zero-Roles User → flow completes, JWT `roles: []`
- [x] Membership-with-Roles User → flow completes, JWT carries Roles
- [x] Cross-tenant User → blocked by `TenantAccessFilter` (v1 contract intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)