### PR TITLE
Fix Thymeleaf application-attribute collision on edit form

### DIFF
--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -71,10 +71,6 @@ Four small additions, all targeting security-adjacent oauth2 / signup branches t
 - `auth.TenantUserDetailsMixin` and `auth.TenantAuthTokenMixin` (0 %): abstract Jackson mixin classes. Their effects are observed indirectly via OAuth2 authorization (de)serialization round-trips.
 - `LimenApplication` (33 %): Spring Boot entry point.
 
-## Findings surfaced (not test-coverage gaps but worth noting)
-
-- **Bug: `GET /manage/t/{slug}/applications/{appId}/edit` is broken.** The controller passes `application` as a model attribute, but Thymeleaf reserves `application` for its `ApplicationAttributeMap` context object. The reserved name shadows the controller's attribute, so `${application.name()}` in `manage/applications/edit.html` fails with `EL1004E: Method name() cannot be found on type ...ApplicationAttributeMap`. Pre-existing — uncovered because no test (and presumably no user) hit the edit-form GET. Fix: rename the model attribute to `app` (matching the convention in `list.html`) and update the template references in `edit.html`. Out of scope for this coverage round.
-
 ## Re-running this report
 
 ```sh

--- a/src/main/java/com/stucray/limen/management/applications/ApplicationController.java
+++ b/src/main/java/com/stucray/limen/management/applications/ApplicationController.java
@@ -61,7 +61,7 @@ public class ApplicationController {
         Model model
     ) {
         model.addAttribute("slug", slug);
-        model.addAttribute("application", applicationService.getApplication(appId, principal.tenantId()));
+        model.addAttribute("app", applicationService.getApplication(appId, principal.tenantId()));
         return "manage/applications/edit";
     }
 

--- a/src/main/resources/templates/manage/applications/edit.html
+++ b/src/main/resources/templates/manage/applications/edit.html
@@ -6,23 +6,23 @@
     <ol class="breadcrumb" aria-label="breadcrumb">
         <li><a th:href="@{'/manage/t/' + ${slug} + '/'}">Home</a></li>
         <li><a th:href="@{'/manage/t/' + ${slug} + '/applications'}">Applications</a></li>
-        <li th:text="${application.name()}">App</li>
+        <li th:text="${app.name()}">App</li>
     </ol>
 
     <hgroup>
         <h1>Edit application</h1>
-        <p th:text="${application.name()}">App name</p>
+        <p th:text="${app.name()}">App name</p>
     </hgroup>
 
-    <form method="post" th:action="@{'/manage/t/' + ${slug} + '/applications/' + ${application.id()} + '/edit'}" class="stack section">
+    <form method="post" th:action="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/edit'}" class="stack section">
         <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
         <label>
             Name
-            <input type="text" name="name" th:value="${application.name()}" required/>
+            <input type="text" name="name" th:value="${app.name()}" required/>
         </label>
         <label>
             Description
-            <textarea name="description" th:text="${application.description()}"></textarea>
+            <textarea name="description" th:text="${app.description()}"></textarea>
         </label>
         <div class="form-actions">
             <button type="submit">Save</button>

--- a/src/test/java/com/stucray/limen/management/applications/ApplicationManagementIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/applications/ApplicationManagementIntegrationTest.java
@@ -111,6 +111,22 @@ class ApplicationManagementIntegrationTest {
         assertThat(applicationRepository.findById(app.id()).orElseThrow().name()).isEqualTo("New Name");
     }
 
+    // Regression: the model attribute used to be named "application", which collides with
+    // Thymeleaf's reserved ApplicationAttributeMap context object. The expression
+    // ${application.name()} silently resolved to the reserved object, and the GET render
+    // failed with EL1004E. The previous edit test only exercised POST, so the bug shipped
+    // invisibly. Rendering must succeed and contain the existing application's name.
+    @Test
+    void editFormGetRendersExistingApplication() throws Exception {
+        Application app = applicationRepository.save(
+            new Application(null, tenantA.id(), "Acme Widgets", "widget catalogue", LocalDateTime.now()));
+
+        mockMvc.perform(get("/manage/t/corp-a/applications/" + app.id() + "/edit").session(sessionA))
+            .andExpect(status().isOk())
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("Acme Widgets")))
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("widget catalogue")));
+    }
+
     @Test
     void ownerCanDeleteApplicationWithoutClients() throws Exception {
         Application app = applicationRepository.save(new Application(null, tenantA.id(), "App", null, LocalDateTime.now()));


### PR DESCRIPTION
## Summary
`GET /manage/t/{slug}/applications/{appId}/edit` was broken. The controller put the `Application` record on the model under the name `application`, which collides with Thymeleaf's reserved `ApplicationAttributeMap` context object (a wrapper around the servlet `ApplicationContext`). The reserved name shadowed the controller's attribute, so `${application.name()}` in `edit.html` resolved to the `ApplicationAttributeMap` and rendering failed with `EL1004E: Method name() cannot be found on type ...ApplicationAttributeMap`.

The bug shipped invisibly because the existing `ownerCanEditApplication` test only exercised `POST /edit` (the form submit). The GET render path had no test, and presumably no user reached the edit form.

## Changes
- **`ApplicationController.editForm`** — rename model attribute `"application"` → `"app"`. Also matches the convention `list.html` already uses (`th:each="app : ${applications}"`).
- **`manage/applications/edit.html`** — rename five `${application...}` references to `${app...}`.
- **`ApplicationManagementIntegrationTest`** — add `editFormGetRendersExistingApplication` regression test that GETs the edit form and asserts the existing application's name + description render. Inline comment explains why the regression existed.
- **`docs/test-coverage.md`** — drop the "Findings surfaced" entry that flagged this bug.

## Test plan
- [ ] `./mvnw test -Dtest=ApplicationManagementIntegrationTest` — 9 tests pass (was 8).
- [ ] `./mvnw clean test` — full suite passes (252 tests).
- [ ] Manually browse to the edit form for an existing application and confirm the name + description render in the breadcrumb, hgroup, and form fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)