### PR TITLE
Add per-snapshot JSONL history + Δ-from-last-run to coverage script

### DIFF
--- a/.claude/skills/coverage-report/SKILL.md
+++ b/.claude/skills/coverage-report/SKILL.md
@@ -8,24 +8,27 @@ description: Regenerate the JaCoCo test-coverage snapshot in docs/test-coverage.
 Refresh `docs/test-coverage.md` from a fresh JaCoCo run. Two helpers do the heavy lifting:
 
 - **JaCoCo plugin** (already configured in `pom.xml`) — running `./mvnw clean test` produces `target/site/jacoco/{index.html,jacoco.csv,jacoco.xml}`.
-- **`scripts/coverage-report.sh`** — reads `target/site/jacoco/jacoco.csv`, compares totals + per-package line coverage against the hardcoded PR #59 baseline (commit `e2fcdb0`), and emits the **Headline numbers** + **Per-package summary** markdown tables in the canonical format (right-aligned percentages, 🟢 / 🔴 / ⚪ indicators after the `%`).
+- **`scripts/coverage-report.sh`** — reads `target/site/jacoco/jacoco.csv`, compares totals + per-package line coverage against the hardcoded PR #59 baseline (commit `e2fcdb0`), and emits the **Headline numbers** + **Per-package summary** markdown tables in the canonical format (right-aligned percentages, 🟢 / 🔴 / ⚪ indicators after the `%`). It also appends a JSON Lines snapshot to `docs/test-coverage-history.jsonl` and emits a trailing **Δ from last run** block on stdout (chat-summary only — see step 3 below).
 
 ## Steps
 
 1. **Regenerate JaCoCo data.** Run `./mvnw clean test` from the project root. Docker must be running (Testcontainers spins up Postgres). All tests must pass — if any fail, surface that to the user before proceeding.
 
-2. **Generate the markdown tables.** Run `scripts/coverage-report.sh` and capture stdout. Verify it produced both tables (look for the `## Headline numbers` and `## Per-package summary` headers).
+2. **Generate the markdown tables.** Run `scripts/coverage-report.sh --tests N` (where `N` comes from grepping the maven output for `Tests run: N`) and capture stdout. Verify it produced all three sections (`## Headline numbers`, `## Per-package summary`, and `## Δ from last run`). The script also appends a snapshot row to `docs/test-coverage-history.jsonl` as a side effect.
 
-3. **Update `docs/test-coverage.md`.** Replace the two existing tables with the script's output. Also update:
+3. **Update `docs/test-coverage.md`.** Replace the two existing tables with the script's `## Headline numbers` and `## Per-package summary` sections. **Do NOT paste the `## Δ from last run` block into the doc** — it's only for the chat summary in step 4. Also update:
    - The **Generated:** line at the top — bump the date and the commit SHA (`git rev-parse --short HEAD`).
-   - The **Run:** line — update the test count (grep the maven output for `Tests run: N`).
+   - The **Run:** line — update the test count to match `--tests N`.
    - The "Closed in this round" / "Remaining gaps" sections only if the user is doing a *substantive* coverage push. For a routine refresh, leave them alone.
 
-4. **Show the user a short summary.** Headline numbers and the deltas from the previous snapshot. Don't paste the whole table — they can read the doc.
+4. **Show the user a short summary.** Headline numbers, the deltas from the PR #59 baseline, *and* the Δ-from-last-run values from the script's trailing block. Don't paste the whole per-package table — they can read the doc.
+
+5. **Stage both files for commit.** `docs/test-coverage.md` and `docs/test-coverage-history.jsonl` should be committed together as part of the same refresh.
 
 ## Caveats
 
 - The script's baseline is hardcoded at PR #59 (commit `e2fcdb0`). Don't change it casually — it's the reference point that makes Δ values meaningful across snapshots. If the user wants a new baseline, edit `scripts/coverage-report.sh` deliberately and call it out.
+- `docs/test-coverage-history.jsonl` is **append-only**. The script writes one new line per run, and this file is committed alongside `docs/test-coverage.md` on every refresh. If a snapshot needs to be retracted (e.g. a botched run got committed), edit the file by hand and surface the edit to the user — don't silently drop entries.
 - Don't skip `clean` on the maven run — leftover `jacoco.exec` from a prior partial run can produce stale numbers.
 - If a class shows surprising coverage (e.g., a controller dropped from 100 % to 50 %), that's signal — surface it to the user before mechanically pasting the new tables.
 - Production code changes (renames, new classes, deletions) shift which classes appear and may invalidate the per-package baseline rows. If you see new packages or vanished ones, flag it.

--- a/scripts/coverage-report.sh
+++ b/scripts/coverage-report.sh
@@ -3,21 +3,72 @@
 # docs/test-coverage.md from a JaCoCo CSV. Δ columns compare against the
 # PR #59 baseline (commit e2fcdb0).
 #
+# Side effect: appends a JSON Lines snapshot to docs/test-coverage-history.jsonl
+# (resolved relative to this script). The trailing "## Δ from last run" block
+# on stdout is for the chat summary only — do NOT paste it into
+# docs/test-coverage.md.
+#
 # Usage:
-#   ./mvnw clean test                            # regenerate target/site/jacoco/jacoco.csv
-#   scripts/coverage-report.sh                   # print tables to stdout
-#   scripts/coverage-report.sh path/to/jacoco.csv
+#   ./mvnw clean test                                    # regenerate target/site/jacoco/jacoco.csv
+#   scripts/coverage-report.sh                           # print tables to stdout
+#   scripts/coverage-report.sh --tests 245               # also record test count in JSONL
+#   scripts/coverage-report.sh path/to/jacoco.csv        # custom CSV path
 
 set -euo pipefail
 
-CSV="${1:-target/site/jacoco/jacoco.csv}"
+CSV=""
+TESTS=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --tests)     TESTS="${2:-}"; shift 2 ;;
+        --tests=*)   TESTS="${1#*=}"; shift ;;
+        -h|--help)
+            sed -n '2,16p' "$0"
+            exit 0
+            ;;
+        *)
+            CSV="$1"; shift
+            ;;
+    esac
+done
+CSV="${CSV:-target/site/jacoco/jacoco.csv}"
 
 if [[ ! -f "$CSV" ]]; then
     echo "Error: $CSV not found. Run ./mvnw clean test first." >&2
     exit 1
 fi
 
-awk -F, '
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HISTORY_FILE="$REPO_ROOT/docs/test-coverage-history.jsonl"
+
+DATE_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+SHA="$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+
+# Read prior run's headline totals (if any) for the Δ-from-last-run block.
+# Tolerate missing/empty file. Extraction is regex-based on a known shape.
+PREV_INSTR=""; PREV_BRANCH=""; PREV_LINE=""; PREV_METHOD=""
+if [[ -f "$HISTORY_FILE" && -s "$HISTORY_FILE" ]]; then
+    PREV_RAW="$(tail -n 1 "$HISTORY_FILE")"
+    PREV_INSTR=$(printf '%s' "$PREV_RAW"  | sed -nE 's/.*"instructions":([0-9.]+).*/\1/p')
+    PREV_BRANCH=$(printf '%s' "$PREV_RAW" | sed -nE 's/.*"branches":([0-9.]+).*/\1/p')
+    PREV_LINE=$(printf '%s' "$PREV_RAW"   | sed -nE 's/.*"lines":([0-9.]+).*/\1/p')
+    PREV_METHOD=$(printf '%s' "$PREV_RAW" | sed -nE 's/.*"methods":([0-9.]+).*/\1/p')
+fi
+
+TMP_JSON="$(mktemp)"
+trap 'rm -f "$TMP_JSON"' EXIT
+
+awk -F, \
+    -v date_utc="$DATE_UTC" \
+    -v sha="$SHA" \
+    -v tests="${TESTS:-}" \
+    -v prev_instr="$PREV_INSTR" \
+    -v prev_branch="$PREV_BRANCH" \
+    -v prev_line_v="$PREV_LINE" \
+    -v prev_method="$PREV_METHOD" \
+    -v jsonpath="$TMP_JSON" \
+    '
 BEGIN {
     # Baseline snapshot: commit e2fcdb0 (PR #59 initial JaCoCo run).
     base_instr  = 84.0
@@ -53,6 +104,11 @@ function emoji(d) {
 function delta(d) {
     return sprintf("%s%.1f %% %s", (d >= 0 ? "+" : ""), d, emoji(d))
 }
+
+# Round to the same precision (1 dp) we display in the markdown tables and
+# persist to JSONL. Used for Δ-from-last-run so the diff matches what the
+# user sees (93.0 → 93.0 reads as +0.0, not -0.0 from float drift).
+function round1(x) { return sprintf("%.1f", x) + 0 }
 
 function comma(n,   s, len, out, i) {
     s = sprintf("%d", n); len = length(s); out = ""
@@ -121,5 +177,47 @@ END {
         printf "| %s | %.1f %% | %s | %s | %.1f %% | %d |\n",
             p, lp_pkg, delta(lp_pkg - bv), bp_pkg, mp_pkg, lm_p[p]
     }
+
+    # Build the JSON Lines entry and write it to a temp path. The shell
+    # appends it to the history file after we have read the prior last line.
+    json = "{\"date\":\"" date_utc "\",\"sha\":\"" sha "\","
+    json = json "\"tests\":" (tests == "" ? "null" : tests + 0) ","
+    json = json sprintf("\"totals\":{\"instructions\":%.1f,\"branches\":%.1f,\"lines\":%.1f,\"methods\":%.1f}", ip, bp, lp, mp)
+    json = json ",\"packages\":{"
+    sep = ""
+    for (i = 1; i <= n; i++) {
+        p = pkgs[i]
+        lp_pkg = 100 * lc_p[p] / (lm_p[p] + lc_p[p])
+        mp_pkg = 100 * mc_p[p] / (mm_p[p] + mc_p[p])
+        json = json sep "\"" p "\":{"
+        json = json sprintf("\"line\":%.1f,", lp_pkg)
+        if (bm_p[p] + bc_p[p] > 0) {
+            json = json sprintf("\"branch\":%.1f,", 100 * bc_p[p] / (bm_p[p] + bc_p[p]))
+        } else {
+            json = json "\"branch\":null,"
+        }
+        json = json sprintf("\"method\":%.1f,\"missed_lines\":%d}", mp_pkg, lm_p[p])
+        sep = ","
+    }
+    json = json "}}"
+    print json > jsonpath
+
+    # Δ-from-last-run block. Chat-summary only — do not paste into the doc.
+    print ""
+    print "## Δ from last run"
+    print ""
+    if (prev_instr == "") {
+        print "_First snapshot — no prior run to compare against._"
+    } else {
+        print "| Metric       | Coverage | Δ from last run |"
+        print "|--------------|---------:|----------------:|"
+        printf "| Instructions | %.1f %% | %s |\n", ip, delta(round1(ip) - prev_instr)
+        printf "| Branches     | %.1f %% | %s |\n", bp, delta(round1(bp) - prev_branch)
+        printf "| Lines        | %.1f %% | %s |\n", lp, delta(round1(lp) - prev_line_v)
+        printf "| Methods      | %.1f %% | %s |\n", mp, delta(round1(mp) - prev_method)
+    }
 }
 ' "$CSV"
+
+mkdir -p "$(dirname "$HISTORY_FILE")"
+cat "$TMP_JSON" >> "$HISTORY_FILE"


### PR DESCRIPTION
## Summary
- The coverage-report script's only delta column compared against the hardcoded PR #59 baseline — good for long-term trend, no signal for "what did this PR move?"
- Append one JSON line per run to `docs/test-coverage-history.jsonl` (date, sha, tests, totals, per-package line/branch/method/missed_lines).
- New `## Δ from last run` markdown block on stdout, computed against the previous JSONL entry; chat-summary only, not pasted into `docs/test-coverage.md`. First run prints a "first snapshot" fallback.
- New optional `--tests N` flag, recorded in the JSONL entry; the coverage-report skill now passes it from the maven Tests-run count and commits the history file alongside the doc.
- Existing headline/per-package tables and the PR #59 baseline column are unchanged. CI integration (PR comments, coverage gate) intentionally out of scope.

## Test plan
- [ ] Run `./scripts/coverage-report.sh --tests 123` on a clean tree; confirm a new line is appended to `docs/test-coverage-history.jsonl` and the stdout ends with a `## Δ from last run` block.
- [ ] Run it a second time with no code changes; confirm the Δ block reads +0.0 ⚪ across the board (no float-drift −0.0).
- [ ] Run it once with the history file removed; confirm the "first snapshot" fallback fires and a fresh file is created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)