### PR TITLE
v2 slice 6: User detail — read-only Memberships display (#45)

### DIFF
--- a/src/main/java/com/stucray/limen/management/memberships/UserMembershipPortfolioQuery.java
+++ b/src/main/java/com/stucray/limen/management/memberships/UserMembershipPortfolioQuery.java
@@ -1,0 +1,149 @@
+package com.stucray.limen.management.memberships;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowCallbackHandler;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Read-only portfolio view of every Membership belonging to a single User
+ * within a single Tenant. Backs the User detail screen.
+ *
+ * Two SELECTs (one per membership table), assembled in Java. Each SELECT
+ * carries a {@code tenant_id} predicate as defence-in-depth, matching the
+ * existing pattern in {@link ClientMembershipQuery} — the FK chains already
+ * enforce containment, but the explicit predicate stops a stray cross-tenant
+ * join from leaking Roles.
+ */
+@Component
+public class UserMembershipPortfolioQuery {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public UserMembershipPortfolioQuery(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public record AppMembershipView(
+        Long applicationMembershipId,
+        Long applicationId,
+        String applicationName,
+        List<String> appRoles,
+        List<ClientMembershipView> clientMemberships
+    ) {}
+
+    public record ClientMembershipView(
+        Long clientMembershipId,
+        String registeredClientId,
+        String clientDisplayName,
+        List<String> clientRoles
+    ) {}
+
+    public List<AppMembershipView> portfolioFor(Long userId, Long tenantId) {
+        if (userId == null || tenantId == null) {
+            return List.of();
+        }
+
+        Map<Long, AppBuilder> byAppMembershipId = new LinkedHashMap<>();
+        jdbcTemplate.query(
+            """
+            SELECT am.id   AS app_membership_id,
+                   a.id    AS application_id,
+                   a.name  AS application_name,
+                   r.name  AS role_name
+              FROM application_membership am
+              JOIN applications a ON a.id = am.application_id
+         LEFT JOIN application_membership_role amr ON amr.application_membership_id = am.id
+         LEFT JOIN role r ON r.id = amr.role_id
+             WHERE am.user_id = ?
+               AND a.tenant_id = ?
+             ORDER BY lower(a.name), lower(r.name)
+            """,
+            (RowCallbackHandler) rs -> {
+                Long ammId = rs.getLong("app_membership_id");
+                Long applicationId = rs.getLong("application_id");
+                String applicationName = rs.getString("application_name");
+                String roleName = rs.getString("role_name");
+                AppBuilder app = byAppMembershipId.computeIfAbsent(ammId,
+                    k -> new AppBuilder(ammId, applicationId, applicationName));
+                if (roleName != null) app.appRoles.add(roleName);
+            },
+            userId, tenantId
+        );
+
+        jdbcTemplate.query(
+            """
+            SELECT cm.id                          AS client_membership_id,
+                   cm.application_membership_id   AS app_membership_id,
+                   m.registered_client_id         AS registered_client_id,
+                   m.display_name                 AS client_display_name,
+                   r.name                         AS role_name
+              FROM client_membership cm
+              JOIN client_metadata m ON m.id = cm.client_metadata_id
+         LEFT JOIN client_membership_role cmr ON cmr.client_membership_id = cm.id
+         LEFT JOIN role r ON r.id = cmr.role_id
+             WHERE cm.user_id = ?
+               AND m.tenant_id = ?
+             ORDER BY lower(m.display_name), lower(r.name)
+            """,
+            (RowCallbackHandler) rs -> {
+                Long ammId = rs.getLong("app_membership_id");
+                AppBuilder app = byAppMembershipId.get(ammId);
+                if (app == null) return;
+                Long cmId = rs.getLong("client_membership_id");
+                String registeredClientId = rs.getString("registered_client_id");
+                String clientDisplayName = rs.getString("client_display_name");
+                String roleName = rs.getString("role_name");
+                ClientBuilder client = app.clients.computeIfAbsent(cmId,
+                    k -> new ClientBuilder(cmId, registeredClientId, clientDisplayName));
+                if (roleName != null) client.roles.add(roleName);
+            },
+            userId, tenantId
+        );
+
+        List<AppMembershipView> out = new ArrayList<>(byAppMembershipId.size());
+        for (AppBuilder app : byAppMembershipId.values()) {
+            List<ClientMembershipView> clients = new ArrayList<>(app.clients.size());
+            for (ClientBuilder client : app.clients.values()) {
+                clients.add(new ClientMembershipView(
+                    client.id, client.registeredClientId, client.displayName, client.roles
+                ));
+            }
+            out.add(new AppMembershipView(
+                app.id, app.applicationId, app.applicationName, app.appRoles, clients
+            ));
+        }
+        return out;
+    }
+
+    private static final class AppBuilder {
+        final Long id;
+        final Long applicationId;
+        final String applicationName;
+        final List<String> appRoles = new ArrayList<>();
+        final Map<Long, ClientBuilder> clients = new LinkedHashMap<>();
+
+        AppBuilder(Long id, Long applicationId, String applicationName) {
+            this.id = id;
+            this.applicationId = applicationId;
+            this.applicationName = applicationName;
+        }
+    }
+
+    private static final class ClientBuilder {
+        final Long id;
+        final String registeredClientId;
+        final String displayName;
+        final List<String> roles = new ArrayList<>();
+
+        ClientBuilder(Long id, String registeredClientId, String displayName) {
+            this.id = id;
+            this.registeredClientId = registeredClientId;
+            this.displayName = displayName;
+        }
+    }
+}

--- a/src/main/java/com/stucray/limen/management/users/UserManagementController.java
+++ b/src/main/java/com/stucray/limen/management/users/UserManagementController.java
@@ -1,6 +1,7 @@
 package com.stucray.limen.management.users;
 
 import com.stucray.limen.auth.TenantUserDetails;
+import com.stucray.limen.management.memberships.UserMembershipPortfolioQuery;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -11,9 +12,14 @@ import org.springframework.web.bind.annotation.*;
 public class UserManagementController {
 
     private final UserManagementService userManagementService;
+    private final UserMembershipPortfolioQuery userMembershipPortfolioQuery;
 
-    public UserManagementController(UserManagementService userManagementService) {
+    public UserManagementController(
+        UserManagementService userManagementService,
+        UserMembershipPortfolioQuery userMembershipPortfolioQuery
+    ) {
         this.userManagementService = userManagementService;
+        this.userMembershipPortfolioQuery = userMembershipPortfolioQuery;
     }
 
     @GetMapping
@@ -80,6 +86,19 @@ public class UserManagementController {
     ) {
         userManagementService.deleteUser(userId, principal.tenantId());
         return "redirect:/manage/t/" + slug + "/users";
+    }
+
+    @GetMapping("/{userId}")
+    public String detail(
+        @PathVariable String slug,
+        @PathVariable Long userId,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        Model model
+    ) {
+        model.addAttribute("slug", slug);
+        model.addAttribute("user", userManagementService.getUser(userId, principal.tenantId()));
+        model.addAttribute("appMemberships", userMembershipPortfolioQuery.portfolioFor(userId, principal.tenantId()));
+        return "manage/users/detail";
     }
 
     @GetMapping("/{userId}/reset-password")

--- a/src/main/resources/templates/manage/users/detail.html
+++ b/src/main/resources/templates/manage/users/detail.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head><title th:text="'User · ' + ${user.username()}">User</title></head>
+<body>
+<h1 th:text="${user.username()}">username</h1>
+<a th:href="@{'/manage/t/' + ${slug} + '/users'}">← Users</a>
+
+<dl>
+    <dt>Status</dt>
+    <dd th:text="${user.enabled()} ? 'Active' : 'Disabled'"></dd>
+    <dt>Tenant Owner</dt>
+    <dd th:text="${user.tenantOwner()} ? 'Yes' : 'No'"></dd>
+</dl>
+
+<h2>Memberships</h2>
+
+<p th:if="${#lists.isEmpty(appMemberships)}">
+    No Memberships yet.
+    Grant this User access from an
+    <a th:href="@{'/manage/t/' + ${slug} + '/applications'}">Application</a>.
+</p>
+
+<ul th:unless="${#lists.isEmpty(appMemberships)}" class="memberships">
+    <li th:each="app : ${appMemberships}">
+        <a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.applicationId()} + '/members'}"
+           th:text="${app.applicationName()}">App name</a>
+        <span th:if="${#lists.isEmpty(app.appRoles())}"> — no App Roles</span>
+        <span th:unless="${#lists.isEmpty(app.appRoles())}">
+            — App Roles: <span th:text="${#strings.listJoin(app.appRoles(), ', ')}">role names</span>
+        </span>
+
+        <ul th:if="${!#lists.isEmpty(app.clientMemberships())}">
+            <li th:each="client : ${app.clientMemberships()}">
+                <a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.applicationId()} + '/clients/' + ${client.registeredClientId()} + '/members'}"
+                   th:text="${client.clientDisplayName()}">Client name</a>
+                <span th:if="${#lists.isEmpty(client.clientRoles())}"> — no Client Roles</span>
+                <span th:unless="${#lists.isEmpty(client.clientRoles())}">
+                    — Client Roles: <span th:text="${#strings.listJoin(client.clientRoles(), ', ')}">role names</span>
+                </span>
+            </li>
+        </ul>
+    </li>
+</ul>
+</body>
+</html>

--- a/src/main/resources/templates/manage/users/list.html
+++ b/src/main/resources/templates/manage/users/list.html
@@ -17,7 +17,7 @@
     </thead>
     <tbody>
         <tr th:each="user : ${users}">
-            <td th:text="${user.username()}"></td>
+            <td><a th:href="@{'/manage/t/' + ${slug} + '/users/' + ${user.id()}}" th:text="${user.username()}"></a></td>
             <td th:text="${user.enabled() ? 'Active' : 'Disabled'}"></td>
             <td th:text="${user.tenantOwner() ? 'Yes' : 'No'}"></td>
             <td>

--- a/src/test/java/com/stucray/limen/management/users/UserDetailControllerIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/users/UserDetailControllerIntegrationTest.java
@@ -1,0 +1,191 @@
+package com.stucray.limen.management.users;
+
+import com.stucray.limen.TestcontainersConfiguration;
+import com.stucray.limen.management.applications.Application;
+import com.stucray.limen.management.applications.ApplicationRepository;
+import com.stucray.limen.management.clients.ClientManagementService;
+import com.stucray.limen.management.clients.TenantClient;
+import com.stucray.limen.management.memberships.ApplicationMembership;
+import com.stucray.limen.management.memberships.ApplicationMembershipRepository;
+import com.stucray.limen.management.memberships.ApplicationMembershipRole;
+import com.stucray.limen.management.memberships.ClientMembership;
+import com.stucray.limen.management.memberships.ClientMembershipRepository;
+import com.stucray.limen.management.memberships.ClientMembershipRole;
+import com.stucray.limen.management.roles.Role;
+import com.stucray.limen.management.roles.RoleRepository;
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.tenant.TenantStatus;
+import com.stucray.limen.user.User;
+import com.stucray.limen.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+class UserDetailControllerIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired TenantRepository tenantRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired ApplicationRepository applicationRepository;
+    @Autowired RoleRepository roleRepository;
+    @Autowired ApplicationMembershipRepository appMembershipRepository;
+    @Autowired ClientMembershipRepository clientMembershipRepository;
+    @Autowired ClientManagementService clientManagementService;
+    @Autowired PasswordEncoder passwordEncoder;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    Tenant tenantA;
+    Tenant tenantB;
+    User ownerA;
+    User aliceA;
+    Application appA;
+    TenantClient clientA;
+    MockHttpSession sessionA;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        jdbcTemplate.execute("DELETE FROM client_membership");
+        jdbcTemplate.execute("DELETE FROM application_membership_role");
+        jdbcTemplate.execute("DELETE FROM application_membership");
+        jdbcTemplate.execute("DELETE FROM role");
+        jdbcTemplate.execute("DELETE FROM oauth2_registered_client WHERE application_id IS NOT NULL");
+        jdbcTemplate.execute("DELETE FROM applications");
+        jdbcTemplate.execute("DELETE FROM users WHERE tenant_id IN (SELECT id FROM tenants WHERE slug != 'system')");
+        jdbcTemplate.execute("DELETE FROM tenants WHERE slug != 'system'");
+
+        tenantA = tenantRepository.save(new Tenant(null, "user-detail-a", "User Detail A", TenantStatus.ACTIVE, LocalDateTime.now()));
+        tenantB = tenantRepository.save(new Tenant(null, "user-detail-b", "User Detail B", TenantStatus.ACTIVE, LocalDateTime.now()));
+        ownerA = userRepository.save(new User(null, tenantA.id(), "owner", passwordEncoder.encode("pass"), true, false, true,  LocalDateTime.now()));
+        aliceA = userRepository.save(new User(null, tenantA.id(), "alice", passwordEncoder.encode("pass"), true, false, false, LocalDateTime.now()));
+        appA = applicationRepository.save(new Application(null, tenantA.id(), "Acme Web", "desc", LocalDateTime.now()));
+        clientA = clientManagementService.createClient(
+            appA.id(), tenantA.id(), "acme-spa",
+            Set.of(AuthorizationGrantType.AUTHORIZATION_CODE),
+            Set.of("http://localhost/callback"), Set.of(), Set.of("openid"),
+            false, true, 5, 30, false
+        ).client();
+
+        MvcResult login = mockMvc.perform(post("/manage/t/user-detail-a/login")
+                .param("username", "owner").param("password", "pass").with(csrf()))
+            .andReturn();
+        sessionA = (MockHttpSession) login.getRequest().getSession(false);
+    }
+
+    @Test
+    void detailPageRendersAppAndNestedClientMembershipsWithRoles() throws Exception {
+        Role appAdmin = roleRepository.save(new Role(null, appA.id(), "app-admin", null, LocalDateTime.now()));
+        Role viewer = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
+        ApplicationMembership am = appMembershipRepository.save(new ApplicationMembership(
+            null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(),
+            Set.of(new ApplicationMembershipRole(appAdmin.id()))
+        ));
+        clientMembershipRepository.save(new ClientMembership(
+            null, aliceA.id(), clientA.id(), am.id(), LocalDateTime.now(), ownerA.id(),
+            Set.of(new ClientMembershipRole(viewer.id()))
+        ));
+
+        mockMvc.perform(get("/manage/t/user-detail-a/users/" + aliceA.id()).session(sessionA))
+            .andExpect(status().isOk())
+            .andExpect(content().string(containsString("Acme Web")))
+            .andExpect(content().string(containsString("app-admin")))
+            .andExpect(content().string(containsString("acme-spa")))
+            .andExpect(content().string(containsString("viewer")))
+            // Links through to the per-Application / per-Client members pages.
+            .andExpect(content().string(containsString(
+                "/manage/t/user-detail-a/applications/" + appA.id() + "/members"
+            )))
+            .andExpect(content().string(containsString(
+                "/manage/t/user-detail-a/applications/" + appA.id()
+                    + "/clients/" + clientA.registeredClientId() + "/members"
+            )));
+    }
+
+    @Test
+    void detailPageShowsEmptyStateWhenUserHasNoMemberships() throws Exception {
+        mockMvc.perform(get("/manage/t/user-detail-a/users/" + aliceA.id()).session(sessionA))
+            .andExpect(status().isOk())
+            .andExpect(content().string(containsString("No Memberships yet")));
+    }
+
+    @Test
+    void detailPageHasNoEditOrGrantOrDeleteAffordances() throws Exception {
+        Role viewer = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
+        ApplicationMembership am = appMembershipRepository.save(new ApplicationMembership(
+            null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), Set.of()
+        ));
+        clientMembershipRepository.save(new ClientMembership(
+            null, aliceA.id(), clientA.id(), am.id(), LocalDateTime.now(), ownerA.id(),
+            Set.of(new ClientMembershipRole(viewer.id()))
+        ));
+
+        String body = mockMvc.perform(get("/manage/t/user-detail-a/users/" + aliceA.id()).session(sessionA))
+            .andExpect(status().isOk())
+            .andReturn().getResponse().getContentAsString();
+
+        // Read-only contract: no membership-mutating forms or links on this page.
+        org.assertj.core.api.Assertions.assertThat(body).doesNotContain("/edit");
+        org.assertj.core.api.Assertions.assertThat(body).doesNotContain("/delete");
+        org.assertj.core.api.Assertions.assertThat(body).doesNotContain("<form");
+    }
+
+    @Test
+    void crossTenantSessionCannotReachUserDetail() throws Exception {
+        userRepository.save(new User(null, tenantB.id(), "ownerB", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        MvcResult loginB = mockMvc.perform(post("/manage/t/user-detail-b/login")
+                .param("username", "ownerB").param("password", "pass").with(csrf()))
+            .andReturn();
+        MockHttpSession sessionB = (MockHttpSession) loginB.getRequest().getSession(false);
+
+        mockMvc.perform(get("/manage/t/user-detail-a/users/" + aliceA.id()).session(sessionB))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/manage/t/user-detail-a/login"));
+    }
+
+    @Test
+    void usernameOnListPageLinksToDetail() throws Exception {
+        mockMvc.perform(get("/manage/t/user-detail-a/users").session(sessionA))
+            .andExpect(status().isOk())
+            .andExpect(content().string(containsString(
+                "/manage/t/user-detail-a/users/" + aliceA.id()
+            )));
+    }
+
+    @Test
+    void detailPageRendersWhenMembershipsExistInOtherAppsButNotForThisUser() throws Exception {
+        // Other user has memberships, target user does not — empty state still shows.
+        User bob = userRepository.save(new User(null, tenantA.id(), "bob", passwordEncoder.encode("pass"), true, false, false, LocalDateTime.now()));
+        appMembershipRepository.save(new ApplicationMembership(
+            null, bob.id(), appA.id(), LocalDateTime.now(), ownerA.id(), Set.of()
+        ));
+
+        mockMvc.perform(get("/manage/t/user-detail-a/users/" + aliceA.id()).session(sessionA))
+            .andExpect(status().isOk())
+            .andExpect(content().string(containsString("No Memberships yet")))
+            .andExpect(content().string(not(containsString("Acme Web"))));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `GET /manage/t/{slug}/users/{userId}` rendering every App Membership (with App Roles) the User holds, each nested with its Client Memberships and Client Roles.
- Read-only by contract: rows link through to the per-Application or per-Client Members tab where editing actually lives. No `<form>`, `/edit`, or `/delete` on the page (verified in test).
- New `UserMembershipPortfolioQuery` — focused two-SELECT JDBC read module modelled on `ClientMembershipQuery`, same defence-in-depth `tenant_id` predicate.

Closes #45.

## Test plan
- [x] `mvn test` — 190 tests, all green
- [x] New `UserDetailControllerIntegrationTest` covers: full portfolio render, empty state, read-only invariant, cross-tenant rejection by `TenantAccessFilter`, list-page link, and another-user-has-memberships isolation
- [ ] Manual: log in as Tenant Owner, grant alice an App Membership + a Client Membership with a Role, visit the user detail page, click through to the App / Client members tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)