### PR TITLE
Use Spring's DelegatingPasswordEncoder

### DIFF
--- a/src/main/java/com/stucray/limen/identity/IdentityConfig.java
+++ b/src/main/java/com/stucray/limen/identity/IdentityConfig.java
@@ -5,7 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
@@ -13,7 +13,7 @@ public class IdentityConfig {
 
     @Bean
     public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 
     @Bean


### PR DESCRIPTION
## Summary
- Swap the hard-coded `BCryptPasswordEncoder` bean in `IdentityConfig` for `PasswordEncoderFactories.createDelegatingPasswordEncoder()`.
- New hashes are written with a `{bcrypt}` prefix; matching delegates by prefix, leaving room to migrate to argon2/scrypt/pbkdf2 later without breaking existing users.

## Notes
- Pre-existing un-prefixed bcrypt hashes will not match — wipe dev DBs before running. `UserBootstrap.run()` re-encodes the system admin on every startup, so the bootstrap admin picks up the new format automatically.
- `password_hash varchar(255)` has plenty of headroom for the prefix.

## Test plan
- [x] `./mvnw test` — 192 tests pass
- [ ] Wipe dev DB and confirm system admin login works after fresh bootstrap
- [ ] Sign up a new tenant owner and confirm login works (hash should be stored with `{bcrypt}` prefix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)