### PR TITLE
Landing page at / + slug-aware /login forwarder + system-admin isolation test

### DIFF
--- a/src/main/java/com/stucray/limen/web/RedirectLoginController.java
+++ b/src/main/java/com/stucray/limen/web/RedirectLoginController.java
@@ -2,12 +2,16 @@ package com.stucray.limen.web;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 public class RedirectLoginController {
 
     @GetMapping("/login")
-    public String redirectToSystemLogin() {
-        return "redirect:/manage/t/system/login";
+    public String login(@RequestParam(required = false) String slug) {
+        if (slug == null || slug.isBlank()) {
+            return "redirect:/";
+        }
+        return "redirect:/manage/t/" + slug + "/login";
     }
 }

--- a/src/main/java/com/stucray/limen/web/RootController.java
+++ b/src/main/java/com/stucray/limen/web/RootController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 public class RootController {
 
     @GetMapping("/")
-    public String redirectToSystemLogin() {
-        return "redirect:/manage/t/system/login";
+    public String landing() {
+        return "landing";
     }
 }

--- a/src/main/resources/static/css/_layout.css
+++ b/src/main/resources/static/css/_layout.css
@@ -112,3 +112,26 @@
     padding: var(--space-lg);
     background: var(--surface-page);
 }
+
+.landing {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+    width: 100%;
+    max-width: var(--content-narrow);
+}
+
+.landing__brand {
+    text-align: center;
+    margin: 0 0 var(--space-sm);
+}
+
+.landing__brand h1 {
+    margin: 0;
+    font-size: var(--font-size-6);
+}
+
+.landing__brand p {
+    margin: var(--space-2xs) 0 0;
+    color: var(--text-muted);
+}

--- a/src/main/resources/templates/landing.html
+++ b/src/main/resources/templates/landing.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{fragments/layout :: layout(~{::title}, ~{::main})}">
+<head><title>Limen</title></head>
+<body>
+<main class="landing">
+    <hgroup class="landing__brand">
+        <h1>Limen</h1>
+        <p>Identity &amp; access for your applications.</p>
+    </hgroup>
+
+    <article class="card card--auth">
+        <h2>Sign in to your organization</h2>
+        <form method="get" action="/login" class="stack">
+            <label>
+                Organization slug
+                <input type="text" name="slug" placeholder="acme"/>
+            </label>
+            <button type="submit" class="btn--block">Continue</button>
+        </form>
+    </article>
+
+    <article class="card card--auth">
+        <h2>Create a new organization</h2>
+        <p class="muted">Set up a new tenant and become its first owner.</p>
+        <a href="/signup" class="btn btn--secondary btn--block">Sign up</a>
+    </article>
+</main>
+</body>
+</html>

--- a/src/test/java/com/stucray/limen/LoginIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/LoginIntegrationTest.java
@@ -18,12 +18,15 @@ import java.time.LocalDateTime;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
- * Bare /login is no longer a POST target — it 302s to the canonical System Tenant
- * management login. Authentication itself is exercised by {@link com.stucray.limen.management.ManagementLoginIntegrationTest}
+ * Bare /login is no longer a POST target — it 302s to the landing page (or to a
+ * specific tenant's management login when given a {@code ?slug=} query parameter).
+ * The root path {@code /} renders the landing page directly. Authentication itself
+ * is exercised by {@link com.stucray.limen.management.ManagementLoginIntegrationTest}
  * (management surface) and by {@code TenantOAuth2RoutingIntegrationTest} /
  * {@code OAuth2ForcedPasswordChangeIntegrationTest} (OAuth2 surface).
  */
@@ -50,17 +53,25 @@ class LoginIntegrationTest {
     }
 
     @Test
-    void bareLoginRedirectsToSystemManagementLogin() throws Exception {
+    void bareLoginRedirectsToLanding() throws Exception {
         mockMvc.perform(get("/login"))
             .andExpect(status().is3xxRedirection())
-            .andExpect(redirectedUrl("/manage/t/system/login"));
+            .andExpect(redirectedUrl("/"));
     }
 
     @Test
-    void rootRedirectsToSystemManagementLogin() throws Exception {
-        mockMvc.perform(get("/"))
+    void loginWithSlugRedirectsToTenantLogin() throws Exception {
+        mockMvc.perform(get("/login").param("slug", "acme"))
             .andExpect(status().is3xxRedirection())
-            .andExpect(redirectedUrl("/manage/t/system/login"));
+            .andExpect(redirectedUrl("/manage/t/acme/login"));
+    }
+
+    @Test
+    void rootRendersLandingPage() throws Exception {
+        mockMvc.perform(get("/"))
+            .andExpect(status().isOk())
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("Sign in to your organization")))
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("Create a new organization")));
     }
 
     @Test

--- a/src/test/java/com/stucray/limen/management/system/SystemAdminCrossTenantIsolationIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/system/SystemAdminCrossTenantIsolationIntegrationTest.java
@@ -1,0 +1,91 @@
+package com.stucray.limen.management.system;
+
+import com.stucray.limen.TestcontainersConfiguration;
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.tenant.TenantStatus;
+import com.stucray.limen.user.User;
+import com.stucray.limen.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Pins the security model where a system admin (authenticated to the `system` tenant)
+ * cannot reach another tenant's management routes. The TenantAccessFilter is
+ * expected to clear the security context and redirect to that tenant's login page.
+ */
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+class SystemAdminCrossTenantIsolationIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired TenantRepository tenantRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired PasswordEncoder passwordEncoder;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    MockHttpSession sysadminSession;
+    Tenant acme;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        jdbcTemplate.execute("DELETE FROM persistent_logins");
+        jdbcTemplate.execute("DELETE FROM users WHERE tenant_id IN (SELECT id FROM tenants WHERE slug != 'system')");
+        jdbcTemplate.execute("DELETE FROM tenants WHERE slug != 'system'");
+        jdbcTemplate.execute("DELETE FROM users WHERE tenant_id = (SELECT id FROM tenants WHERE slug = 'system')");
+
+        Tenant systemTenant = tenantRepository.findBySlug("system").orElseThrow();
+        userRepository.save(new User(
+            null, systemTenant.id(), "sysadmin",
+            passwordEncoder.encode("syspass"),
+            true, false, false, LocalDateTime.now()
+        ));
+
+        acme = tenantRepository.save(new Tenant(
+            null, "acme", "Acme", TenantStatus.ACTIVE, LocalDateTime.now()
+        ));
+
+        MvcResult login = mockMvc.perform(post("/manage/t/system/login")
+                .param("username", "sysadmin")
+                .param("password", "syspass")
+                .with(csrf()))
+            .andExpect(status().is3xxRedirection())
+            .andReturn();
+        sysadminSession = (MockHttpSession) login.getRequest().getSession(false);
+        assertThat(sysadminSession).isNotNull();
+    }
+
+    @Test
+    void systemAdminCannotReachAnotherTenantsManagementRoutes() throws Exception {
+        mockMvc.perform(get("/manage/t/acme/users").session(sysadminSession))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/manage/t/acme/login"));
+
+        // Filter invalidates the session.
+        assertThat(sysadminSession.isInvalid()).isTrue();
+
+        // Same now-invalid session presented to /manage/t/system/ no longer authenticates.
+        mockMvc.perform(get("/manage/t/system/").session(sysadminSession))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/manage/t/system/login"));
+    }
+}


### PR DESCRIPTION
## Summary

A first-time visitor at the root URL now reaches a real landing page with two clear paths — sign in (slug entry) or sign up — instead of a redirect to the system admin's operator login. Closes the new-visitor discoverability gap surfaced after PR #54 merged.

- **`templates/landing.html`** (new) — two stacked cards using the existing auth-shell fragment: "Sign in to your organization" with a slug input + Continue, and "Create a new organization" with a link to `/signup`. Minimal CSS additions in `_layout.css` (`.landing`, `.landing__brand`).
- **`RootController`** — renders the landing template instead of redirecting to `/manage/t/system/login`.
- **`RedirectLoginController`** — `/login` is now a smart forwarder: no slug → redirect to `/`; `?slug=X` → redirect to `/manage/t/{X}/login`. Unknown slugs are gracefully handled by the existing `ManagementLoginController` which 302s to `/signup`.
- **`LoginIntegrationTest`** — two existing tests retargeted to the new behaviour (`bareLoginRedirectsToLanding`, `rootRendersLandingPage`); added `loginWithSlugRedirectsToTenantLogin`.
- **`SystemAdminCrossTenantIsolationIntegrationTest`** (new) — pins the security model: a system admin authenticated to `/manage/t/system/` cannot reach another tenant's management routes (force-logout + redirect to that tenant's login). Defense-in-depth — `TenantAccessFilter` already enforces this for all tenant pairs, but the system-admin case is now covered explicitly.

The slug input on the landing intentionally has no client-side `required` / `pattern` / `autofocus`. Empty and unknown slugs are handled gracefully server-side, and HTML5 `:invalid` styling on a focused-then-blurred input was producing misleading "validation failed" feedback when a user clicked the Sign up link.

## Test plan

- [ ] `./mvnw test` — full suite green (192/192 locally; +1 for the new system-admin isolation test, +1 for `loginWithSlugRedirectsToTenantLogin`)
- [ ] Visit `http://localhost:8090/` — landing page renders with both cards (no redirect)
- [ ] Submit Continue with empty slug → redirected back to `/`
- [ ] Type slug `system` → submit → land at `/manage/t/system/login`
- [ ] Type a non-existent slug → submit → land at `/signup` (graceful fallback)
- [ ] Click Sign up → `/signup` form, submit creates a new tenant → redirected to `/manage/t/{slug}/login?registered`
- [ ] Spot check (security): from a system-admin session, type `/manage/t/{any-other-tenant}/users` directly — confirm session is destroyed and redirected to that tenant's login

## Out of scope (deferred)

- System-tenants empty-state hint when only the system tenant exists — captured in memory as a small follow-up. Less important now that landing exists, since system admins typically encounter the new flow before reaching the tenants page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)