### PR TITLE
Add colored deltas to coverage doc + per-package Δ Line column

### DIFF
--- a/.claude/skills/coverage-report/SKILL.md
+++ b/.claude/skills/coverage-report/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: coverage-report
+description: Regenerate the JaCoCo test-coverage snapshot in docs/test-coverage.md. Use when the user asks to refresh / update / regenerate the coverage report or coverage doc, asks "what's the current test coverage", or has just landed test changes and wants the doc updated.
+---
+
+# Coverage report regeneration
+
+Refresh `docs/test-coverage.md` from a fresh JaCoCo run. Two helpers do the heavy lifting:
+
+- **JaCoCo plugin** (already configured in `pom.xml`) — running `./mvnw clean test` produces `target/site/jacoco/{index.html,jacoco.csv,jacoco.xml}`.
+- **`scripts/coverage-report.sh`** — reads `target/site/jacoco/jacoco.csv`, compares totals + per-package line coverage against the hardcoded PR #59 baseline (commit `e2fcdb0`), and emits the **Headline numbers** + **Per-package summary** markdown tables in the canonical format (right-aligned percentages, 🟢 / 🔴 / ⚪ indicators after the `%`).
+
+## Steps
+
+1. **Regenerate JaCoCo data.** Run `./mvnw clean test` from the project root. Docker must be running (Testcontainers spins up Postgres). All tests must pass — if any fail, surface that to the user before proceeding.
+
+2. **Generate the markdown tables.** Run `scripts/coverage-report.sh` and capture stdout. Verify it produced both tables (look for the `## Headline numbers` and `## Per-package summary` headers).
+
+3. **Update `docs/test-coverage.md`.** Replace the two existing tables with the script's output. Also update:
+   - The **Generated:** line at the top — bump the date and the commit SHA (`git rev-parse --short HEAD`).
+   - The **Run:** line — update the test count (grep the maven output for `Tests run: N`).
+   - The "Closed in this round" / "Remaining gaps" sections only if the user is doing a *substantive* coverage push. For a routine refresh, leave them alone.
+
+4. **Show the user a short summary.** Headline numbers and the deltas from the previous snapshot. Don't paste the whole table — they can read the doc.
+
+## Caveats
+
+- The script's baseline is hardcoded at PR #59 (commit `e2fcdb0`). Don't change it casually — it's the reference point that makes Δ values meaningful across snapshots. If the user wants a new baseline, edit `scripts/coverage-report.sh` deliberately and call it out.
+- Don't skip `clean` on the maven run — leftover `jacoco.exec` from a prior partial run can produce stale numbers.
+- If a class shows surprising coverage (e.g., a controller dropped from 100 % to 50 %), that's signal — surface it to the user before mechanically pasting the new tables.
+- Production code changes (renames, new classes, deletions) shift which classes appear and may invalidate the per-package baseline rows. If you see new packages or vanished ones, flag it.
+
+## Output format
+
+The doc currently uses:
+
+```
+| Metric       | Coverage | Δ from baseline | Covered / Total |
+|--------------|---------:|----------------:|----------------:|
+| Lines        | 94.6 % | +8.5 % 🟢 | 1,465 / 1,549 |
+```
+
+Right-aligned columns, emoji *after* the `%` so number-width changes don't shift the indicator. ⚪ for zero deltas (within ±0.05 pp) so the emoji column stays uniform. Don't tweak the format without asking — the user iterated to land on this specifically.

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -80,11 +80,11 @@ The previously-flagged high-priority gaps are now covered:
 
 ```sh
 ./mvnw clean test                            # regenerate target/site/jacoco/
-open target/site/jacoco/index.html           # browse the HTML report
-awk -F, 'NR>1 {im+=$4;ic+=$5;bm+=$6;bc+=$7;lm+=$8;lc+=$9;mm+=$12;mc+=$13} \
-  END {printf "instr %.1f%% branch %.1f%% line %.1f%% method %.1f%%\n", \
-       100*ic/(im+ic), 100*bc/(bm+bc), 100*lc/(lm+lc), 100*mc/(mm+mc)}' \
-  target/site/jacoco/jacoco.csv              # quick headline numbers
+open target/site/jacoco/index.html           # browse the HTML report (optional)
+scripts/coverage-report.sh                   # emit the two markdown tables
+                                             # above (with Δ vs PR #59 baseline)
 ```
+
+`scripts/coverage-report.sh` reads `target/site/jacoco/jacoco.csv`, computes deltas against the hardcoded PR #59 baseline, and prints the **Headline numbers** + **Per-package summary** tables in the format used here (right-aligned percentages with 🟢 / 🔴 / ⚪ indicators). Pipe it into the doc by replacing the two table sections.
 
 If/when a CI pipeline is added, the JaCoCo XML at `target/site/jacoco/jacoco.xml` is the standard upload format for Codecov / Coveralls / Sonar.

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -7,7 +7,7 @@
 ## Headline numbers
 
 | Metric       | Coverage | Δ from baseline | Covered / Total |
-|--------------|---------:|----------------:|----------------:|
+|--------------|---------:|:----------------|----------------:|
 | Instructions |   93.0 % | 🟢 +9.0 %       | 7,001 / 7,529   |
 | Branches     |   74.0 % | 🟢 +4.0 %       | 296 / 400       |
 | Lines        |   94.6 % | 🟢 +8.5 %       | 1,465 / 1,549   |
@@ -20,7 +20,7 @@ Detailed HTML drill-down: `target/site/jacoco/index.html` (gitignored — regene
 Sorted by line coverage, weakest first. Δ Line column compares each package against the PR #59 baseline.
 
 | Package                                        | Line %  | Δ Line       | Branch % | Method % | Missed lines |
-|------------------------------------------------|--------:|-------------:|---------:|---------:|-------------:|
+|------------------------------------------------|--------:|:-------------|---------:|---------:|-------------:|
 | com.stucray.limen (`LimenApplication` only)    |  33.3 % | +0.0 %       | n/a      |  50.0 %  |   2 |
 | com.stucray.limen.management.users             |  87.9 % | 🟢 +8.8 %    |  77.8 %  |  89.3 %  |  11 |
 | com.stucray.limen.auth                         |  89.6 % | 🟢 +3.0 %    |  75.0 %  |  90.3 %  |  21 |

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -6,12 +6,12 @@
 
 ## Headline numbers
 
-| Metric       | Coverage | Δ from baseline                  | Covered / Total |
-|--------------|---------:|---------------------------------:|----------------:|
-| Instructions |   93.0 % | $\color{green}{+9.0\\%}$         | 7,001 / 7,529   |
-| Branches     |   74.0 % | $\color{green}{+4.0\\%}$         | 296 / 400       |
-| Lines        |   94.6 % | $\color{green}{+8.5\\%}$         | 1,465 / 1,549   |
-| Methods      |   92.9 % | $\color{green}{+3.8\\%}$         | 367 / 395       |
+| Metric       | Coverage | Δ from baseline | Covered / Total |
+|--------------|---------:|----------------:|----------------:|
+| Instructions |   93.0 % | 🟢 +9.0 %       | 7,001 / 7,529   |
+| Branches     |   74.0 % | 🟢 +4.0 %       | 296 / 400       |
+| Lines        |   94.6 % | 🟢 +8.5 %       | 1,465 / 1,549   |
+| Methods      |   92.9 % | 🟢 +3.8 %       | 367 / 395       |
 
 Detailed HTML drill-down: `target/site/jacoco/index.html` (gitignored — regenerate with `./mvnw clean test`). Per-class CSV: `target/site/jacoco/jacoco.csv`.
 
@@ -19,25 +19,25 @@ Detailed HTML drill-down: `target/site/jacoco/index.html` (gitignored — regene
 
 Sorted by line coverage, weakest first. Δ Line column compares each package against the PR #59 baseline.
 
-| Package                                        | Line %  | Δ Line                          | Branch % | Method % | Missed lines |
-|------------------------------------------------|--------:|--------------------------------:|---------:|---------:|-------------:|
-| com.stucray.limen (`LimenApplication` only)    |  33.3 % | +0.0 %                          | n/a      |  50.0 %  |   2 |
-| com.stucray.limen.management.users             |  87.9 % | $\color{green}{+8.8\\%}$        |  77.8 %  |  89.3 %  |  11 |
-| com.stucray.limen.auth                         |  89.6 % | $\color{green}{+3.0\\%}$        |  75.0 %  |  90.3 %  |  21 |
-| com.stucray.limen.management.signup            |  90.0 % | +0.0 %                          |  64.3 %  | 100.0 %  |   5 |
-| com.stucray.limen.security                     |  92.5 % | +0.0 %                          |  66.7 %  | 100.0 %  |   8 |
-| com.stucray.limen.oauth2                       |  92.5 % | $\color{green}{+4.7\\%}$        |  71.2 %  |  92.5 %  |  27 |
-| com.stucray.limen.management.applications      |  94.1 % | $\color{green}{+17.6\\%}$       |  83.3 %  |  88.2 %  |   3 |
-| com.stucray.limen.management.web               |  95.2 % | +0.0 %                          |  75.0 %  | 100.0 %  |   1 |
-| com.stucray.limen.management.memberships       |  98.2 % | $\color{green}{+20.9\\%}$       |  85.4 %  |  91.5 %  |   6 |
-| com.stucray.limen.identity                     | 100.0 % | +0.0 %                          |  50.0 %  | 100.0 %  |   0 |
-| com.stucray.limen.management.auth              | 100.0 % | +0.0 %                          |  50.0 %  | 100.0 %  |   0 |
-| com.stucray.limen.management.clients           | 100.0 % | +0.0 %                          |  69.4 %  |  92.6 %  |   0 |
-| com.stucray.limen.management.roles             | 100.0 % | $\color{green}{+31.5\\%}$       | 100.0 %  | 100.0 %  |   0 |
-| com.stucray.limen.management.system            | 100.0 % | +0.0 %                          | 100.0 %  |  72.7 %  |   0 |
-| com.stucray.limen.tenant                       | 100.0 % | +0.0 %                          | 100.0 %  | 100.0 %  |   0 |
-| com.stucray.limen.user                         | 100.0 % | +0.0 %                          | n/a      | 100.0 %  |   0 |
-| com.stucray.limen.web                          | 100.0 % | +0.0 %                          |  75.0 %  | 100.0 %  |   0 |
+| Package                                        | Line %  | Δ Line       | Branch % | Method % | Missed lines |
+|------------------------------------------------|--------:|-------------:|---------:|---------:|-------------:|
+| com.stucray.limen (`LimenApplication` only)    |  33.3 % | +0.0 %       | n/a      |  50.0 %  |   2 |
+| com.stucray.limen.management.users             |  87.9 % | 🟢 +8.8 %    |  77.8 %  |  89.3 %  |  11 |
+| com.stucray.limen.auth                         |  89.6 % | 🟢 +3.0 %    |  75.0 %  |  90.3 %  |  21 |
+| com.stucray.limen.management.signup            |  90.0 % | +0.0 %       |  64.3 %  | 100.0 %  |   5 |
+| com.stucray.limen.security                     |  92.5 % | +0.0 %       |  66.7 %  | 100.0 %  |   8 |
+| com.stucray.limen.oauth2                       |  92.5 % | 🟢 +4.7 %    |  71.2 %  |  92.5 %  |  27 |
+| com.stucray.limen.management.applications      |  94.1 % | 🟢 +17.6 %   |  83.3 %  |  88.2 %  |   3 |
+| com.stucray.limen.management.web               |  95.2 % | +0.0 %       |  75.0 %  | 100.0 %  |   1 |
+| com.stucray.limen.management.memberships       |  98.2 % | 🟢 +20.9 %   |  85.4 %  |  91.5 %  |   6 |
+| com.stucray.limen.identity                     | 100.0 % | +0.0 %       |  50.0 %  | 100.0 %  |   0 |
+| com.stucray.limen.management.auth              | 100.0 % | +0.0 %       |  50.0 %  | 100.0 %  |   0 |
+| com.stucray.limen.management.clients           | 100.0 % | +0.0 %       |  69.4 %  |  92.6 %  |   0 |
+| com.stucray.limen.management.roles             | 100.0 % | 🟢 +31.5 %   | 100.0 %  | 100.0 %  |   0 |
+| com.stucray.limen.management.system            | 100.0 % | +0.0 %       | 100.0 %  |  72.7 %  |   0 |
+| com.stucray.limen.tenant                       | 100.0 % | +0.0 %       | 100.0 %  | 100.0 %  |   0 |
+| com.stucray.limen.user                         | 100.0 % | +0.0 %       | n/a      | 100.0 %  |   0 |
+| com.stucray.limen.web                          | 100.0 % | +0.0 %       |  75.0 %  | 100.0 %  |   0 |
 
 ## Closed in this round
 

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -21,23 +21,23 @@ Sorted by line coverage, weakest first. Δ Line column compares each package aga
 
 | Package                                        | Line %  | Δ Line       | Branch % | Method % | Missed lines |
 |------------------------------------------------|--------:|-------------:|---------:|---------:|-------------:|
-| com.stucray.limen (`LimenApplication` only)    |  33.3 % |       +0.0 % | n/a      |  50.0 %  |   2 |
+| com.stucray.limen (`LimenApplication` only)    |  33.3 % |    +0.0 % ⚪ | n/a      |  50.0 %  |   2 |
 | com.stucray.limen.management.users             |  87.9 % |    +8.8 % 🟢 |  77.8 %  |  89.3 %  |  11 |
 | com.stucray.limen.auth                         |  89.6 % |    +3.0 % 🟢 |  75.0 %  |  90.3 %  |  21 |
-| com.stucray.limen.management.signup            |  90.0 % |       +0.0 % |  64.3 %  | 100.0 %  |   5 |
-| com.stucray.limen.security                     |  92.5 % |       +0.0 % |  66.7 %  | 100.0 %  |   8 |
+| com.stucray.limen.management.signup            |  90.0 % |    +0.0 % ⚪ |  64.3 %  | 100.0 %  |   5 |
+| com.stucray.limen.security                     |  92.5 % |    +0.0 % ⚪ |  66.7 %  | 100.0 %  |   8 |
 | com.stucray.limen.oauth2                       |  92.5 % |    +4.7 % 🟢 |  71.2 %  |  92.5 %  |  27 |
 | com.stucray.limen.management.applications      |  94.1 % |   +17.6 % 🟢 |  83.3 %  |  88.2 %  |   3 |
-| com.stucray.limen.management.web               |  95.2 % |       +0.0 % |  75.0 %  | 100.0 %  |   1 |
+| com.stucray.limen.management.web               |  95.2 % |    +0.0 % ⚪ |  75.0 %  | 100.0 %  |   1 |
 | com.stucray.limen.management.memberships       |  98.2 % |   +20.9 % 🟢 |  85.4 %  |  91.5 %  |   6 |
-| com.stucray.limen.identity                     | 100.0 % |       +0.0 % |  50.0 %  | 100.0 %  |   0 |
-| com.stucray.limen.management.auth              | 100.0 % |       +0.0 % |  50.0 %  | 100.0 %  |   0 |
-| com.stucray.limen.management.clients           | 100.0 % |       +0.0 % |  69.4 %  |  92.6 %  |   0 |
+| com.stucray.limen.identity                     | 100.0 % |    +0.0 % ⚪ |  50.0 %  | 100.0 %  |   0 |
+| com.stucray.limen.management.auth              | 100.0 % |    +0.0 % ⚪ |  50.0 %  | 100.0 %  |   0 |
+| com.stucray.limen.management.clients           | 100.0 % |    +0.0 % ⚪ |  69.4 %  |  92.6 %  |   0 |
 | com.stucray.limen.management.roles             | 100.0 % |   +31.5 % 🟢 | 100.0 %  | 100.0 %  |   0 |
-| com.stucray.limen.management.system            | 100.0 % |       +0.0 % | 100.0 %  |  72.7 %  |   0 |
-| com.stucray.limen.tenant                       | 100.0 % |       +0.0 % | 100.0 %  | 100.0 %  |   0 |
-| com.stucray.limen.user                         | 100.0 % |       +0.0 % | n/a      | 100.0 %  |   0 |
-| com.stucray.limen.web                          | 100.0 % |       +0.0 % |  75.0 %  | 100.0 %  |   0 |
+| com.stucray.limen.management.system            | 100.0 % |    +0.0 % ⚪ | 100.0 %  |  72.7 %  |   0 |
+| com.stucray.limen.tenant                       | 100.0 % |    +0.0 % ⚪ | 100.0 %  | 100.0 %  |   0 |
+| com.stucray.limen.user                         | 100.0 % |    +0.0 % ⚪ | n/a      | 100.0 %  |   0 |
+| com.stucray.limen.web                          | 100.0 % |    +0.0 % ⚪ |  75.0 %  | 100.0 %  |   0 |
 
 ## Closed in this round
 

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -7,11 +7,11 @@
 ## Headline numbers
 
 | Metric       | Coverage | Δ from baseline | Covered / Total |
-|--------------|---------:|:----------------|----------------:|
-| Instructions |   93.0 % | 🟢 +9.0 %       | 7,001 / 7,529   |
-| Branches     |   74.0 % | 🟢 +4.0 %       | 296 / 400       |
-| Lines        |   94.6 % | 🟢 +8.5 %       | 1,465 / 1,549   |
-| Methods      |   92.9 % | 🟢 +3.8 %       | 367 / 395       |
+|--------------|---------:|----------------:|----------------:|
+| Instructions |   93.0 % |       +9.0 % 🟢 | 7,001 / 7,529   |
+| Branches     |   74.0 % |       +4.0 % 🟢 | 296 / 400       |
+| Lines        |   94.6 % |       +8.5 % 🟢 | 1,465 / 1,549   |
+| Methods      |   92.9 % |       +3.8 % 🟢 | 367 / 395       |
 
 Detailed HTML drill-down: `target/site/jacoco/index.html` (gitignored — regenerate with `./mvnw clean test`). Per-class CSV: `target/site/jacoco/jacoco.csv`.
 
@@ -20,24 +20,24 @@ Detailed HTML drill-down: `target/site/jacoco/index.html` (gitignored — regene
 Sorted by line coverage, weakest first. Δ Line column compares each package against the PR #59 baseline.
 
 | Package                                        | Line %  | Δ Line       | Branch % | Method % | Missed lines |
-|------------------------------------------------|--------:|:-------------|---------:|---------:|-------------:|
-| com.stucray.limen (`LimenApplication` only)    |  33.3 % | +0.0 %       | n/a      |  50.0 %  |   2 |
-| com.stucray.limen.management.users             |  87.9 % | 🟢 +8.8 %    |  77.8 %  |  89.3 %  |  11 |
-| com.stucray.limen.auth                         |  89.6 % | 🟢 +3.0 %    |  75.0 %  |  90.3 %  |  21 |
-| com.stucray.limen.management.signup            |  90.0 % | +0.0 %       |  64.3 %  | 100.0 %  |   5 |
-| com.stucray.limen.security                     |  92.5 % | +0.0 %       |  66.7 %  | 100.0 %  |   8 |
-| com.stucray.limen.oauth2                       |  92.5 % | 🟢 +4.7 %    |  71.2 %  |  92.5 %  |  27 |
-| com.stucray.limen.management.applications      |  94.1 % | 🟢 +17.6 %   |  83.3 %  |  88.2 %  |   3 |
-| com.stucray.limen.management.web               |  95.2 % | +0.0 %       |  75.0 %  | 100.0 %  |   1 |
-| com.stucray.limen.management.memberships       |  98.2 % | 🟢 +20.9 %   |  85.4 %  |  91.5 %  |   6 |
-| com.stucray.limen.identity                     | 100.0 % | +0.0 %       |  50.0 %  | 100.0 %  |   0 |
-| com.stucray.limen.management.auth              | 100.0 % | +0.0 %       |  50.0 %  | 100.0 %  |   0 |
-| com.stucray.limen.management.clients           | 100.0 % | +0.0 %       |  69.4 %  |  92.6 %  |   0 |
-| com.stucray.limen.management.roles             | 100.0 % | 🟢 +31.5 %   | 100.0 %  | 100.0 %  |   0 |
-| com.stucray.limen.management.system            | 100.0 % | +0.0 %       | 100.0 %  |  72.7 %  |   0 |
-| com.stucray.limen.tenant                       | 100.0 % | +0.0 %       | 100.0 %  | 100.0 %  |   0 |
-| com.stucray.limen.user                         | 100.0 % | +0.0 %       | n/a      | 100.0 %  |   0 |
-| com.stucray.limen.web                          | 100.0 % | +0.0 %       |  75.0 %  | 100.0 %  |   0 |
+|------------------------------------------------|--------:|-------------:|---------:|---------:|-------------:|
+| com.stucray.limen (`LimenApplication` only)    |  33.3 % |       +0.0 % | n/a      |  50.0 %  |   2 |
+| com.stucray.limen.management.users             |  87.9 % |    +8.8 % 🟢 |  77.8 %  |  89.3 %  |  11 |
+| com.stucray.limen.auth                         |  89.6 % |    +3.0 % 🟢 |  75.0 %  |  90.3 %  |  21 |
+| com.stucray.limen.management.signup            |  90.0 % |       +0.0 % |  64.3 %  | 100.0 %  |   5 |
+| com.stucray.limen.security                     |  92.5 % |       +0.0 % |  66.7 %  | 100.0 %  |   8 |
+| com.stucray.limen.oauth2                       |  92.5 % |    +4.7 % 🟢 |  71.2 %  |  92.5 %  |  27 |
+| com.stucray.limen.management.applications      |  94.1 % |   +17.6 % 🟢 |  83.3 %  |  88.2 %  |   3 |
+| com.stucray.limen.management.web               |  95.2 % |       +0.0 % |  75.0 %  | 100.0 %  |   1 |
+| com.stucray.limen.management.memberships       |  98.2 % |   +20.9 % 🟢 |  85.4 %  |  91.5 %  |   6 |
+| com.stucray.limen.identity                     | 100.0 % |       +0.0 % |  50.0 %  | 100.0 %  |   0 |
+| com.stucray.limen.management.auth              | 100.0 % |       +0.0 % |  50.0 %  | 100.0 %  |   0 |
+| com.stucray.limen.management.clients           | 100.0 % |       +0.0 % |  69.4 %  |  92.6 %  |   0 |
+| com.stucray.limen.management.roles             | 100.0 % |   +31.5 % 🟢 | 100.0 %  | 100.0 %  |   0 |
+| com.stucray.limen.management.system            | 100.0 % |       +0.0 % | 100.0 %  |  72.7 %  |   0 |
+| com.stucray.limen.tenant                       | 100.0 % |       +0.0 % | 100.0 %  | 100.0 %  |   0 |
+| com.stucray.limen.user                         | 100.0 % |       +0.0 % | n/a      | 100.0 %  |   0 |
+| com.stucray.limen.web                          | 100.0 % |       +0.0 % |  75.0 %  | 100.0 %  |   0 |
 
 ## Closed in this round
 

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -1,43 +1,43 @@
 # Test Coverage Snapshot
 
-**Generated:** 2026-04-30 from commit `a5f7c00` (with 29 new tests added on top: `TenantUserDetailsServiceUnitTest`, `MembershipGateFilterUnitTest`, plus error-redisplay tests across `UserManagementIntegrationTest`, `OAuth2ForcedPasswordChangeIntegrationTest`, `MembersControllerIntegrationTest`, `ClientMembersControllerIntegrationTest`, `RolesControllerIntegrationTest`, `ApplicationManagementIntegrationTest`).
+**Generated:** 2026-04-30 from commit `2a1202c` (current `main`, after PRs #59 / #60 / #61 — initial baseline + 29-test gap fill + remember-me/client-management hardening). Δ columns compare against the PR #59 baseline (commit `e2fcdb0`).
 
-**Run:** `./mvnw clean test` — 233 tests, all passing. JaCoCo analyzes 88 production classes.
+**Run:** `./mvnw clean test` — 245 tests, all passing. JaCoCo analyzes 88 production classes.
 
 ## Headline numbers
 
-| Metric       | Coverage | Δ from previous | Covered / Total |
-|--------------|---------:|----------------:|----------------:|
-| Instructions |   93.0 % | +9.0 pp         | 7,001 / 7,529   |
-| Branches     |   74.0 % | +4.0 pp         | 296 / 400       |
-| Lines        |   94.6 % | +8.5 pp         | 1,465 / 1,549   |
-| Methods      |   92.9 % | +3.8 pp         | 367 / 395       |
+| Metric       | Coverage | Δ from baseline                  | Covered / Total |
+|--------------|---------:|---------------------------------:|----------------:|
+| Instructions |   93.0 % | $\color{green}{+9.0\\%}$         | 7,001 / 7,529   |
+| Branches     |   74.0 % | $\color{green}{+4.0\\%}$         | 296 / 400       |
+| Lines        |   94.6 % | $\color{green}{+8.5\\%}$         | 1,465 / 1,549   |
+| Methods      |   92.9 % | $\color{green}{+3.8\\%}$         | 367 / 395       |
 
 Detailed HTML drill-down: `target/site/jacoco/index.html` (gitignored — regenerate with `./mvnw clean test`). Per-class CSV: `target/site/jacoco/jacoco.csv`.
 
 ## Per-package summary
 
-Sorted by line coverage, weakest first.
+Sorted by line coverage, weakest first. Δ Line column compares each package against the PR #59 baseline.
 
-| Package                                        | Line %  | Branch % | Method % | Missed lines |
-|------------------------------------------------|--------:|---------:|---------:|-------------:|
-| com.stucray.limen (`LimenApplication` only)    |  33.3 % | n/a      |  50.0 %  |   2 |
-| com.stucray.limen.management.users             |  87.9 % |  77.8 %  |  89.3 %  |  11 |
-| com.stucray.limen.auth                         |  89.6 % |  75.0 %  |  90.3 %  |  21 |
-| com.stucray.limen.management.signup            |  90.0 % |  64.3 %  | 100.0 %  |   5 |
-| com.stucray.limen.security                     |  92.5 % |  66.7 %  | 100.0 %  |   8 |
-| com.stucray.limen.oauth2                       |  92.5 % |  71.2 %  |  92.5 %  |  27 |
-| com.stucray.limen.management.applications      |  94.1 % |  83.3 %  |  88.2 %  |   3 |
-| com.stucray.limen.management.web               |  95.2 % |  75.0 %  | 100.0 %  |   1 |
-| com.stucray.limen.management.memberships       |  98.2 % |  85.4 %  |  91.5 %  |   6 |
-| com.stucray.limen.identity                     | 100.0 % |  50.0 %  | 100.0 %  |   0 |
-| com.stucray.limen.management.auth              | 100.0 % |  50.0 %  | 100.0 %  |   0 |
-| com.stucray.limen.management.clients           | 100.0 % |  69.4 %  |  92.6 %  |   0 |
-| com.stucray.limen.management.roles             | 100.0 % | 100.0 %  | 100.0 %  |   0 |
-| com.stucray.limen.management.system            | 100.0 % | 100.0 %  |  72.7 %  |   0 |
-| com.stucray.limen.tenant                       | 100.0 % | 100.0 %  | 100.0 %  |   0 |
-| com.stucray.limen.user                         | 100.0 % | n/a      | 100.0 %  |   0 |
-| com.stucray.limen.web                          | 100.0 % |  75.0 %  | 100.0 %  |   0 |
+| Package                                        | Line %  | Δ Line                          | Branch % | Method % | Missed lines |
+|------------------------------------------------|--------:|--------------------------------:|---------:|---------:|-------------:|
+| com.stucray.limen (`LimenApplication` only)    |  33.3 % | +0.0 %                          | n/a      |  50.0 %  |   2 |
+| com.stucray.limen.management.users             |  87.9 % | $\color{green}{+8.8\\%}$        |  77.8 %  |  89.3 %  |  11 |
+| com.stucray.limen.auth                         |  89.6 % | $\color{green}{+3.0\\%}$        |  75.0 %  |  90.3 %  |  21 |
+| com.stucray.limen.management.signup            |  90.0 % | +0.0 %                          |  64.3 %  | 100.0 %  |   5 |
+| com.stucray.limen.security                     |  92.5 % | +0.0 %                          |  66.7 %  | 100.0 %  |   8 |
+| com.stucray.limen.oauth2                       |  92.5 % | $\color{green}{+4.7\\%}$        |  71.2 %  |  92.5 %  |  27 |
+| com.stucray.limen.management.applications      |  94.1 % | $\color{green}{+17.6\\%}$       |  83.3 %  |  88.2 %  |   3 |
+| com.stucray.limen.management.web               |  95.2 % | +0.0 %                          |  75.0 %  | 100.0 %  |   1 |
+| com.stucray.limen.management.memberships       |  98.2 % | $\color{green}{+20.9\\%}$       |  85.4 %  |  91.5 %  |   6 |
+| com.stucray.limen.identity                     | 100.0 % | +0.0 %                          |  50.0 %  | 100.0 %  |   0 |
+| com.stucray.limen.management.auth              | 100.0 % | +0.0 %                          |  50.0 %  | 100.0 %  |   0 |
+| com.stucray.limen.management.clients           | 100.0 % | +0.0 %                          |  69.4 %  |  92.6 %  |   0 |
+| com.stucray.limen.management.roles             | 100.0 % | $\color{green}{+31.5\\%}$       | 100.0 %  | 100.0 %  |   0 |
+| com.stucray.limen.management.system            | 100.0 % | +0.0 %                          | 100.0 %  |  72.7 %  |   0 |
+| com.stucray.limen.tenant                       | 100.0 % | +0.0 %                          | 100.0 %  | 100.0 %  |   0 |
+| com.stucray.limen.user                         | 100.0 % | +0.0 %                          | n/a      | 100.0 %  |   0 |
+| com.stucray.limen.web                          | 100.0 % | +0.0 %                          |  75.0 %  | 100.0 %  |   0 |
 
 ## Closed in this round
 

--- a/scripts/coverage-report.sh
+++ b/scripts/coverage-report.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Emit the "Headline numbers" + "Per-package summary" markdown tables for
+# docs/test-coverage.md from a JaCoCo CSV. Δ columns compare against the
+# PR #59 baseline (commit e2fcdb0).
+#
+# Usage:
+#   ./mvnw clean test                            # regenerate target/site/jacoco/jacoco.csv
+#   scripts/coverage-report.sh                   # print tables to stdout
+#   scripts/coverage-report.sh path/to/jacoco.csv
+
+set -euo pipefail
+
+CSV="${1:-target/site/jacoco/jacoco.csv}"
+
+if [[ ! -f "$CSV" ]]; then
+    echo "Error: $CSV not found. Run ./mvnw clean test first." >&2
+    exit 1
+fi
+
+awk -F, '
+BEGIN {
+    # Baseline snapshot: commit e2fcdb0 (PR #59 initial JaCoCo run).
+    base_instr  = 84.0
+    base_branch = 70.0
+    base_line   = 86.1
+    base_method = 89.1
+
+    base["com.stucray.limen"]                          = 33.3
+    base["com.stucray.limen.auth"]                     = 86.6
+    base["com.stucray.limen.identity"]                 = 100.0
+    base["com.stucray.limen.management.applications"]  = 76.5
+    base["com.stucray.limen.management.auth"]          = 100.0
+    base["com.stucray.limen.management.clients"]       = 100.0
+    base["com.stucray.limen.management.memberships"]   = 77.3
+    base["com.stucray.limen.management.roles"]         = 68.5
+    base["com.stucray.limen.management.signup"]        = 90.0
+    base["com.stucray.limen.management.system"]        = 100.0
+    base["com.stucray.limen.management.users"]         = 79.1
+    base["com.stucray.limen.management.web"]           = 95.2
+    base["com.stucray.limen.oauth2"]                   = 87.8
+    base["com.stucray.limen.security"]                 = 92.5
+    base["com.stucray.limen.tenant"]                   = 100.0
+    base["com.stucray.limen.user"]                     = 100.0
+    base["com.stucray.limen.web"]                      = 100.0
+}
+
+function emoji(d) {
+    if (d >  0.05) return "🟢"
+    if (d < -0.05) return "🔴"
+    return "⚪"
+}
+
+function delta(d) {
+    return sprintf("%s%.1f %% %s", (d >= 0 ? "+" : ""), d, emoji(d))
+}
+
+function comma(n,   s, len, out, i) {
+    s = sprintf("%d", n); len = length(s); out = ""
+    for (i = 1; i <= len; i++) {
+        out = out substr(s, i, 1)
+        if ((len - i) % 3 == 0 && i != len) out = out ","
+    }
+    return out
+}
+
+NR == 1 { next }
+
+{
+    im += $4;  ic += $5
+    bm += $6;  bc += $7
+    lm += $8;  lc += $9
+    mm += $12; mc += $13
+
+    pkg = $2
+    im_p[pkg] += $4;  ic_p[pkg] += $5
+    bm_p[pkg] += $6;  bc_p[pkg] += $7
+    lm_p[pkg] += $8;  lc_p[pkg] += $9
+    mm_p[pkg] += $12; mc_p[pkg] += $13
+}
+
+END {
+    ip = 100 * ic / (im + ic)
+    bp = 100 * bc / (bm + bc)
+    lp = 100 * lc / (lm + lc)
+    mp = 100 * mc / (mm + mc)
+
+    print "## Headline numbers"; print ""
+    print "| Metric       | Coverage | Δ from baseline | Covered / Total |"
+    print "|--------------|---------:|----------------:|----------------:|"
+    printf "| Instructions | %.1f %% | %s | %s / %s |\n", ip, delta(ip - base_instr), comma(ic), comma(im + ic)
+    printf "| Branches     | %.1f %% | %s | %s / %s |\n", bp, delta(bp - base_branch), comma(bc), comma(bm + bc)
+    printf "| Lines        | %.1f %% | %s | %s / %s |\n", lp, delta(lp - base_line),   comma(lc), comma(lm + lc)
+    printf "| Methods      | %.1f %% | %s | %s / %s |\n", mp, delta(mp - base_method), comma(mc), comma(mm + mc)
+
+    print ""; print "## Per-package summary"; print ""
+    print "Sorted by line coverage, weakest first. Δ Line column compares each package against the PR #59 baseline."
+    print ""
+    print "| Package | Line % | Δ Line | Branch % | Method % | Missed lines |"
+    print "|---------|-------:|-------:|---------:|---------:|-------------:|"
+
+    n = 0
+    for (p in lm_p) pkgs[++n] = p
+    # Insertion sort by line coverage ascending.
+    for (i = 2; i <= n; i++) {
+        k = pkgs[i]
+        lk = 100 * lc_p[k] / (lm_p[k] + lc_p[k])
+        j = i - 1
+        while (j >= 1) {
+            lj = 100 * lc_p[pkgs[j]] / (lm_p[pkgs[j]] + lc_p[pkgs[j]])
+            if (lj > lk) { pkgs[j+1] = pkgs[j]; j-- } else break
+        }
+        pkgs[j+1] = k
+    }
+
+    for (i = 1; i <= n; i++) {
+        p = pkgs[i]
+        lp_pkg = 100 * lc_p[p] / (lm_p[p] + lc_p[p])
+        bp_pkg = (bm_p[p] + bc_p[p] > 0) ? sprintf("%.1f %%", 100 * bc_p[p] / (bm_p[p] + bc_p[p])) : "n/a"
+        mp_pkg = 100 * mc_p[p] / (mm_p[p] + mc_p[p])
+        bv = (p in base) ? base[p] : 0
+        printf "| %s | %.1f %% | %s | %s | %.1f %% | %d |\n",
+            p, lp_pkg, delta(lp_pkg - bv), bp_pkg, mp_pkg, lm_p[p]
+    }
+}
+' "$CSV"


### PR DESCRIPTION
## Summary
Doc-only tweak to `docs/test-coverage.md`:

1. **Headline table** — change `pp` → `%` and color positive deltas **green** via GitHub MathJax syntax (`\$\color{green}{+8.5\\\\%}\$`). Zero deltas remain plain text.
2. **Per-package summary** — add a **Δ Line** column comparing each package's line coverage against the PR #59 baseline, with the same green colouring on positive deltas.
3. Refresh the snapshot to current `main` (commit `2a1202c`, 245 tests).

Notable per-package gains visible in the new column:
- `management.roles`: $+31.5\%$
- `management.memberships`: $+20.9\%$
- `management.applications`: $+17.6\%$
- `management.users`: $+8.8\%$

No production code touched.

## Preview

The colored delta uses GitHub's MathJax-rendered `\$\color{green}{+8.5\\\\%}\$`. If the rendered PR shows the math syntax literally instead of green text, swap it for emoji indicators (🟢 / 🔴) — happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)