### PR TITLE
Fill top test-coverage gaps surfaced by the JaCoCo baseline

### DIFF
--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -1,17 +1,17 @@
 # Test Coverage Snapshot
 
-**Generated:** 2026-04-30 from commit `e2fcdb0` (with the uncommitted JaCoCo `pom.xml` config and the in-progress `ClientManagementIntegrationTest.java` applied).
+**Generated:** 2026-04-30 from commit `a5f7c00` (with 29 new tests added on top: `TenantUserDetailsServiceUnitTest`, `MembershipGateFilterUnitTest`, plus error-redisplay tests across `UserManagementIntegrationTest`, `OAuth2ForcedPasswordChangeIntegrationTest`, `MembersControllerIntegrationTest`, `ClientMembersControllerIntegrationTest`, `RolesControllerIntegrationTest`, `ApplicationManagementIntegrationTest`).
 
-**Run:** `./mvnw clean test` — 204 tests, all passing. JaCoCo analyzes 88 production classes.
+**Run:** `./mvnw clean test` — 233 tests, all passing. JaCoCo analyzes 88 production classes.
 
 ## Headline numbers
 
-| Metric       | Coverage | Covered / Total |
-|--------------|---------:|----------------:|
-| Instructions |   84.0 % | 6,323 / 7,529   |
-| Branches     |   70.0 % | 280 / 400       |
-| Lines        |   86.1 % | 1,333 / 1,549   |
-| Methods      |   89.1 % | 352 / 395       |
+| Metric       | Coverage | Δ from previous | Covered / Total |
+|--------------|---------:|----------------:|----------------:|
+| Instructions |   93.0 % | +9.0 pp         | 7,001 / 7,529   |
+| Branches     |   74.0 % | +4.0 pp         | 296 / 400       |
+| Lines        |   94.6 % | +8.5 pp         | 1,465 / 1,549   |
+| Methods      |   92.9 % | +3.8 pp         | 367 / 395       |
 
 Detailed HTML drill-down: `target/site/jacoco/index.html` (gitignored — regenerate with `./mvnw clean test`). Per-class CSV: `target/site/jacoco/jacoco.csv`.
 
@@ -22,85 +22,59 @@ Sorted by line coverage, weakest first.
 | Package                                        | Line %  | Branch % | Method % | Missed lines |
 |------------------------------------------------|--------:|---------:|---------:|-------------:|
 | com.stucray.limen (`LimenApplication` only)    |  33.3 % | n/a      |  50.0 %  |   2 |
-| com.stucray.limen.management.roles             |  68.5 % | 100.0 %  |  89.5 %  |  23 |
-| com.stucray.limen.management.applications      |  76.5 % |  66.7 %  |  82.4 %  |  12 |
-| com.stucray.limen.management.memberships       |  77.3 % |  82.9 %  |  83.1 %  |  75 |
-| com.stucray.limen.management.users             |  79.1 % |  66.7 %  |  85.7 %  |  19 |
-| com.stucray.limen.auth                         |  86.6 % |  75.0 %  |  83.9 %  |  27 |
-| com.stucray.limen.oauth2                       |  87.8 % |  62.9 %  |  91.0 %  |  44 |
+| com.stucray.limen.management.users             |  87.9 % |  77.8 %  |  89.3 %  |  11 |
+| com.stucray.limen.auth                         |  89.6 % |  75.0 %  |  90.3 %  |  21 |
 | com.stucray.limen.management.signup            |  90.0 % |  64.3 %  | 100.0 %  |   5 |
 | com.stucray.limen.security                     |  92.5 % |  66.7 %  | 100.0 %  |   8 |
+| com.stucray.limen.oauth2                       |  92.5 % |  71.2 %  |  92.5 %  |  27 |
+| com.stucray.limen.management.applications      |  94.1 % |  83.3 %  |  88.2 %  |   3 |
 | com.stucray.limen.management.web               |  95.2 % |  75.0 %  | 100.0 %  |   1 |
+| com.stucray.limen.management.memberships       |  98.2 % |  85.4 %  |  91.5 %  |   6 |
 | com.stucray.limen.identity                     | 100.0 % |  50.0 %  | 100.0 %  |   0 |
 | com.stucray.limen.management.auth              | 100.0 % |  50.0 %  | 100.0 %  |   0 |
 | com.stucray.limen.management.clients           | 100.0 % |  69.4 %  |  92.6 %  |   0 |
+| com.stucray.limen.management.roles             | 100.0 % | 100.0 %  | 100.0 %  |   0 |
 | com.stucray.limen.management.system            | 100.0 % | 100.0 %  |  72.7 %  |   0 |
 | com.stucray.limen.tenant                       | 100.0 % | 100.0 %  | 100.0 %  |   0 |
 | com.stucray.limen.user                         | 100.0 % | n/a      | 100.0 %  |   0 |
 | com.stucray.limen.web                          | 100.0 % |  75.0 %  | 100.0 %  |   0 |
 
-## High-priority gaps
+## Closed in this round
 
-Security- and tenant-isolation-critical paths come first. These are the gaps most likely to mask a real bug.
+The previously-flagged high-priority gaps are now covered:
 
-### `auth.TenantUserDetailsService` — line 40 %, method 20 %
-- File: `src/main/java/com/stucray/limen/auth/TenantUserDetailsService.java:32`
-- Only the constructor is exercised (transitively, by Spring DI). `loadByUsernameAndSlug` — the production code path used to rehydrate a remember-me cookie into a `UserDetails` — is **never called by any test directly**. The two `orElseThrow` lambdas (unknown tenant, unknown user) are also untested.
-- The single grep hit (`TenantPersistentTokenBasedRememberMeServicesUnitTest`) only references the *type*, not the method.
-- **Suggested test:** unit or `@SpringBootTest` slice that calls `loadByUsernameAndSlug` for: (a) success, (b) unknown slug → `UsernameNotFoundException("Unknown tenant: …")`, (c) known slug + unknown username → `UsernameNotFoundException(username)`.
+- `auth.TenantUserDetailsService` — happy/unknown-tenant/unknown-user paths and the unsupported `loadUserByUsername` are exercised by `TenantUserDetailsServiceUnitTest`.
+- `oauth2.MembershipGateFilter` — missing `client_id`, unknown `client_id`, single- and multi-redirect-uri fallbacks, and the unbound-`TenantScope` short-circuit are exercised by `MembershipGateFilterUnitTest`.
+- `management.users.PasswordChangeController` and `oauth2.EndUserPasswordChangeController` — mismatched-password and blank-password redisplay paths, plus the no-saved-request fallback for the OAuth2 controller.
+- Management `*Controller` form-error redisplay paths in `MembersController.update()`, `ClientMembersController.update()`, `RolesController.update()`, `RolesController.delete()` (FK ON DELETE RESTRICT), and `ApplicationController.create()`.
 
-### `oauth2.OAuth2TenantLoginController` — line 33 %, method 50 %
+## Remaining gaps
+
+### High-priority (security-adjacent)
+
+#### `oauth2.OAuth2TenantLoginController` — line 33 %, branch 0 %
 - File: `src/main/java/com/stucray/limen/oauth2/OAuth2TenantLoginController.java:19`
-- The `GET /t/{slug}/login` happy path is hit, but the **unknown-tenant fallback** at line 22–24 (`return "redirect:/manage/t/system/login"`) is uncovered. A regression here would silently send users to the wrong tenant's login.
-- **Suggested test:** `@WebMvcTest` (or extend an existing OAuth2 integration test) hitting `/t/does-not-exist/login` and asserting the redirect target.
+- Same gap as the previous report — deliberately deferred this round.
+- **Suggested test:** MockMvc GET `/t/does-not-exist/login` asserting redirect to `/manage/t/system/login`.
 
-### `oauth2.MembershipGateFilter` — line 78 %, branch 54 %
-- File: `src/main/java/com/stucray/limen/oauth2/MembershipGateFilter.java`
-- This is the filter that gates access to OAuth2 client apps based on tenant membership — branch coverage here matters more than line coverage. With 12 of 26 branches missed, several reject/allow combinations are untested.
-- **Suggested test:** drive each (member, non-member, system-tenant, missing-membership) × (interactive, programmatic) cell explicitly.
-
-### `oauth2.EndUserPasswordChangeController` — line 81 %, branch 60 %
-- File: `src/main/java/com/stucray/limen/oauth2/EndUserPasswordChangeController.java`
-- Three of five methods missed (likely the GET form, error redisplay, and an alternate POST branch). End-user password change is a security-sensitive flow; validation and rejection branches deserve explicit coverage.
-- **Suggested test:** integration tests for invalid current-password, mismatched new/confirm, and policy-rejected new password.
-
-### `auth.TenantPersistentTokenBasedRememberMeServices` — line 79 %, branch 73 %
-- File: `src/main/java/com/stucray/limen/auth/TenantPersistentTokenBasedRememberMeServices.java`
-- Has both unit and integration tests, but 13 missed lines and 6 missed branches remain — likely cookie-corruption / slug-mismatch / token-collision edges. Worth a careful pass given the security weight.
-
-### `security.JdbcSigningKeyStore` — line 87 %
-- File: `src/main/java/com/stucray/limen/security/JdbcSigningKeyStore.java`
-- 6 lines uncovered with full branch coverage — probably an error-path or a key-rotation seam. Low risk, but worth a glance since it underpins JWT signing.
-
-## Medium-priority gaps (controllers / UI)
-
-These are mostly Thymeleaf-rendering or form-handler endpoints in the management UI. Coverage is shallow because integration tests focus on the golden path; not every form/error rendering is exercised.
+### Medium-priority
 
 | Class | Line % | Notes |
 |-------|-------:|-------|
-| `management.users.PasswordChangeController` | 47 % | 2 of 3 methods covered, 8/15 lines missed. Likely the validation-error redisplay path. |
-| `management.roles.RolesController` | 50 % | 2 of 7 methods missed, 23/46 lines uncovered. Form rendering / error paths. |
-| `management.memberships.ClientMembersController` | 52 % | 4 of 12 methods missed, 40/83 lines. Mirrors `MembersController`. |
-| `management.memberships.MembersController` | 53 % | Same shape — 4 of 12 methods missed, 33/70 lines. |
-| `management.applications.ApplicationController` | 61 % | 2 of 7 methods missed, 11 lines. |
-| `management.users.UserManagementController` | 71 % | 2 of 12 methods missed, 10 lines. |
+| `management.users.UserManagementController` | 71 % | 2 of 12 methods missed; some POST handlers (e.g., conflict on `createUser` duplicate-username) likely uncovered. |
 | `oauth2.TenantAwareOAuth2AuthorizationService` | 74 % | 11 missed lines, 7 missed branches — probable error/serialization paths. |
+| `auth.TenantPersistentTokenBasedRememberMeServices` | 79 % | 13 missed lines, 6 missed branches — cookie-corruption / token-collision edges. |
 | `management.signup.SignupService` | 85 % | 5 missed lines, 10 missed branches — validation rejection edges. |
-
-For the four `*Controller` classes above, the existing tests focus on POST success and GET list. Likely missing: invalid-form redisplay, role/permission rejection, and edge cases like deleting the last admin / removing yourself.
+| `security.JdbcSigningKeyStore` | 87 % | 6 missed lines with full branch coverage — error path or rotation seam. |
 
 ## Likely-noise (informational, no action recommended)
 
-- `auth.TenantUserDetailsMixin` and `auth.TenantAuthTokenMixin` (0 %): abstract Jackson mixin classes with `@JsonCreator` constructors that are never directly invoked. Their effects are observed indirectly via OAuth2 authorization (de)serialization round-trips. JaCoCo can't see that.
-- `LimenApplication` (33 %): Spring Boot entry point; the `main` method runs only at boot. Not worth synthetic coverage.
+- `auth.TenantUserDetailsMixin` and `auth.TenantAuthTokenMixin` (0 %): abstract Jackson mixin classes. Their effects are observed indirectly via OAuth2 authorization (de)serialization round-trips.
+- `LimenApplication` (33 %): Spring Boot entry point.
 
-## Suggested next steps (in priority order)
+## Findings surfaced (not test-coverage gaps but worth noting)
 
-1. Add a unit test for `TenantUserDetailsService.loadByUsernameAndSlug` covering happy path, unknown tenant, unknown user — small, high-value.
-2. Add the unknown-tenant case to `OAuth2TenantLoginController` — one extra MockMvc assertion.
-3. Expand `MembershipGateFilter` tests to cover the missing branch combinations.
-4. Add validation-error / policy-rejection cases to `EndUserPasswordChangeController` and `PasswordChangeController`.
-5. Pad out the management `*Controller` integration tests with form-error redisplay assertions (cheap volume gain, but lower per-test value than items 1–4).
+- **Bug: `GET /manage/t/{slug}/applications/{appId}/edit` is broken.** The controller passes `application` as a model attribute, but Thymeleaf reserves `application` for its `ApplicationAttributeMap` context object. The reserved name shadows the controller's attribute, so `${application.name()}` in `manage/applications/edit.html` fails with `EL1004E: Method name() cannot be found on type ...ApplicationAttributeMap`. Pre-existing — uncovered because no test (and presumably no user) hit the edit-form GET. Fix: rename the model attribute to `app` (matching the convention in `list.html`) and update the template references in `edit.html`. Out of scope for this coverage round.
 
 ## Re-running this report
 

--- a/src/test/java/com/stucray/limen/auth/TenantUserDetailsServiceUnitTest.java
+++ b/src/test/java/com/stucray/limen/auth/TenantUserDetailsServiceUnitTest.java
@@ -1,0 +1,80 @@
+package com.stucray.limen.auth;
+
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.tenant.TenantStatus;
+import com.stucray.limen.user.User;
+import com.stucray.limen.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class TenantUserDetailsServiceUnitTest {
+
+    @Mock TenantRepository tenantRepository;
+    @Mock UserRepository userRepository;
+
+    TenantUserDetailsService service;
+
+    Tenant alpha;
+    User alice;
+
+    @BeforeEach
+    void setUp() {
+        service = new TenantUserDetailsService(tenantRepository, userRepository);
+        alpha = new Tenant(1L, "alpha", "Alpha", TenantStatus.ACTIVE, LocalDateTime.now());
+        alice = new User(10L, 1L, "alice", "hash", true, false, false, LocalDateTime.now());
+    }
+
+    @Test
+    void loadByUsernameAndSlugReturnsTenantUserDetailsForKnownUser() {
+        given(tenantRepository.findBySlug("alpha")).willReturn(Optional.of(alpha));
+        given(userRepository.findByUsernameAndTenantId("alice", 1L)).willReturn(Optional.of(alice));
+
+        UserDetails details = service.loadByUsernameAndSlug("alice", "alpha");
+
+        assertThat(details).isInstanceOf(TenantUserDetails.class);
+        TenantUserDetails tenantDetails = (TenantUserDetails) details;
+        assertThat(tenantDetails.getUsername()).isEqualTo("alice");
+        assertThat(tenantDetails.tenantSlug()).isEqualTo("alpha");
+        assertThat(tenantDetails.userId()).isEqualTo(10L);
+    }
+
+    @Test
+    void loadByUsernameAndSlugThrowsWhenTenantSlugUnknown() {
+        given(tenantRepository.findBySlug("ghost")).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.loadByUsernameAndSlug("alice", "ghost"))
+            .isInstanceOf(UsernameNotFoundException.class)
+            .hasMessageContaining("Unknown tenant: ghost");
+    }
+
+    @Test
+    void loadByUsernameAndSlugThrowsWhenUserUnknownInTenant() {
+        given(tenantRepository.findBySlug("alpha")).willReturn(Optional.of(alpha));
+        given(userRepository.findByUsernameAndTenantId("nobody", 1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.loadByUsernameAndSlug("nobody", "alpha"))
+            .isInstanceOf(UsernameNotFoundException.class)
+            .hasMessage("nobody");
+    }
+
+    @Test
+    void loadUserByUsernameAlwaysThrowsBecauseSlugIsRequired() {
+        assertThatThrownBy(() -> service.loadUserByUsername("alice"))
+            .isInstanceOf(UnsupportedOperationException.class)
+            .hasMessageContaining("loadByUsernameAndSlug");
+    }
+}

--- a/src/test/java/com/stucray/limen/management/applications/ApplicationManagementIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/applications/ApplicationManagementIntegrationTest.java
@@ -73,6 +73,25 @@ class ApplicationManagementIntegrationTest {
     }
 
     @Test
+    void createWithDuplicateNameRedisplaysFormWithError() throws Exception {
+        applicationRepository.save(new Application(null, tenantA.id(), "Existing", "desc", LocalDateTime.now()));
+
+        mockMvc.perform(post("/manage/t/corp-a/applications").session(sessionA).with(csrf())
+                .param("name", "Existing").param("description", "dup attempt"))
+            .andExpect(status().isOk())
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("already exists")));
+
+        // Only the original survives; the duplicate must not have been persisted.
+        assertThat(applicationRepository.findAllByTenantId(tenantA.id())).hasSize(1);
+    }
+
+    @Test
+    void newFormGetRendersTemplate() throws Exception {
+        mockMvc.perform(get("/manage/t/corp-a/applications/new").session(sessionA))
+            .andExpect(status().isOk());
+    }
+
+    @Test
     void ownerCanListApplications() throws Exception {
         applicationRepository.save(new Application(null, tenantA.id(), "App 1", "desc", LocalDateTime.now()));
 

--- a/src/test/java/com/stucray/limen/management/memberships/ClientMembersControllerIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/memberships/ClientMembersControllerIntegrationTest.java
@@ -159,6 +159,51 @@ class ClientMembersControllerIntegrationTest {
     }
 
     @Test
+    void editFormSubmitWithUnknownRoleIdRedisplaysFormWithError() throws Exception {
+        ApplicationMembership am = appMembershipRepository.save(new ApplicationMembership(
+            null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), Set.of()
+        ));
+        ClientMembership cm = clientMembershipRepository.save(new ClientMembership(
+            null, aliceA.id(), clientA.id(), am.id(), LocalDateTime.now(), ownerA.id(), Set.of()
+        ));
+
+        mockMvc.perform(post(url("/members/" + cm.id() + "/edit"))
+                .session(sessionA).with(csrf())
+                .param("roleIds", "999999"))
+            .andExpect(status().isOk())
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("Role not found: 999999")));
+
+        assertThat(clientMembershipRepository.findById(cm.id()).orElseThrow().roleIds()).isEmpty();
+    }
+
+    @Test
+    void editFormGetRendersTemplateWithMembershipDetails() throws Exception {
+        ApplicationMembership am = appMembershipRepository.save(new ApplicationMembership(
+            null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), Set.of()
+        ));
+        ClientMembership cm = clientMembershipRepository.save(new ClientMembership(
+            null, aliceA.id(), clientA.id(), am.id(), LocalDateTime.now(), ownerA.id(), Set.of()
+        ));
+        roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
+
+        mockMvc.perform(get(url("/members/" + cm.id() + "/edit")).session(sessionA))
+            .andExpect(status().isOk())
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("alice")))
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("viewer")));
+    }
+
+    @Test
+    void newFormGetRendersGrantableUsers() throws Exception {
+        appMembershipRepository.save(new ApplicationMembership(
+            null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), Set.of()
+        ));
+
+        mockMvc.perform(get(url("/members/new")).session(sessionA))
+            .andExpect(status().isOk())
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("alice")));
+    }
+
+    @Test
     void editFormSubmitWithNoRoleIdsClearsAssignments() throws Exception {
         ApplicationMembership am = appMembershipRepository.save(new ApplicationMembership(
             null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), Set.of()

--- a/src/test/java/com/stucray/limen/management/memberships/MembersControllerIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/memberships/MembersControllerIntegrationTest.java
@@ -139,6 +139,45 @@ class MembersControllerIntegrationTest {
     }
 
     @Test
+    void editFormSubmitWithUnknownRoleIdRedisplaysFormWithError() throws Exception {
+        ApplicationMembership m = membershipRepository.save(new ApplicationMembership(
+            null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), java.util.Set.of()
+        ));
+
+        mockMvc.perform(post("/manage/t/members-corp-a/applications/" + appA.id() + "/members/" + m.id() + "/edit")
+                .session(sessionA).with(csrf())
+                .param("roleIds", "999999"))
+            .andExpect(status().isOk())
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("Role not found: 999999")));
+
+        // The persisted membership must remain unchanged (rejection happens before save).
+        assertThat(membershipRepository.findById(m.id()).orElseThrow().roleIds()).isEmpty();
+    }
+
+    @Test
+    void editFormGetRendersTemplateWithMembershipDetails() throws Exception {
+        ApplicationMembership m = membershipRepository.save(new ApplicationMembership(
+            null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), java.util.Set.of()
+        ));
+        roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
+
+        mockMvc.perform(get("/manage/t/members-corp-a/applications/" + appA.id() + "/members/" + m.id() + "/edit")
+                .session(sessionA))
+            .andExpect(status().isOk())
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("alice")))
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("viewer")));
+    }
+
+    @Test
+    void newFormGetRendersGrantableUsersExcludingExistingMembers() throws Exception {
+        // alice is grantable initially.
+        mockMvc.perform(get("/manage/t/members-corp-a/applications/" + appA.id() + "/members/new")
+                .session(sessionA))
+            .andExpect(status().isOk())
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("alice")));
+    }
+
+    @Test
     void editFormSubmitWithNoRoleIdsClearsAssignments() throws Exception {
         Role viewer = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
         ApplicationMembership m = membershipRepository.save(new ApplicationMembership(

--- a/src/test/java/com/stucray/limen/management/roles/RolesControllerIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/roles/RolesControllerIntegrationTest.java
@@ -116,6 +116,61 @@ class RolesControllerIntegrationTest {
     }
 
     @Test
+    void editWithDuplicateNameRedisplaysFormWithError() throws Exception {
+        roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
+        Role editor = roleRepository.save(new Role(null, appA.id(), "editor", null, LocalDateTime.now()));
+
+        mockMvc.perform(post("/manage/t/roles-corp-a/applications/" + appA.id() + "/roles/" + editor.id() + "/edit")
+                .session(sessionA).with(csrf())
+                .param("name", "viewer").param("description", "collision"))
+            .andExpect(status().isOk())
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("already exists")));
+
+        Role reloaded = roleRepository.findByIdAndApplicationId(editor.id(), appA.id()).orElseThrow();
+        assertThat(reloaded.name()).isEqualTo("editor");
+    }
+
+    @Test
+    void editFormGetRendersTemplateWithRole() throws Exception {
+        Role role = roleRepository.save(new Role(null, appA.id(), "viewer", "read-only", LocalDateTime.now()));
+
+        mockMvc.perform(get("/manage/t/roles-corp-a/applications/" + appA.id() + "/roles/" + role.id() + "/edit")
+                .session(sessionA))
+            .andExpect(status().isOk())
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("viewer")));
+    }
+
+    @Test
+    void newFormGetRendersTemplate() throws Exception {
+        mockMvc.perform(get("/manage/t/roles-corp-a/applications/" + appA.id() + "/roles/new").session(sessionA))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    void deleteOfRoleAssignedToMembershipRedisplaysListWithError() throws Exception {
+        // Insert a role then directly attach it to an application_membership_role
+        // row so the FK ON DELETE RESTRICT fires when the role is deleted. Using
+        // raw SQL keeps the test independent of the ApplicationMembershipService.
+        Role role = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
+        Long ownerId = userRepository.findByUsernameAndTenantId("owner", tenantA.id()).orElseThrow().id();
+        Long membershipId = jdbcTemplate.queryForObject(
+            "INSERT INTO application_membership (user_id, application_id, granted_at, granted_by) VALUES (?,?,NOW(),?) RETURNING id",
+            Long.class, ownerId, appA.id(), ownerId
+        );
+        jdbcTemplate.update(
+            "INSERT INTO application_membership_role (application_membership_id, role_id) VALUES (?,?)",
+            membershipId, role.id()
+        );
+
+        mockMvc.perform(post("/manage/t/roles-corp-a/applications/" + appA.id() + "/roles/" + role.id() + "/delete")
+                .session(sessionA).with(csrf()))
+            .andExpect(status().isOk())
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("Cannot delete a role that is still assigned")));
+
+        assertThat(roleRepository.findById(role.id())).isPresent();
+    }
+
+    @Test
     void ownerCanDeleteRole() throws Exception {
         Role role = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
 

--- a/src/test/java/com/stucray/limen/management/users/UserManagementIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/users/UserManagementIntegrationTest.java
@@ -147,4 +147,48 @@ class UserManagementIntegrationTest {
 
         assertThat(userRepository.findById(newUser.id()).orElseThrow().mustChangePassword()).isFalse();
     }
+
+    @Test
+    void changePasswordRedisplaysFormWhenNewAndConfirmDoNotMatch() throws Exception {
+        User newUser = userRepository.save(new User(null, tenant.id(), "newuser", passwordEncoder.encode("temp"), true, true, false, LocalDateTime.now()));
+
+        MvcResult login = mockMvc.perform(post("/manage/t/corp/login")
+                .param("username", "newuser").param("password", "temp").with(csrf()))
+            .andReturn();
+        MockHttpSession newUserSession = (MockHttpSession) login.getRequest().getSession(false);
+
+        mockMvc.perform(post("/manage/t/corp/change-password").session(newUserSession).with(csrf())
+                .param("newPassword", "newpass123").param("confirmPassword", "different1"))
+            .andExpect(status().isOk())
+            .andExpect(view().name("manage/users/change-password"))
+            .andExpect(model().attribute("errorMessage", "Passwords do not match"));
+
+        assertThat(userRepository.findById(newUser.id()).orElseThrow().mustChangePassword()).isTrue();
+    }
+
+    @Test
+    void changePasswordRedisplaysFormWhenNewPasswordIsBlank() throws Exception {
+        User newUser = userRepository.save(new User(null, tenant.id(), "newuser", passwordEncoder.encode("temp"), true, true, false, LocalDateTime.now()));
+
+        MvcResult login = mockMvc.perform(post("/manage/t/corp/login")
+                .param("username", "newuser").param("password", "temp").with(csrf()))
+            .andReturn();
+        MockHttpSession newUserSession = (MockHttpSession) login.getRequest().getSession(false);
+
+        mockMvc.perform(post("/manage/t/corp/change-password").session(newUserSession).with(csrf())
+                .param("newPassword", "   ").param("confirmPassword", "   "))
+            .andExpect(status().isOk())
+            .andExpect(view().name("manage/users/change-password"))
+            .andExpect(model().attribute("errorMessage", "Password is required"));
+
+        assertThat(userRepository.findById(newUser.id()).orElseThrow().mustChangePassword()).isTrue();
+    }
+
+    @Test
+    void changePasswordFormGetRendersTemplateWithSlug() throws Exception {
+        mockMvc.perform(get("/manage/t/corp/change-password").session(ownerSession))
+            .andExpect(status().isOk())
+            .andExpect(view().name("manage/users/change-password"))
+            .andExpect(model().attribute("slug", "corp"));
+    }
 }

--- a/src/test/java/com/stucray/limen/oauth2/MembershipGateFilterUnitTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/MembershipGateFilterUnitTest.java
@@ -1,0 +1,228 @@
+package com.stucray.limen.oauth2;
+
+import com.stucray.limen.auth.TenantUserDetails;
+import com.stucray.limen.management.memberships.ClientMembershipQuery;
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantScope;
+import com.stucray.limen.tenant.TenantStatus;
+import com.stucray.limen.user.User;
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+/**
+ * Branch-coverage unit tests for {@link MembershipGateFilter}. The
+ * integration test ({@code OAuth2AuthorizeMembershipGateIntegrationTest})
+ * covers the happy path + denial-with-state; this fills in the parameter-
+ * shape edges and {@code resolveRedirectUri} fallbacks that are awkward to
+ * exercise through the full SAS flow.
+ */
+@ExtendWith(MockitoExtension.class)
+class MembershipGateFilterUnitTest {
+
+    @Mock RegisteredClientRepository registeredClientRepository;
+    @Mock ClientMembershipQuery clientMembershipQuery;
+
+    MembershipGateFilter filter;
+
+    Tenant alpha;
+    User alice;
+    TenantUserDetails principal;
+
+    @BeforeEach
+    void setUp() {
+        filter = new MembershipGateFilter(registeredClientRepository, clientMembershipQuery);
+        alpha = new Tenant(1L, "alpha", "Alpha", TenantStatus.ACTIVE, LocalDateTime.now());
+        alice = new User(10L, 1L, "alice", "hash", true, false, false, LocalDateTime.now());
+        principal = new TenantUserDetails(alice, alpha);
+        SecurityContextHolder.getContext().setAuthentication(
+            UsernamePasswordAuthenticationToken.authenticated(principal, null, principal.getAuthorities()));
+    }
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void nonAuthorizeRequestPassesThroughWithoutLookup() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/somewhere/else");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(req, res, chain);
+
+        verify(chain, times(1)).doFilter(req, res);
+        verifyNoInteractions(registeredClientRepository, clientMembershipQuery);
+    }
+
+    @Test
+    void unauthenticatedRequestPassesThroughWithoutLookup() throws Exception {
+        SecurityContextHolder.clearContext();
+        MockHttpServletRequest req = newAuthorizeRequest();
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(req, res, chain);
+
+        verify(chain, times(1)).doFilter(req, res);
+        verifyNoInteractions(registeredClientRepository, clientMembershipQuery);
+    }
+
+    @Test
+    void missingClientIdPassesThroughForSasToHandle() throws Exception {
+        MockHttpServletRequest req = newAuthorizeRequest();
+        // No client_id parameter set.
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        TenantScope.run("alpha", 1L, () -> {
+            try {
+                filter.doFilter(req, res, chain);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        verify(chain, times(1)).doFilter(req, res);
+        verifyNoInteractions(registeredClientRepository, clientMembershipQuery);
+    }
+
+    @Test
+    void unknownClientIdPassesThroughForSasToReportInvalidClient() throws Exception {
+        MockHttpServletRequest req = newAuthorizeRequest();
+        req.setParameter("client_id", "ghost-client");
+        given(registeredClientRepository.findByClientId("ghost-client")).willReturn(null);
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        TenantScope.run("alpha", 1L, () -> {
+            try {
+                filter.doFilter(req, res, chain);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        verify(chain, times(1)).doFilter(req, res);
+        verifyNoInteractions(clientMembershipQuery);
+    }
+
+    @Test
+    void multipleRegisteredRedirectsAndNoRequestedYields403() throws Exception {
+        RegisteredClient client = pkceClientBuilder("multi-redirect-client")
+            .redirectUri("http://localhost/cb1")
+            .redirectUri("http://localhost/cb2")
+            .build();
+        given(registeredClientRepository.findByClientId("multi-redirect-client")).willReturn(client);
+        given(clientMembershipQuery.hasMembership(10L, client.getId(), 1L)).willReturn(false);
+
+        MockHttpServletRequest req = newAuthorizeRequest();
+        req.setParameter("client_id", "multi-redirect-client");
+        // No redirect_uri supplied; with multiple registered URIs the filter refuses
+        // to guess and falls through to a 403 instead of redirecting.
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        TenantScope.run("alpha", 1L, () -> {
+            try {
+                filter.doFilter(req, res, chain);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        assertThat(res.getStatus()).isEqualTo(403);
+        assertThat(res.getErrorMessage()).isEqualTo("access_denied");
+        verify(chain, never()).doFilter(req, res);
+    }
+
+    @Test
+    void singleRegisteredRedirectIsUsedAsFallbackWhenRequestOmitsIt() throws Exception {
+        RegisteredClient client = pkceClientBuilder("single-redirect-client")
+            .redirectUri("http://localhost/only-callback")
+            .build();
+        given(registeredClientRepository.findByClientId("single-redirect-client")).willReturn(client);
+        given(clientMembershipQuery.hasMembership(10L, client.getId(), 1L)).willReturn(false);
+
+        MockHttpServletRequest req = newAuthorizeRequest();
+        req.setParameter("client_id", "single-redirect-client");
+        // No redirect_uri supplied; single registered URI is used as fallback.
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        TenantScope.run("alpha", 1L, () -> {
+            try {
+                filter.doFilter(req, res, chain);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        assertThat(res.getStatus()).isEqualTo(302);
+        assertThat(res.getHeader("Location"))
+            .startsWith("http://localhost/only-callback")
+            .contains("error=access_denied");
+        verify(chain, never()).doFilter(req, res);
+    }
+
+    @Test
+    void unboundTenantScopeFallsThroughToAccessDenied() throws Exception {
+        RegisteredClient client = pkceClientBuilder("scoped-client")
+            .redirectUri("http://localhost/callback")
+            .build();
+        given(registeredClientRepository.findByClientId("scoped-client")).willReturn(client);
+
+        MockHttpServletRequest req = newAuthorizeRequest();
+        req.setParameter("client_id", "scoped-client");
+        req.setParameter("redirect_uri", "http://localhost/callback");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        // No TenantScope.run wrapper — tenantId() returns null and the && short-circuits.
+        filter.doFilter(req, res, chain);
+
+        assertThat(res.getStatus()).isEqualTo(302);
+        assertThat(res.getHeader("Location"))
+            .startsWith("http://localhost/callback")
+            .contains("error=access_denied");
+        verify(chain, never()).doFilter(req, res);
+        verifyNoInteractions(clientMembershipQuery);
+    }
+
+    private static MockHttpServletRequest newAuthorizeRequest() {
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/oauth2/authorize");
+        req.setServletPath("/oauth2/authorize");
+        return req;
+    }
+
+    private static RegisteredClient.Builder pkceClientBuilder(String clientId) {
+        return RegisteredClient.withId(UUID.randomUUID().toString())
+            .clientId(clientId)
+            .clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE);
+    }
+}

--- a/src/test/java/com/stucray/limen/oauth2/OAuth2ForcedPasswordChangeIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/OAuth2ForcedPasswordChangeIntegrationTest.java
@@ -201,6 +201,72 @@ class OAuth2ForcedPasswordChangeIntegrationTest {
             .contains("/t/alpha-corp/oauth2/authorize");
     }
 
+    @Test
+    void blankNewPasswordRerendersFormAndDoesNotClearFlag() throws Exception {
+        User original = userRepository.save(new User(
+            null, tenant.id(), "alice",
+            passwordEncoder.encode("temp"),
+            true, true, false, LocalDateTime.now()));
+
+        MockHttpSession session = startAuthorize(newPkce().challenge());
+
+        mockMvc.perform(post("/t/alpha-corp/login")
+                .param("username", "alice").param("password", "temp")
+                .session(session).with(csrf()))
+            .andExpect(status().is3xxRedirection());
+
+        mockMvc.perform(post("/t/alpha-corp/change-password")
+                .param("newPassword", "   ").param("confirmPassword", "   ")
+                .session(session).with(csrf()))
+            .andExpect(status().isOk());
+
+        assertThat(userRepository.findById(original.id()).orElseThrow().mustChangePassword()).isTrue();
+    }
+
+    @Test
+    void changePasswordWithoutSavedRequestRedirectsToTenantHome() throws Exception {
+        // Direct visit to the change-password page (no prior /oauth2/authorize → no
+        // SavedRequest in the cache); after success the controller should fall back
+        // to redirect:/t/{slug}/.
+        User original = userRepository.save(new User(
+            null, tenant.id(), "alice",
+            passwordEncoder.encode("temp"),
+            true, true, false, LocalDateTime.now()));
+
+        MockHttpSession session = new MockHttpSession();
+        mockMvc.perform(post("/t/alpha-corp/login")
+                .param("username", "alice").param("password", "temp")
+                .session(session).with(csrf()))
+            .andExpect(status().is3xxRedirection());
+
+        MvcResult result = mockMvc.perform(post("/t/alpha-corp/change-password")
+                .param("newPassword", "newpass123")
+                .param("confirmPassword", "newpass123")
+                .session(session).with(csrf()))
+            .andExpect(status().is3xxRedirection())
+            .andReturn();
+
+        assertThat(result.getResponse().getHeader("Location")).isEqualTo("/t/alpha-corp/");
+        assertThat(userRepository.findById(original.id()).orElseThrow().mustChangePassword()).isFalse();
+    }
+
+    @Test
+    void changePasswordFormGetRendersChangePasswordView() throws Exception {
+        userRepository.save(new User(
+            null, tenant.id(), "alice",
+            passwordEncoder.encode("temp"),
+            true, true, false, LocalDateTime.now()));
+
+        MockHttpSession session = new MockHttpSession();
+        mockMvc.perform(post("/t/alpha-corp/login")
+                .param("username", "alice").param("password", "temp")
+                .session(session).with(csrf()))
+            .andExpect(status().is3xxRedirection());
+
+        mockMvc.perform(get("/t/alpha-corp/change-password").session(session))
+            .andExpect(status().isOk());
+    }
+
     private MockHttpSession startAuthorize(String codeChallenge) throws Exception {
         MockHttpSession session = new MockHttpSession();
         String authzUri = UriComponentsBuilder.fromPath("/t/alpha-corp/oauth2/authorize")


### PR DESCRIPTION
## Summary
Adds 29 tests (204 → 233 passing) and lifts line coverage **86.1 % → 94.6 %**, closing the highest-priority gaps from `docs/test-coverage.md`.

| Metric       | Before | After  | Δ       |
|--------------|-------:|-------:|--------:|
| Instructions | 84.0 % | 93.0 % | +9.0 pp |
| Branches     | 70.0 % | 74.0 % | +4.0 pp |
| Lines        | 86.1 % | 94.6 % | +8.5 pp |
| Methods      | 89.1 % | 92.9 % | +3.8 pp |

## What's covered now
- **`auth.TenantUserDetailsService`** — happy / unknown-tenant / unknown-user / the unsupported `loadUserByUsername` path (new `TenantUserDetailsServiceUnitTest`).
- **`oauth2.MembershipGateFilter`** — missing `client_id`, unknown `client_id`, single- and multi-redirect-uri fallbacks, and the unbound-`TenantScope` short-circuit (new `MembershipGateFilterUnitTest`; mocks-only to avoid spinning up the full SAS flow per branch).
- **Password change flows** — mismatched + blank-password redisplay paths in both `management.users.PasswordChangeController` and `oauth2.EndUserPasswordChangeController`, plus the no-saved-request fallback for the OAuth2 controller.
- **Management `*Controller` form-error redisplay paths** — unknown role-id on `MembersController.update` / `ClientMembersController.update`, duplicate-name on `RolesController.update`, FK ON DELETE RESTRICT on `RolesController.delete`, duplicate-name on `ApplicationController.create`, plus `newForm`/`editForm` GET smoke tests where those handlers were at 0 % coverage.

## Side-finding (not in this PR)
Writing a GET test for `/manage/t/{slug}/applications/{appId}/edit` surfaced a **pre-existing bug**: the controller passes `application` as a model attribute, but Thymeleaf reserves `application` for its `ApplicationAttributeMap`, which shadows the model attribute and breaks `\${application.name()}` in `manage/applications/edit.html`. Documented in `docs/test-coverage.md` for separate follow-up — the fix is to rename the model attribute to `app` (matching `list.html`'s convention) in both the controller and the template.

## Test plan
- [x] \`./mvnw clean test\` exits 0 — 233 tests, 0 failures.
- [x] \`docs/test-coverage.md\` headline numbers match \`target/site/jacoco/index.html\`.
- [x] Each new test exercises a previously-uncovered branch (verified by spot-checking JaCoCo HTML before/after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)