### PR TITLE
Annotate every JUnit test class and method with @DisplayName

### DIFF
--- a/src/test/java/com/stucray/limen/IssuerContractTest.java
+++ b/src/test/java/com/stucray/limen/IssuerContractTest.java
@@ -4,6 +4,7 @@ import com.stucray.limen.tenant.TenantRepository;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -28,6 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@DisplayName("OIDC issuer contract")
 class IssuerContractTest {
 
     private static final String CLIENT_ID = "bff-client";
@@ -67,6 +69,7 @@ class IssuerContractTest {
     }
 
     @Test
+    @DisplayName("/.well-known/openid-configuration advertises issuer, JWKS, authorize, and token endpoints")
     void openidConfigurationHasCorrectEndpoints() throws Exception {
         mockMvc.perform(get("/.well-known/openid-configuration"))
             .andExpect(status().isOk())

--- a/src/test/java/com/stucray/limen/LimenApplicationTests.java
+++ b/src/test/java/com/stucray/limen/LimenApplicationTests.java
@@ -1,14 +1,17 @@
 package com.stucray.limen;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
+@DisplayName("Spring application context")
 class LimenApplicationTests {
 
 	@Test
+	@DisplayName("Boots cleanly against Postgres + the full bean graph")
 	void contextLoads() {
 	}
 

--- a/src/test/java/com/stucray/limen/LoginIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/LoginIntegrationTest.java
@@ -4,6 +4,7 @@ import com.stucray.limen.tenant.TenantRepository;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -33,6 +34,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@DisplayName("Landing page + bare-/login forwarder")
 class LoginIntegrationTest {
 
     @Autowired MockMvc mockMvc;
@@ -53,6 +55,7 @@ class LoginIntegrationTest {
     }
 
     @Test
+    @DisplayName("GET /login with no slug redirects to the landing page")
     void bareLoginRedirectsToLanding() throws Exception {
         mockMvc.perform(get("/login"))
             .andExpect(status().is3xxRedirection())
@@ -60,6 +63,7 @@ class LoginIntegrationTest {
     }
 
     @Test
+    @DisplayName("GET /login?slug=acme redirects to that tenant's management login")
     void loginWithSlugRedirectsToTenantLogin() throws Exception {
         mockMvc.perform(get("/login").param("slug", "acme"))
             .andExpect(status().is3xxRedirection())
@@ -67,6 +71,7 @@ class LoginIntegrationTest {
     }
 
     @Test
+    @DisplayName("GET / renders the landing page with both sign-in and sign-up affordances")
     void rootRendersLandingPage() throws Exception {
         mockMvc.perform(get("/"))
             .andExpect(status().isOk())
@@ -75,6 +80,7 @@ class LoginIntegrationTest {
     }
 
     @Test
+    @DisplayName("System admin signs in at /manage/t/system/login and lands on /manage/t/system/")
     void systemAdminLoginAtSystemTenantSucceeds() throws Exception {
         mockMvc.perform(post("/manage/t/system/login")
                 .param("username", "testuser")

--- a/src/test/java/com/stucray/limen/auth/CrossTenantLoginIsolationIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/auth/CrossTenantLoginIsolationIntegrationTest.java
@@ -7,6 +7,7 @@ import com.stucray.limen.tenant.TenantStatus;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -30,6 +31,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@DisplayName("Cross-tenant credential isolation")
 class CrossTenantLoginIsolationIntegrationTest {
 
     @Autowired MockMvc mockMvc;
@@ -63,6 +65,7 @@ class CrossTenantLoginIsolationIntegrationTest {
     }
 
     @Test
+    @DisplayName("OAuth2 surface: alice@alpha cannot sign in with beta's password")
     void oauth2LoginRejectsOtherTenantsPassword() throws Exception {
         mockMvc.perform(post("/t/alpha/login")
                 .param("username", "alice")
@@ -73,6 +76,7 @@ class CrossTenantLoginIsolationIntegrationTest {
     }
 
     @Test
+    @DisplayName("Management surface: alice@alpha cannot sign in with beta's password")
     void managementLoginRejectsOtherTenantsPassword() throws Exception {
         mockMvc.perform(post("/manage/t/alpha/login")
                 .param("username", "alice")
@@ -83,6 +87,7 @@ class CrossTenantLoginIsolationIntegrationTest {
     }
 
     @Test
+    @DisplayName("OAuth2 surface: alice@alpha signs in successfully with alpha's password")
     void oauth2LoginAcceptsOwnTenantsPassword() throws Exception {
         mockMvc.perform(post("/t/alpha/login")
                 .param("username", "alice")

--- a/src/test/java/com/stucray/limen/auth/TenantPersistentTokenBasedRememberMeServicesIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/auth/TenantPersistentTokenBasedRememberMeServicesIntegrationTest.java
@@ -8,6 +8,7 @@ import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -39,6 +40,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@DisplayName("Remember-me end-to-end (cookie + persisted row)")
 class TenantPersistentTokenBasedRememberMeServicesIntegrationTest {
 
     @Autowired MockMvc mockMvc;
@@ -66,6 +68,7 @@ class TenantPersistentTokenBasedRememberMeServicesIntegrationTest {
     }
 
     @Test
+    @DisplayName("OAuth2 login: persisted persistent_logins row carries the user's tenant_id")
     void rememberMeRowOnOAuth2LoginCarriesTenantId() throws Exception {
         mockMvc.perform(post("/t/alpha-rm/login")
                 .param("username", "alice")
@@ -88,6 +91,7 @@ class TenantPersistentTokenBasedRememberMeServicesIntegrationTest {
     }
 
     @Test
+    @DisplayName("Management login: persisted persistent_logins row carries the user's tenant_id")
     void rememberMeOnManagementLoginCarriesTenantId() throws Exception {
         mockMvc.perform(post("/manage/t/alpha-rm/login")
                 .param("username", "alice")
@@ -104,6 +108,7 @@ class TenantPersistentTokenBasedRememberMeServicesIntegrationTest {
     }
 
     @Test
+    @DisplayName("Issued cookie value (base64-decoded) is series:token:slug")
     void cookieValueIncludesSlugAsThirdSegment() throws Exception {
         MvcResult result = mockMvc.perform(post("/t/alpha-rm/login")
                 .param("username", "alice")
@@ -124,6 +129,7 @@ class TenantPersistentTokenBasedRememberMeServicesIntegrationTest {
     }
 
     @Test
+    @DisplayName("Tampered cookie token triggers CookieTheftException and removes all of the user's tokens")
     void tamperedCookieTokenInvalidatesAllOfUsersTokens() throws Exception {
         Cookie rememberMeCookie = loginAndGetRememberMeCookie("/manage/t/alpha-rm/login", "alpha-pwd");
         assertThat(rememberMeCookie).isNotNull();
@@ -146,6 +152,7 @@ class TenantPersistentTokenBasedRememberMeServicesIntegrationTest {
     }
 
     @Test
+    @DisplayName("Expired persistent token is rejected, but the row is preserved (only theft removes it)")
     void expiredCookieIsRejected() throws Exception {
         Cookie rememberMeCookie = loginAndGetRememberMeCookie("/manage/t/alpha-rm/login", "alpha-pwd");
         assertThat(rememberMeCookie).isNotNull();
@@ -165,6 +172,7 @@ class TenantPersistentTokenBasedRememberMeServicesIntegrationTest {
     }
 
     @Test
+    @DisplayName("Logout deletes the persistent_logins row and redirects back to the tenant's login page")
     void logoutRemovesPersistentTokenAndRedirectsToTenantLogin() throws Exception {
         MvcResult login = mockMvc.perform(post("/manage/t/alpha-rm/login")
                 .param("username", "alice")

--- a/src/test/java/com/stucray/limen/auth/TenantPersistentTokenBasedRememberMeServicesUnitTest.java
+++ b/src/test/java/com/stucray/limen/auth/TenantPersistentTokenBasedRememberMeServicesUnitTest.java
@@ -7,6 +7,7 @@ import com.stucray.limen.tenant.TenantStatus;
 import com.stucray.limen.user.User;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -28,6 +29,7 @@ import static org.mockito.BDDMockito.given;
  * Avoids loading a Spring context — exercises pure logic only.
  */
 @ExtendWith(MockitoExtension.class)
+@DisplayName("Remember-me services: cookie encode/decode")
 class TenantPersistentTokenBasedRememberMeServicesUnitTest {
 
     @Mock TenantUserDetailsService userDetailsService;
@@ -60,6 +62,7 @@ class TenantPersistentTokenBasedRememberMeServicesUnitTest {
     }
 
     @Test
+    @DisplayName("Issued cookie encodes series:token:slug — slug is the third segment")
     void onLoginSuccessIssuesCookieWithSeriesTokenSlug() {
         TenantUserDetails principal = new TenantUserDetails(alice, alpha);
         UsernamePasswordAuthenticationToken auth = UsernamePasswordAuthenticationToken
@@ -80,6 +83,7 @@ class TenantPersistentTokenBasedRememberMeServicesUnitTest {
     }
 
     @Test
+    @DisplayName("Cookie carrying a different tenant's slug is rejected and cancelled")
     void processAutoLoginRejectsCookieWithMismatchedSlug() {
         // Build a base64-encoded `series:token:slug` cookie value where slug = beta
         String value = base64("ser-1:tok-1:beta");
@@ -97,6 +101,7 @@ class TenantPersistentTokenBasedRememberMeServicesUnitTest {
     }
 
     @Test
+    @DisplayName("Legacy 2-segment cookie (no slug) is rejected and cancelled")
     void processAutoLoginRejectsCookieWithWrongSegmentCount() {
         // Build a 2-segment cookie (legacy / pre-V2 format) — also rejected.
         String value = base64("ser-1:tok-1");
@@ -112,6 +117,7 @@ class TenantPersistentTokenBasedRememberMeServicesUnitTest {
     }
 
     @Test
+    @DisplayName("Cookie carrying a slug for a no-longer-existing tenant is rejected")
     void processAutoLoginRejectsUnknownSlug() {
         given(tenantRepository.findBySlug("alpha")).willReturn(Optional.empty());
 

--- a/src/test/java/com/stucray/limen/auth/TenantPersistentTokenRepositoryIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/auth/TenantPersistentTokenRepositoryIntegrationTest.java
@@ -5,6 +5,7 @@ import com.stucray.limen.tenant.Tenant;
 import com.stucray.limen.tenant.TenantRepository;
 import com.stucray.limen.tenant.TenantStatus;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -19,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
+@DisplayName("TenantPersistentTokenRepository: tenant-scoped CRUD")
 class TenantPersistentTokenRepositoryIntegrationTest {
 
     @Autowired TenantPersistentTokenRepository repo;
@@ -37,6 +39,7 @@ class TenantPersistentTokenRepositoryIntegrationTest {
     }
 
     @Test
+    @DisplayName("getTokenForSeries returns the row only when called with the matching tenant_id")
     void createAndGetIsTenantScoped() {
         repo.createNewToken(new PersistentRememberMeToken("alice", "series-1", "tok-1", new Date()), alpha.id());
         repo.createNewToken(new PersistentRememberMeToken("alice", "series-2", "tok-2", new Date()), beta.id());
@@ -51,6 +54,7 @@ class TenantPersistentTokenRepositoryIntegrationTest {
     }
 
     @Test
+    @DisplayName("updateToken under the wrong tenant_id is a no-op; under the right one it replaces the token")
     void updateIsTenantScoped() {
         repo.createNewToken(new PersistentRememberMeToken("alice", "series-3", "old-tok", new Date()), alpha.id());
 
@@ -64,6 +68,7 @@ class TenantPersistentTokenRepositoryIntegrationTest {
     }
 
     @Test
+    @DisplayName("removeUserTokens deletes only the rows belonging to the named tenant")
     void removeUserTokensIsTenantScoped() {
         repo.createNewToken(new PersistentRememberMeToken("alice", "series-4", "tok-a", new Date()), alpha.id());
         repo.createNewToken(new PersistentRememberMeToken("alice", "series-5", "tok-b", new Date()), beta.id());
@@ -76,6 +81,7 @@ class TenantPersistentTokenRepositoryIntegrationTest {
     }
 
     @Test
+    @DisplayName("Two tenants can store rows for the same series — (tenant_id, series) is the composite PK")
     void sameSeriesAcrossTenantsCoexist() {
         // (tenant_id, series) is the PK so both rows can persist with the same series.
         repo.createNewToken(new PersistentRememberMeToken("alice", "shared", "tok-a", new Date()), alpha.id());

--- a/src/test/java/com/stucray/limen/auth/TenantUserDetailsServiceUnitTest.java
+++ b/src/test/java/com/stucray/limen/auth/TenantUserDetailsServiceUnitTest.java
@@ -6,6 +6,7 @@ import com.stucray.limen.tenant.TenantStatus;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -21,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
+@DisplayName("TenantUserDetailsService")
 class TenantUserDetailsServiceUnitTest {
 
     @Mock TenantRepository tenantRepository;
@@ -39,6 +41,7 @@ class TenantUserDetailsServiceUnitTest {
     }
 
     @Test
+    @DisplayName("Returns TenantUserDetails carrying both username and tenant slug for a known user")
     void loadByUsernameAndSlugReturnsTenantUserDetailsForKnownUser() {
         given(tenantRepository.findBySlug("alpha")).willReturn(Optional.of(alpha));
         given(userRepository.findByUsernameAndTenantId("alice", 1L)).willReturn(Optional.of(alice));
@@ -53,6 +56,7 @@ class TenantUserDetailsServiceUnitTest {
     }
 
     @Test
+    @DisplayName("Throws UsernameNotFoundException when the slug does not resolve to a tenant")
     void loadByUsernameAndSlugThrowsWhenTenantSlugUnknown() {
         given(tenantRepository.findBySlug("ghost")).willReturn(Optional.empty());
 
@@ -62,6 +66,7 @@ class TenantUserDetailsServiceUnitTest {
     }
 
     @Test
+    @DisplayName("Throws UsernameNotFoundException when the user is unknown within the resolved tenant")
     void loadByUsernameAndSlugThrowsWhenUserUnknownInTenant() {
         given(tenantRepository.findBySlug("alpha")).willReturn(Optional.of(alpha));
         given(userRepository.findByUsernameAndTenantId("nobody", 1L)).willReturn(Optional.empty());
@@ -72,6 +77,7 @@ class TenantUserDetailsServiceUnitTest {
     }
 
     @Test
+    @DisplayName("loadUserByUsername (the slugless API) always throws — slug is required")
     void loadUserByUsernameAlwaysThrowsBecauseSlugIsRequired() {
         assertThatThrownBy(() -> service.loadUserByUsername("alice"))
             .isInstanceOf(UnsupportedOperationException.class)

--- a/src/test/java/com/stucray/limen/auth/login/PostLoginIntentsUnitTest.java
+++ b/src/test/java/com/stucray/limen/auth/login/PostLoginIntentsUnitTest.java
@@ -5,6 +5,7 @@ import com.stucray.limen.tenant.Tenant;
 import com.stucray.limen.tenant.TenantStatus;
 import com.stucray.limen.user.User;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -25,6 +26,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
+@DisplayName("PostLoginIntents (success-handler chain)")
 class PostLoginIntentsUnitTest {
 
     private static final TenantUrlScheme OAUTH2 = new TenantUrlScheme(
@@ -60,6 +62,7 @@ class PostLoginIntentsUnitTest {
     }
 
     @Test
+    @DisplayName("passwordChangeRequired: redirects to the tenant change-password URL when must_change_password is set")
     void passwordChangeRequiredRedirectsWhenFlagSet() {
         PostLoginIntent intent = PostLoginIntents.passwordChangeRequired();
 
@@ -69,6 +72,7 @@ class PostLoginIntentsUnitTest {
     }
 
     @Test
+    @DisplayName("passwordChangeRequired: returns null (falls through) when the flag is not set")
     void passwordChangeRequiredFallsThroughWhenFlagNotSet() {
         PostLoginIntent intent = PostLoginIntents.passwordChangeRequired();
 
@@ -78,6 +82,7 @@ class PostLoginIntentsUnitTest {
     }
 
     @Test
+    @DisplayName("resumeOAuth2Authorize: rewrites a saved /oauth2/authorize URL to /t/{slug}/oauth2/authorize and clears the cache")
     void resumeOAuth2AuthorizeReturnsTenantPrefixedUrlAndClearsCache() {
         given(requestCache.getRequest(req, res)).willReturn(savedRequest);
         given(savedRequest.getRedirectUrl())
@@ -92,6 +97,7 @@ class PostLoginIntentsUnitTest {
     }
 
     @Test
+    @DisplayName("resumeOAuth2Authorize: returns null and leaves the cache untouched when there is no saved request")
     void resumeOAuth2AuthorizeFallsThroughWhenNoSavedRequest() {
         given(requestCache.getRequest(req, res)).willReturn(null);
         PostLoginIntent intent = PostLoginIntents.resumeOAuth2Authorize(requestCache);
@@ -103,6 +109,7 @@ class PostLoginIntentsUnitTest {
     }
 
     @Test
+    @DisplayName("resumeOAuth2Authorize: returns null when the saved request is not for /oauth2/authorize")
     void resumeOAuth2AuthorizeFallsThroughWhenSavedRequestIsNotAuthorize() {
         given(requestCache.getRequest(req, res)).willReturn(savedRequest);
         given(savedRequest.getRedirectUrl()).willReturn("http://localhost/some-other-page");
@@ -115,6 +122,7 @@ class PostLoginIntentsUnitTest {
     }
 
     @Test
+    @DisplayName("tenantHome: always returns /t/{principal-slug}/ — the catch-all default")
     void tenantHomeAlwaysReturnsHomeUrlForPrincipalSlug() {
         PostLoginIntent intent = PostLoginIntents.tenantHome();
 

--- a/src/test/java/com/stucray/limen/auth/login/SyntheticSchemeIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/auth/login/SyntheticSchemeIntegrationTest.java
@@ -7,6 +7,7 @@ import com.stucray.limen.tenant.TenantStatus;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -46,6 +47,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import({TestcontainersConfiguration.class, SyntheticSchemeIntegrationTest.SyntheticSchemeConfig.class})
 @SpringBootTest
 @AutoConfigureMockMvc
+@DisplayName("TenantUrlScheme bean discovery — synthetic third surface")
 class SyntheticSchemeIntegrationTest {
 
     @Autowired MockMvc mockMvc;
@@ -74,12 +76,14 @@ class SyntheticSchemeIntegrationTest {
     }
 
     @Test
+    @DisplayName("Application context exposes 3 TenantUrlScheme beans (default 2 + synthetic)")
     void threeSchemesAreRegistered() {
         // Pin discoverability: the synthetic scheme is visible alongside the two defaults.
         assertThat(applicationContext.getBeansOfType(TenantUrlScheme.class)).hasSize(3);
     }
 
     @Test
+    @DisplayName("Alpha session hitting /api/t/beta/... is force-logged-out and redirected to /api/t/beta/login")
     void crossTenantAccessOnSyntheticSurfaceForcesLogoutAndRedirects() throws Exception {
         MvcResult loginResult = mockMvc.perform(post("/manage/t/alpha/login")
                 .param("username", "owner")

--- a/src/test/java/com/stucray/limen/auth/login/TenantLoginUnitTest.java
+++ b/src/test/java/com/stucray/limen/auth/login/TenantLoginUnitTest.java
@@ -2,6 +2,7 @@ package com.stucray.limen.auth.login;
 
 import com.stucray.limen.auth.TenantPersistentTokenBasedRememberMeServices;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -16,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ExtendWith(MockitoExtension.class)
+@DisplayName("TenantLogin (immutable wither chain + intent ordering)")
 class TenantLoginUnitTest {
 
     @Mock AuthenticationManager authManager;
@@ -35,6 +37,7 @@ class TenantLoginUnitTest {
     }
 
     @Test
+    @DisplayName("withIntents() returns a new instance and leaves the original's intent list intact")
     void withIntentsReturnsNewInstanceWithoutMutatingOriginal() {
         TenantLogin replaced = original.withIntents(List.of(intentC));
 
@@ -44,6 +47,7 @@ class TenantLoginUnitTest {
     }
 
     @Test
+    @DisplayName("withRememberMe() returns a new instance and leaves the original's flag intact")
     void withRememberMeReturnsNewInstanceWithoutMutatingOriginal() {
         TenantLogin disabled = original.withRememberMe(false);
 
@@ -53,6 +57,7 @@ class TenantLoginUnitTest {
     }
 
     @Test
+    @DisplayName("withRememberMe() and withIntents() can be chained and compose without mutating the original")
     void withMethodsAreChainable() {
         TenantLogin chained = original.withRememberMe(false).withIntents(List.of(intentC));
 
@@ -63,6 +68,7 @@ class TenantLoginUnitTest {
     }
 
     @Test
+    @DisplayName("Two intents with the same explicit @Order value blow up at startup")
     void verifyOrderUniquenessRejectsDuplicateExplicitOrders() throws Exception {
         @Order(50) class IntentX implements PostLoginIntent {
             public String resolve(jakarta.servlet.http.HttpServletRequest req,
@@ -94,6 +100,7 @@ class TenantLoginUnitTest {
     }
 
     @Test
+    @DisplayName("Distinct explicit @Order values are accepted")
     void verifyOrderUniquenessAllowsDistinctExplicitOrders() throws Exception {
         @Order(10) class IntentX implements PostLoginIntent {
             public String resolve(jakarta.servlet.http.HttpServletRequest req,
@@ -116,6 +123,7 @@ class TenantLoginUnitTest {
     }
 
     @Test
+    @DisplayName("Intents without an explicit @Order are not subject to the uniqueness check")
     void verifyOrderUniquenessIgnoresIntentsWithoutOrder() throws Exception {
         // Two lambda intents have no @Order annotation; default chain mixes them with no collision.
         TenantLogin login = new TenantLogin(authManager, rememberMe, "key",

--- a/src/test/java/com/stucray/limen/auth/login/TenantUrlSchemeUnitTest.java
+++ b/src/test/java/com/stucray/limen/auth/login/TenantUrlSchemeUnitTest.java
@@ -1,5 +1,6 @@
 package com.stucray.limen.auth.login;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpMethod;
 
@@ -8,6 +9,7 @@ import java.util.regex.Pattern;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@DisplayName("TenantUrlScheme: slug parsing + URL templating")
 class TenantUrlSchemeUnitTest {
 
     private static final TenantUrlScheme OAUTH2 = new TenantUrlScheme(
@@ -29,79 +31,93 @@ class TenantUrlSchemeUnitTest {
     );
 
     @Test
+    @DisplayName("slugFrom: extracts the slug from /t/{slug}/login on the OAuth2 surface")
     void slugFromHappyPathOAuth2Login() {
         assertThat(OAUTH2.slugFrom("/t/alpha/login")).isEqualTo("alpha");
     }
 
     @Test
+    @DisplayName("slugFrom: extracts the slug from /manage/t/{slug}/login on the management surface")
     void slugFromHappyPathManagementLogin() {
         assertThat(MANAGEMENT.slugFrom("/manage/t/alpha/login")).isEqualTo("alpha");
     }
 
     @Test
+    @DisplayName("slugFrom: extracts the slug from /t/{slug} (no trailing segment)")
     void slugFromAcceptsBaseTenantUrlWithoutTrailingSegment() {
         assertThat(OAUTH2.slugFrom("/t/alpha")).isEqualTo("alpha");
     }
 
     @Test
+    @DisplayName("slugFrom: returns null when the URI is for a different surface (no cross-scheme matching)")
     void slugFromReturnsNullWhenUriDoesNotMatchScheme() {
         assertThat(OAUTH2.slugFrom("/manage/t/alpha/login")).isNull();
         assertThat(MANAGEMENT.slugFrom("/t/alpha/login")).isNull();
     }
 
     @Test
+    @DisplayName("slugFrom: returns null when the URI has no /t/ prefix at all")
     void slugFromReturnsNullForMalformedUri() {
         // No /t/ prefix, no slug capture.
         assertThat(OAUTH2.slugFrom("/some/random/path")).isNull();
     }
 
     @Test
+    @DisplayName("slugFrom: returns null when the slug segment is empty (//)")
     void slugFromReturnsNullForEmptySlug() {
         // Pattern uses [^/]+ which requires at least one char, so // collapses to no match.
         assertThat(OAUTH2.slugFrom("/t//login")).isNull();
     }
 
     @Test
+    @DisplayName("slugFrom: returns null when the URI is null")
     void slugFromReturnsNullForNullUri() {
         assertThat(OAUTH2.slugFrom((String) null)).isNull();
     }
 
     @Test
+    @DisplayName("slugFrom: accepts hyphens and dots inside the slug (e.g. acme-corp.io)")
     void slugFromAcceptsSlugWithSpecialCharacters() {
         assertThat(OAUTH2.slugFrom("/t/acme-corp.io/login")).isEqualTo("acme-corp.io");
     }
 
     @Test
+    @DisplayName("loginUrl: renders the login URL template for both surfaces")
     void loginUrlRendersTemplate() {
         assertThat(OAUTH2.loginUrl("alpha")).isEqualTo("/t/alpha/login");
         assertThat(MANAGEMENT.loginUrl("alpha")).isEqualTo("/manage/t/alpha/login");
     }
 
     @Test
+    @DisplayName("homeUrl: renders the post-login home URL template for both surfaces")
     void homeUrlRendersTemplate() {
         assertThat(OAUTH2.homeUrl("alpha")).isEqualTo("/t/alpha/");
         assertThat(MANAGEMENT.homeUrl("alpha")).isEqualTo("/manage/t/alpha/");
     }
 
     @Test
+    @DisplayName("changePasswordUrl: renders the change-password URL template for both surfaces")
     void changePasswordUrlRendersTemplate() {
         assertThat(OAUTH2.changePasswordUrl("alpha")).isEqualTo("/t/alpha/change-password");
         assertThat(MANAGEMENT.changePasswordUrl("alpha")).isEqualTo("/manage/t/alpha/change-password");
     }
 
     @Test
+    @DisplayName("loginUrl: rejects an empty slug")
     void loginUrlRejectsEmptySlug() {
         assertThatThrownBy(() -> OAUTH2.loginUrl(""))
             .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
+    @DisplayName("homeUrl: rejects a null slug")
     void homeUrlRejectsNullSlug() {
         assertThatThrownBy(() -> OAUTH2.homeUrl(null))
             .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
+    @DisplayName("changePasswordUrl: rejects an empty slug")
     void changePasswordUrlRejectsEmptySlug() {
         assertThatThrownBy(() -> OAUTH2.changePasswordUrl(""))
             .isInstanceOf(IllegalArgumentException.class);

--- a/src/test/java/com/stucray/limen/identity/UserBootstrapTest.java
+++ b/src/test/java/com/stucray/limen/identity/UserBootstrapTest.java
@@ -7,6 +7,7 @@ import com.stucray.limen.tenant.TenantStatus;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -21,6 +22,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
+@DisplayName("Startup user-bootstrap runner")
 class UserBootstrapTest {
 
     @Mock TenantRepository tenantRepository;
@@ -39,6 +41,7 @@ class UserBootstrapTest {
     private static final BootstrapAdminProperties ADMIN = new BootstrapAdminProperties("admin", "pass");
 
     @Test
+    @DisplayName("Always looks up the system tenant on startup, even with no admin credentials configured")
     void alwaysBootstrapsSystemTenant() throws Exception {
         new UserBootstrap(NO_ADMIN, tenantRepository, tenantProvisioningService, userRepository, passwordEncoder).run();
         verify(tenantRepository).findBySlug("system");
@@ -46,6 +49,7 @@ class UserBootstrapTest {
     }
 
     @Test
+    @DisplayName("Provisions the system tenant when it does not yet exist")
     void createsSystemTenantWhenAbsent() throws Exception {
         given(tenantRepository.findBySlug("system")).willReturn(Optional.empty());
         given(tenantProvisioningService.createTenant("system", "System")).willReturn(SYSTEM_TENANT);
@@ -56,12 +60,14 @@ class UserBootstrapTest {
     }
 
     @Test
+    @DisplayName("Skips user creation entirely when no bootstrap admin credentials are configured")
     void doesNothingWithUsersWhenCredentialsUnset() throws Exception {
         new UserBootstrap(NO_ADMIN, tenantRepository, tenantProvisioningService, userRepository, passwordEncoder).run();
         verifyNoInteractions(userRepository, passwordEncoder);
     }
 
     @Test
+    @DisplayName("Creates the configured admin user in the system tenant with an encoded password")
     void createsAdminUserInSystemTenantWhenAbsent() throws Exception {
         given(userRepository.findByUsernameAndTenantId("admin", 1L)).willReturn(Optional.empty());
         given(passwordEncoder.encode("pass")).willReturn("hashed");
@@ -75,6 +81,7 @@ class UserBootstrapTest {
     }
 
     @Test
+    @DisplayName("Re-hashes and saves the admin password when the admin user already exists")
     void updatesPasswordHashWhenAdminUserExists() throws Exception {
         var existing = new User(10L, 1L, "admin", "oldhash", true, false, false, LocalDateTime.now());
         given(userRepository.findByUsernameAndTenantId("admin", 1L)).willReturn(Optional.of(existing));

--- a/src/test/java/com/stucray/limen/management/ManagementForcedPasswordChangeIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/ManagementForcedPasswordChangeIntegrationTest.java
@@ -11,6 +11,7 @@ import com.stucray.limen.tenant.TenantStatus;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -51,6 +52,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@DisplayName("Management surface: forced password change + saved /authorize resume")
 class ManagementForcedPasswordChangeIntegrationTest {
 
     @Autowired MockMvc mockMvc;
@@ -102,6 +104,7 @@ class ManagementForcedPasswordChangeIntegrationTest {
     }
 
     @Test
+    @DisplayName("Login with must_change_password=true redirects to /manage/t/{slug}/change-password")
     void managementLoginRedirectsToChangePasswordWhenMustChangeFlagSet() throws Exception {
         userRepository.save(new User(
             null, tenant.id(), "alice",
@@ -119,6 +122,7 @@ class ManagementForcedPasswordChangeIntegrationTest {
     }
 
     @Test
+    @DisplayName("Login with a saved /oauth2/authorize redirects to the tenant-prefixed authorize URL, not the management home")
     void managementLoginResumesSavedOAuth2AuthorizeRequest() throws Exception {
         userRepository.save(new User(
             null, tenant.id(), "owner",
@@ -140,6 +144,7 @@ class ManagementForcedPasswordChangeIntegrationTest {
     }
 
     @Test
+    @DisplayName("Successful password change resumes the saved /oauth2/authorize flow and clears must_change_password")
     void changePasswordResumesOAuth2FlowAndClearsFlag() throws Exception {
         User original = userRepository.save(new User(
             null, tenant.id(), "alice",
@@ -166,6 +171,7 @@ class ManagementForcedPasswordChangeIntegrationTest {
     }
 
     @Test
+    @DisplayName("Mismatched newPassword/confirmPassword re-renders the form; flag stays set")
     void mismatchedPasswordsRerendersFormAndDoesNotClearFlag() throws Exception {
         User original = userRepository.save(new User(
             null, tenant.id(), "alice",
@@ -188,6 +194,7 @@ class ManagementForcedPasswordChangeIntegrationTest {
     }
 
     @Test
+    @DisplayName("Blank/whitespace newPassword re-renders the form; flag stays set")
     void blankNewPasswordRerendersFormAndDoesNotClearFlag() throws Exception {
         User original = userRepository.save(new User(
             null, tenant.id(), "alice",
@@ -209,6 +216,7 @@ class ManagementForcedPasswordChangeIntegrationTest {
     }
 
     @Test
+    @DisplayName("Successful password change with no saved request redirects to /manage/t/{slug}/")
     void changePasswordWithoutSavedRequestRedirectsToManagementHome() throws Exception {
         User original = userRepository.save(new User(
             null, tenant.id(), "alice",
@@ -233,6 +241,7 @@ class ManagementForcedPasswordChangeIntegrationTest {
     }
 
     @Test
+    @DisplayName("GET /manage/t/{slug}/change-password renders the change-password form")
     void changePasswordFormGetRendersChangePasswordView() throws Exception {
         userRepository.save(new User(
             null, tenant.id(), "alice",

--- a/src/test/java/com/stucray/limen/management/ManagementLoginIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/ManagementLoginIntegrationTest.java
@@ -7,6 +7,7 @@ import com.stucray.limen.tenant.TenantStatus;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -28,6 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@DisplayName("Management surface: login + tenant access control")
 class ManagementLoginIntegrationTest {
 
     @Autowired MockMvc mockMvc;
@@ -61,6 +63,7 @@ class ManagementLoginIntegrationTest {
     }
 
     @Test
+    @DisplayName("GET /manage/t/{slug}/login renders the login page with the tenant's display name")
     void loginFormRendersForTenant() throws Exception {
         mockMvc.perform(get("/manage/t/test-corp/login"))
             .andExpect(status().isOk())
@@ -69,6 +72,7 @@ class ManagementLoginIntegrationTest {
     }
 
     @Test
+    @DisplayName("Successful login redirects to /manage/t/{slug}/")
     void successfulLoginRedirectsToHome() throws Exception {
         mockMvc.perform(post("/manage/t/test-corp/login")
                 .param("username", "owner")
@@ -79,6 +83,7 @@ class ManagementLoginIntegrationTest {
     }
 
     @Test
+    @DisplayName("Bad password redirects back to /manage/t/{slug}/login?error")
     void failedLoginShowsError() throws Exception {
         mockMvc.perform(post("/manage/t/test-corp/login")
                 .param("username", "owner")
@@ -89,6 +94,7 @@ class ManagementLoginIntegrationTest {
     }
 
     @Test
+    @DisplayName("Unauthenticated access to /manage/t/{slug}/ is redirected to that tenant's login page")
     void unauthenticatedAccessToManagementPageRedirectsToLogin() throws Exception {
         mockMvc.perform(get("/manage/t/test-corp/"))
             .andExpect(status().is3xxRedirection())
@@ -96,6 +102,7 @@ class ManagementLoginIntegrationTest {
     }
 
     @Test
+    @DisplayName("Authenticated user can GET /manage/t/{slug}/ and sees their tenant's display name")
     void authenticatedUserCanAccessManagementHome() throws Exception {
         MvcResult loginResult = mockMvc.perform(post("/manage/t/test-corp/login")
                 .param("username", "owner")
@@ -111,6 +118,7 @@ class ManagementLoginIntegrationTest {
     }
 
     @Test
+    @DisplayName("System admin can sign in at /manage/t/system/login")
     void systemAdminCanLoginAtSystemSlug() throws Exception {
         Tenant systemTenant = tenantRepository.findBySlug("system").orElseThrow();
         userRepository.save(new User(
@@ -128,6 +136,7 @@ class ManagementLoginIntegrationTest {
     }
 
     @Test
+    @DisplayName("Cross-tenant access: TenantAccessFilter force-logs out and redirects to the URL slug's login page")
     void userCannotAccessAnotherTenantManagementPages() throws Exception {
         MvcResult loginResult = mockMvc.perform(post("/manage/t/test-corp/login")
                 .param("username", "owner")

--- a/src/test/java/com/stucray/limen/management/SignupIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/SignupIntegrationTest.java
@@ -3,6 +3,7 @@ package com.stucray.limen.management;
 import com.stucray.limen.TestcontainersConfiguration;
 import com.stucray.limen.tenant.TenantRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -23,6 +24,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@DisplayName("Public /signup flow: tenant + owner creation")
 class SignupIntegrationTest {
 
     @Autowired MockMvc mockMvc;
@@ -36,6 +38,7 @@ class SignupIntegrationTest {
     }
 
     @Test
+    @DisplayName("GET /signup renders the form (no auth required)")
     void signupFormRendersForUnauthenticatedRequest() throws Exception {
         mockMvc.perform(get("/signup"))
             .andExpect(status().isOk())
@@ -44,6 +47,7 @@ class SignupIntegrationTest {
     }
 
     @Test
+    @DisplayName("Successful POST /signup creates the tenant + owner user and redirects to the tenant login page")
     void successfulSignupCreatesTenantAndOwner() throws Exception {
         mockMvc.perform(post("/signup")
                 .param("organizationName", "Acme Corp")
@@ -62,6 +66,7 @@ class SignupIntegrationTest {
     }
 
     @Test
+    @DisplayName("Slug already taken: form re-renders with an 'already taken' message")
     void duplicateSlugReturnsError() throws Exception {
         jdbcTemplate.execute(
             "INSERT INTO tenants (slug, display_name, status) VALUES ('taken-slug', 'Taken', 'ACTIVE')");
@@ -77,6 +82,7 @@ class SignupIntegrationTest {
     }
 
     @Test
+    @DisplayName("Reserved slugs (system, admin, manage, api, …) are rejected with a 'reserved' message")
     void reservedSlugReturnsError() throws Exception {
         for (String reserved : new String[]{"system", "admin", "manage", "api", "www", "static", "health", "limen"}) {
             mockMvc.perform(post("/signup")
@@ -91,6 +97,7 @@ class SignupIntegrationTest {
     }
 
     @Test
+    @DisplayName("Slug containing uppercase letters is rejected with a character-set hint")
     void invalidSlugFormatReturnsError() throws Exception {
         mockMvc.perform(post("/signup")
                 .param("organizationName", "Test")
@@ -104,6 +111,7 @@ class SignupIntegrationTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("invalidFormCases")
+    @DisplayName("Invalid field re-renders form with field-level error")
     void invalidFormFieldRendersFieldError(
         String label, String slug, String orgName, String username, String password, String expectedFragment
     ) throws Exception {

--- a/src/test/java/com/stucray/limen/management/applications/ApplicationManagementIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/applications/ApplicationManagementIntegrationTest.java
@@ -7,6 +7,7 @@ import com.stucray.limen.tenant.TenantStatus;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -28,6 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@DisplayName("Applications: CRUD on the management surface")
 class ApplicationManagementIntegrationTest {
 
     @Autowired MockMvc mockMvc;
@@ -63,6 +65,7 @@ class ApplicationManagementIntegrationTest {
     }
 
     @Test
+    @DisplayName("Owner can POST /applications to create a new application in their tenant")
     void ownerCanCreateApplication() throws Exception {
         mockMvc.perform(post("/manage/t/corp-a/applications").session(sessionA).with(csrf())
                 .param("name", "My App").param("description", "A test app"))
@@ -73,6 +76,7 @@ class ApplicationManagementIntegrationTest {
     }
 
     @Test
+    @DisplayName("Create with a name already in use re-renders the form with an 'already exists' message")
     void createWithDuplicateNameRedisplaysFormWithError() throws Exception {
         applicationRepository.save(new Application(null, tenantA.id(), "Existing", "desc", LocalDateTime.now()));
 
@@ -86,12 +90,14 @@ class ApplicationManagementIntegrationTest {
     }
 
     @Test
+    @DisplayName("GET /applications/new renders the new-application form")
     void newFormGetRendersTemplate() throws Exception {
         mockMvc.perform(get("/manage/t/corp-a/applications/new").session(sessionA))
             .andExpect(status().isOk());
     }
 
     @Test
+    @DisplayName("GET /applications lists the applications belonging to the owner's tenant")
     void ownerCanListApplications() throws Exception {
         applicationRepository.save(new Application(null, tenantA.id(), "App 1", "desc", LocalDateTime.now()));
 
@@ -101,6 +107,7 @@ class ApplicationManagementIntegrationTest {
     }
 
     @Test
+    @DisplayName("Owner can POST /applications/{id}/edit to rename and re-describe an application")
     void ownerCanEditApplication() throws Exception {
         Application app = applicationRepository.save(new Application(null, tenantA.id(), "Old Name", "old desc", LocalDateTime.now()));
 
@@ -117,6 +124,7 @@ class ApplicationManagementIntegrationTest {
     // failed with EL1004E. The previous edit test only exercised POST, so the bug shipped
     // invisibly. Rendering must succeed and contain the existing application's name.
     @Test
+    @DisplayName("GET /applications/{id}/edit renders the existing application (regression: Thymeleaf 'application' attribute collision)")
     void editFormGetRendersExistingApplication() throws Exception {
         Application app = applicationRepository.save(
             new Application(null, tenantA.id(), "Acme Widgets", "widget catalogue", LocalDateTime.now()));
@@ -128,6 +136,7 @@ class ApplicationManagementIntegrationTest {
     }
 
     @Test
+    @DisplayName("Owner can DELETE an application that has no associated OAuth clients")
     void ownerCanDeleteApplicationWithoutClients() throws Exception {
         Application app = applicationRepository.save(new Application(null, tenantA.id(), "App", null, LocalDateTime.now()));
 
@@ -138,6 +147,7 @@ class ApplicationManagementIntegrationTest {
     }
 
     @Test
+    @DisplayName("Delete is blocked with 'Cannot delete' when the application still has registered OAuth clients")
     void deleteBlockedWhenApplicationHasClients() throws Exception {
         Application app = applicationRepository.save(new Application(null, tenantA.id(), "App", null, LocalDateTime.now()));
         // Insert a fake client record to simulate the FK constraint check
@@ -154,6 +164,7 @@ class ApplicationManagementIntegrationTest {
     }
 
     @Test
+    @DisplayName("Tenant A's applications are not visible to a tenant B session — TenantAccessFilter forces logout")
     void tenantAApplicationsNotVisibleToTenantBSession() throws Exception {
         Application appA = applicationRepository.save(new Application(null, tenantA.id(), "App A", null, LocalDateTime.now()));
         userRepository.save(new User(null, tenantB.id(), "ownerB", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));

--- a/src/test/java/com/stucray/limen/management/clients/ClientManagementIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/clients/ClientManagementIntegrationTest.java
@@ -9,6 +9,7 @@ import com.stucray.limen.tenant.TenantStatus;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -38,6 +39,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@DisplayName("OAuth clients: CRUD on the management surface")
 class ClientManagementIntegrationTest {
 
     @Autowired MockMvc mockMvc;
@@ -92,6 +94,7 @@ class ClientManagementIntegrationTest {
     }
 
     @Test
+    @DisplayName("Owner can list the application's OAuth clients")
     void ownerCanListClients() throws Exception {
         createConfidentialClient("Visible Client");
 
@@ -101,12 +104,14 @@ class ClientManagementIntegrationTest {
     }
 
     @Test
+    @DisplayName("Owner can GET the new-client form")
     void ownerCanGetNewClientForm() throws Exception {
         mockMvc.perform(get(clientsUrl() + "/new").session(sessionA))
             .andExpect(status().isOk());
     }
 
     @Test
+    @DisplayName("Creating a confidential client flashes the one-time clientSecret + clientId for the owner to copy")
     void ownerCanCreateConfidentialClient() throws Exception {
         mockMvc.perform(post(clientsUrl()).session(sessionA).with(csrf())
                 .param("displayName", "Created Client")
@@ -129,6 +134,7 @@ class ClientManagementIntegrationTest {
     }
 
     @Test
+    @DisplayName("Public-client creation does not flash a clientSecret (PKCE-only flow has no secret)")
     void publicClientCreationDoesNotProduceSecretFlash() throws Exception {
         mockMvc.perform(post(clientsUrl()).session(sessionA).with(csrf())
                 .param("displayName", "Public Client")
@@ -145,6 +151,7 @@ class ClientManagementIntegrationTest {
     }
 
     @Test
+    @DisplayName("Owner can GET the edit-client form prefilled with the existing client's display name")
     void ownerCanGetEditClientForm() throws Exception {
         TenantClient created = createConfidentialClient("Editable Client");
 
@@ -154,6 +161,7 @@ class ClientManagementIntegrationTest {
     }
 
     @Test
+    @DisplayName("POST /{clientId}/edit updates token TTLs, refresh-reuse, and PKCE flag on the registered client")
     void ownerCanUpdateClientSettings() throws Exception {
         TenantClient created = createConfidentialClient("Updatable Client");
 
@@ -174,6 +182,7 @@ class ClientManagementIntegrationTest {
     }
 
     @Test
+    @DisplayName("POST /{clientId}/rotate-secret replaces the stored hash and flashes the new secret once")
     void ownerCanRotateClientSecret() throws Exception {
         TenantClient created = createConfidentialClient("Rotating Client");
         String oldHash = registeredClientRepository.findById(created.registeredClientId()).getClientSecret();
@@ -190,6 +199,7 @@ class ClientManagementIntegrationTest {
     }
 
     @Test
+    @DisplayName("POST /{clientId}/delete removes both the tenant_client row and the registered_client row")
     void ownerCanDeleteClient() throws Exception {
         TenantClient created = createConfidentialClient("Deletable Client");
 
@@ -203,6 +213,7 @@ class ClientManagementIntegrationTest {
     }
 
     @Test
+    @DisplayName("Tenant A's clients list is not visible to a tenant B session — TenantAccessFilter forces logout")
     void tenantAClientsNotVisibleToTenantBSession() throws Exception {
         createConfidentialClient("Tenant A Client");
         userRepository.save(new User(null, tenantB.id(), "ownerB", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));

--- a/src/test/java/com/stucray/limen/management/clients/ClientTokenSettingsIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/clients/ClientTokenSettingsIntegrationTest.java
@@ -14,6 +14,7 @@ import com.stucray.limen.tenant.TenantRepository;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -47,6 +48,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@DisplayName("Per-client token settings flow through to issued tokens")
 class ClientTokenSettingsIntegrationTest {
 
     @Autowired MockMvc mockMvc;
@@ -95,6 +97,7 @@ class ClientTokenSettingsIntegrationTest {
     }
 
     @Test
+    @DisplayName("Configured access-token TTL: exp − iat on the issued JWT matches the configured minutes")
     void accessTokenTtlIsReflectedInIssuedToken() throws Exception {
         long ttlMinutes = 2;
         ClientManagementService.ClientCreationResult result = clientManagementService.createClient(
@@ -127,6 +130,7 @@ class ClientTokenSettingsIntegrationTest {
     }
 
     @Test
+    @DisplayName("requirePkce=true: token exchange without code_verifier returns 400 Bad Request")
     void pkceRequiredClientRejectsTokenExchangeWithoutCodeVerifier() throws Exception {
         ClientManagementService.ClientCreationResult result = clientManagementService.createClient(
             app.id(), tenant.id(), "pkce-client",
@@ -191,6 +195,7 @@ class ClientTokenSettingsIntegrationTest {
     }
 
     @Test
+    @DisplayName("reuseRefreshTokens=false (rotation): refresh issues a new token and the old one is rejected")
     void refreshTokenRotationIssuesNewTokenAndInvalidatesOld() throws Exception {
         ClientManagementService.ClientCreationResult result = clientManagementService.createClient(
             app.id(), tenant.id(), "rotation-client",
@@ -230,6 +235,7 @@ class ClientTokenSettingsIntegrationTest {
     }
 
     @Test
+    @DisplayName("reuseRefreshTokens=true: the same refresh token works for repeated exchanges")
     void reuseRefreshTokensAllowsRepeatedUseOfSameToken() throws Exception {
         ClientManagementService.ClientCreationResult result = clientManagementService.createClient(
             app.id(), tenant.id(), "reuse-client",
@@ -261,6 +267,7 @@ class ClientTokenSettingsIntegrationTest {
     }
 
     @Test
+    @DisplayName("Updating a client's TTL through the management UI shortens TTLs of subsequent tokens")
     void updatingTokenSettingsIsReflectedInSubsequentTokens() throws Exception {
         ClientManagementService.ClientCreationResult result = clientManagementService.createClient(
             app.id(), tenant.id(), "update-client",

--- a/src/test/java/com/stucray/limen/management/memberships/ApplicationMembershipServiceIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/memberships/ApplicationMembershipServiceIntegrationTest.java
@@ -11,6 +11,7 @@ import com.stucray.limen.tenant.TenantStatus;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -26,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
+@DisplayName("ApplicationMembershipService (grant/revoke + role assignments)")
 class ApplicationMembershipServiceIntegrationTest {
 
     @Autowired ApplicationMembershipService membershipService;
@@ -69,6 +71,7 @@ class ApplicationMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("grant: persists membership with granted_at, granted_by, and an empty role set")
     void grantStoresRowWithGrantedAtAndGrantedBy() {
         ApplicationMembership m = membershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
 
@@ -81,6 +84,7 @@ class ApplicationMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("Granting the same user to the same application twice is rejected with 'already a member'")
     void duplicateUserApplicationRejected() {
         membershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
 
@@ -90,6 +94,7 @@ class ApplicationMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("Caller's tenantId mismatching the application's tenant: list/grant return 'Application not found'")
     void crossTenantApplicationAccessRejected() {
         // Caller claims tenantA but appB belongs to tenantB.
         assertThatThrownBy(() -> membershipService.listMemberships(appB.id(), tenantA.id()))
@@ -102,6 +107,7 @@ class ApplicationMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("Granting a user that lives in a different tenant is rejected with 'User not found'")
     void grantingUserFromAnotherTenantRejected() {
         // carolB is in tenantB; appA is in tenantA. Even though the caller
         // legitimately controls tenantA, granting a foreign User must fail.
@@ -111,6 +117,7 @@ class ApplicationMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("Repository-level: (user_id, application_id) unique constraint surfaces as DataIntegrityViolation")
     void uniqueConstraintHonouredAtRepositoryLevel() {
         membershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
 
@@ -120,6 +127,7 @@ class ApplicationMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("updateRoles: assigns a set of roles to an existing membership")
     void updateRolesAssignsSet() {
         ApplicationMembership m = membershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
         Role viewer = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
@@ -132,6 +140,7 @@ class ApplicationMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("updateRoles: replaces (not unions) the existing role set")
     void updateRolesReplacesExistingSet() {
         ApplicationMembership m = membershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
         Role viewer = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
@@ -145,6 +154,7 @@ class ApplicationMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("updateRoles: passing an empty set clears all role assignments on the membership")
     void updateRolesEmptyClearsSet() {
         ApplicationMembership m = membershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
         Role viewer = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
@@ -156,6 +166,7 @@ class ApplicationMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("Roles defined on a different application (different tenant) cannot be assigned")
     void cannotAssignRoleFromAnotherApplication() {
         ApplicationMembership m = membershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
         // Role belongs to a *different* tenant's application — clearly not assignable.
@@ -167,6 +178,7 @@ class ApplicationMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("Roles defined on a sibling application in the same tenant cannot be assigned")
     void cannotAssignRoleFromAnotherAppInSameTenant() {
         // Same tenant, different app — still must be rejected.
         Application appA2 = applicationRepository.save(new Application(null, tenantA.id(), "App A2", null, LocalDateTime.now()));
@@ -179,6 +191,7 @@ class ApplicationMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("revoke: deletes the membership row and all of its role-assignment join rows; role itself survives")
     void revokeRemovesRowAndRoleAssignments() {
         Role viewer = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
         ApplicationMembership m = membershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
@@ -197,6 +210,7 @@ class ApplicationMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("Deleting a Role still assigned to a membership trips ON DELETE RESTRICT (DataIntegrityViolation)")
     void roleAssignedToMembershipCannotBeDeleted() {
         Role viewer = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
         ApplicationMembership m = membershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
@@ -210,6 +224,7 @@ class ApplicationMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("Deleting an Application cascades to its memberships when no roles are assigned")
     void deletingApplicationCascadesMembershipWithoutRoleAssignments() {
         ApplicationMembership m = membershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
 
@@ -219,6 +234,7 @@ class ApplicationMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("Deleting an Application whose Roles are still assigned fails RESTRICT (admin must clear first)")
     void deletingApplicationWithAssignedRolesFailsRestrict() {
         // The PRD #39 RESTRICT on application_membership_role.role_id protects
         // against silent role-assignment loss. As a side effect, an Application
@@ -236,6 +252,7 @@ class ApplicationMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("Deleting a User cascades to all of their memberships")
     void deletingUserCascadesMembership() {
         membershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
 
@@ -245,6 +262,7 @@ class ApplicationMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("Deleting the granter (admin) nullifies granted_by on existing memberships (audit history preserved)")
     void deletingGranterNullifiesGrantedBy() {
         ApplicationMembership m = membershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
 
@@ -255,6 +273,7 @@ class ApplicationMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("listGrantableUsers: excludes users that are already members of the application")
     void listGrantableUsersExcludesExistingMembers() {
         membershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
 

--- a/src/test/java/com/stucray/limen/management/memberships/ClientMembersControllerIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/memberships/ClientMembersControllerIntegrationTest.java
@@ -13,6 +13,7 @@ import com.stucray.limen.tenant.TenantStatus;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -39,6 +40,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@DisplayName("ClientMembersController (per-client member CRUD on the management UI)")
 class ClientMembersControllerIntegrationTest {
 
     @Autowired MockMvc mockMvc;
@@ -94,6 +96,7 @@ class ClientMembersControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("Owner can list a client's members")
     void ownerCanListClientMembers() throws Exception {
         ApplicationMembership am = appMembershipRepository.save(new ApplicationMembership(
             null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), Set.of()
@@ -108,6 +111,7 @@ class ClientMembersControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("Owner can grant a client membership to an existing application member")
     void ownerCanGrantClientMembership() throws Exception {
         appMembershipRepository.save(new ApplicationMembership(
             null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), Set.of()
@@ -128,6 +132,7 @@ class ClientMembersControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("Granting a client membership for a user without an application membership re-renders with 'not a member of this application'")
     void grantWithoutAppMembershipRedisplaysFormWithError() throws Exception {
         // alice has no App Membership for appA, so the eligibility gate fires.
         mockMvc.perform(post(url("/members"))
@@ -138,6 +143,7 @@ class ClientMembersControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("Owner can assign multiple roles to a client membership via the edit form")
     void ownerCanAssignRolesViaEditForm() throws Exception {
         ApplicationMembership am = appMembershipRepository.save(new ApplicationMembership(
             null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), Set.of()
@@ -159,6 +165,7 @@ class ClientMembersControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("Submitting the edit form with an unknown role id re-renders with a 'Role not found' error")
     void editFormSubmitWithUnknownRoleIdRedisplaysFormWithError() throws Exception {
         ApplicationMembership am = appMembershipRepository.save(new ApplicationMembership(
             null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), Set.of()
@@ -177,6 +184,7 @@ class ClientMembersControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("Edit form GET renders the existing membership and the available roles")
     void editFormGetRendersTemplateWithMembershipDetails() throws Exception {
         ApplicationMembership am = appMembershipRepository.save(new ApplicationMembership(
             null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), Set.of()
@@ -193,6 +201,7 @@ class ClientMembersControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("New-grant form GET lists only users with an application membership but no client membership yet")
     void newFormGetRendersGrantableUsers() throws Exception {
         appMembershipRepository.save(new ApplicationMembership(
             null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), Set.of()
@@ -204,6 +213,7 @@ class ClientMembersControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("Submitting edit with no roleIds clears all role assignments on the membership")
     void editFormSubmitWithNoRoleIdsClearsAssignments() throws Exception {
         ApplicationMembership am = appMembershipRepository.save(new ApplicationMembership(
             null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), Set.of()
@@ -222,6 +232,7 @@ class ClientMembersControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("Owner can revoke a client membership via POST /members/{id}/delete")
     void ownerCanRevokeClientMembership() throws Exception {
         ApplicationMembership am = appMembershipRepository.save(new ApplicationMembership(
             null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), Set.of()
@@ -238,6 +249,7 @@ class ClientMembersControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("Tenant B session is force-redirected to tenant A's login when reaching tenant A's client members")
     void tenantBSessionCannotReachTenantAClientMembers() throws Exception {
         userRepository.save(new User(null, tenantB.id(), "ownerB", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
         MvcResult loginB = mockMvc.perform(post("/manage/t/client-mem-b/login")
@@ -251,6 +263,7 @@ class ClientMembersControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("Clients-list page links each row to its /members page")
     void clientMembersLinkAppearsOnClientsList() throws Exception {
         mockMvc.perform(get("/manage/t/client-mem-a/applications/" + appA.id() + "/clients").session(sessionA))
             .andExpect(status().isOk())

--- a/src/test/java/com/stucray/limen/management/memberships/ClientMembershipQueryIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/memberships/ClientMembershipQueryIntegrationTest.java
@@ -13,6 +13,7 @@ import com.stucray.limen.tenant.TenantStatus;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -28,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
+@DisplayName("ClientMembershipQuery (read-side; used by token issuance)")
 class ClientMembershipQueryIntegrationTest {
 
     @Autowired ClientMembershipQuery clientMembershipQuery;
@@ -86,6 +88,7 @@ class ClientMembershipQueryIntegrationTest {
     }
 
     @Test
+    @DisplayName("rolesFor: returns the assigned role names, sorted alphabetically")
     void rolesForReturnsAssignedRolesAlphabetical() {
         Role viewer = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
         Role editor = roleRepository.save(new Role(null, appA.id(), "editor", null, LocalDateTime.now()));
@@ -107,6 +110,7 @@ class ClientMembershipQueryIntegrationTest {
     }
 
     @Test
+    @DisplayName("rolesFor: returns empty when there is no client membership")
     void rolesForReturnsEmptyWhenNoMembership() {
         List<String> roles = clientMembershipQuery.rolesFor(
             aliceA.id(), clientA.registeredClientId(), tenantA.id()
@@ -115,6 +119,7 @@ class ClientMembershipQueryIntegrationTest {
     }
 
     @Test
+    @DisplayName("rolesFor: returns empty when the membership exists but has no roles assigned")
     void rolesForReturnsEmptyWhenMembershipExistsButNoRolesAssigned() {
         applicationMembershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
         clientMembershipService.grant(
@@ -129,6 +134,7 @@ class ClientMembershipQueryIntegrationTest {
     }
 
     @Test
+    @DisplayName("rolesFor: defensive tenant_id predicate rejects rows when caller passes the wrong tenant")
     void rolesForIsCrossTenantSafe() {
         // carol is in tenantB and has full Membership + Role for clientB.
         Role role = roleRepository.save(new Role(null, appB.id(), "viewer", null, LocalDateTime.now()));
@@ -151,6 +157,7 @@ class ClientMembershipQueryIntegrationTest {
     }
 
     @Test
+    @DisplayName("rolesFor: returns empty when the user belongs to a different tenant from the requested client")
     void rolesForRejectsForeignTenantUser() {
         // alice (tenantA) has no Membership for clientB (tenantB) — must be empty
         // even when caller passes tenantB id, simulating a stray cross-tenant query.
@@ -161,6 +168,7 @@ class ClientMembershipQueryIntegrationTest {
     }
 
     @Test
+    @DisplayName("hasMembership: returns true when the user has a client membership for that registered_client")
     void hasMembershipReturnsTrueForExistingMembership() {
         applicationMembershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
         clientMembershipService.grant(
@@ -175,6 +183,7 @@ class ClientMembershipQueryIntegrationTest {
     }
 
     @Test
+    @DisplayName("hasMembership: returns true even when the membership has zero roles assigned")
     void hasMembershipReturnsTrueEvenWithNoRoles() {
         // Membership-without-Roles is still a Membership — slice 5's gate
         // depends on this distinction (presence of row, not Roles count).
@@ -191,6 +200,7 @@ class ClientMembershipQueryIntegrationTest {
     }
 
     @Test
+    @DisplayName("hasMembership: returns false when no client membership row exists")
     void hasMembershipReturnsFalseWhenAbsent() {
         boolean has = clientMembershipQuery.hasMembership(
             aliceA.id(), clientA.registeredClientId(), tenantA.id()
@@ -199,6 +209,7 @@ class ClientMembershipQueryIntegrationTest {
     }
 
     @Test
+    @DisplayName("hasMembership: returns false when caller's tenant_id does not match the row's tenant")
     void hasMembershipIsCrossTenantSafe() {
         applicationMembershipService.grant(appB.id(), tenantB.id(), carolB.id(), adminB.id());
         clientMembershipService.grant(
@@ -213,6 +224,7 @@ class ClientMembershipQueryIntegrationTest {
     }
 
     @Test
+    @DisplayName("rolesFor: tolerates any-arg-null and returns empty rather than throwing")
     void rolesForToleratesNullArgs() {
         assertThat(clientMembershipQuery.rolesFor(null, "any", tenantA.id())).isEmpty();
         assertThat(clientMembershipQuery.rolesFor(aliceA.id(), null, tenantA.id())).isEmpty();
@@ -220,6 +232,7 @@ class ClientMembershipQueryIntegrationTest {
     }
 
     @Test
+    @DisplayName("hasMembership: tolerates any-arg-null and returns false rather than throwing")
     void hasMembershipToleratesNullArgs() {
         assertThat(clientMembershipQuery.hasMembership(null, "any", tenantA.id())).isFalse();
         assertThat(clientMembershipQuery.hasMembership(aliceA.id(), null, tenantA.id())).isFalse();

--- a/src/test/java/com/stucray/limen/management/memberships/ClientMembershipServiceIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/memberships/ClientMembershipServiceIntegrationTest.java
@@ -14,6 +14,7 @@ import com.stucray.limen.tenant.TenantStatus;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -30,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
+@DisplayName("ClientMembershipService (per-client memberships derived from app memberships)")
 class ClientMembershipServiceIntegrationTest {
 
     @Autowired ClientMembershipService clientMembershipService;
@@ -94,6 +96,7 @@ class ClientMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("grant: persists row with granted_at, granted_by, and FK back to the app membership")
     void grantStoresRowWithGrantedAtGrantedByAndAppMembershipFk() {
         ApplicationMembership am = applicationMembershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
 
@@ -111,6 +114,7 @@ class ClientMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("Granting a client membership requires an existing application membership (gates downward)")
     void grantRequiresExistingApplicationMembership() {
         // alice has no App Membership for appA.
         assertThatThrownBy(() -> clientMembershipService.grant(
@@ -120,6 +124,7 @@ class ClientMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("Granting a client membership for app A2 fails when the user is only a member of app A")
     void grantRejectedIfUserOnlyHasAppMembershipForDifferentApp() {
         // Cross-table invariant: alice has App Membership for appA only, but
         // tries to be granted Client Membership on a Client of appA2. The
@@ -135,6 +140,7 @@ class ClientMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("Granting the same user to the same client twice is rejected with 'already a member'")
     void duplicateUserClientRejected() {
         applicationMembershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
         clientMembershipService.grant(clientA.registeredClientId(), appA.id(), tenantA.id(), aliceA.id(), adminA.id());
@@ -146,6 +152,7 @@ class ClientMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("Caller's tenantId mismatching the client's tenant: list/grant return 'Client not found'")
     void crossTenantClientAccessRejected() {
         // Caller claims tenantA but clientB belongs to tenantB.
         assertThatThrownBy(() -> clientMembershipService.listMemberships(clientB.registeredClientId(), appA.id(), tenantA.id()))
@@ -159,6 +166,7 @@ class ClientMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("URL mismatch (clientA2 listed under appA) is rejected even within the same tenant")
     void mismatchedClientApplicationPathRejected() {
         // URL claims clientA2 (which belongs to appA2) hangs off appA. Reject
         // even within the same tenant — the URL hierarchy must be honest.
@@ -168,6 +176,7 @@ class ClientMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("Granting a user from a different tenant is rejected with 'User not found'")
     void grantingUserFromAnotherTenantRejected() {
         applicationMembershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
 
@@ -178,6 +187,7 @@ class ClientMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("Repository-level: (user_id, client_metadata_id) unique constraint surfaces as DataIntegrityViolation")
     void uniqueConstraintHonouredAtRepositoryLevel() {
         applicationMembershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
         ApplicationMembership am = applicationMembershipRepository.findByUserIdAndApplicationId(aliceA.id(), appA.id()).orElseThrow();
@@ -189,6 +199,7 @@ class ClientMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("updateRoles: assigns a set of roles to an existing client membership")
     void updateRolesAssignsSet() {
         applicationMembershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
         ClientMembership cm = clientMembershipService.grant(clientA.registeredClientId(), appA.id(), tenantA.id(), aliceA.id(), adminA.id());
@@ -202,6 +213,7 @@ class ClientMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("updateRoles: passing an empty set clears all role assignments")
     void updateRolesEmptyClearsSet() {
         applicationMembershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
         ClientMembership cm = clientMembershipService.grant(clientA.registeredClientId(), appA.id(), tenantA.id(), aliceA.id(), adminA.id());
@@ -215,6 +227,7 @@ class ClientMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("Roles from a sibling app (same tenant) cannot be assigned to a client membership")
     void cannotAssignRoleFromAnotherApplication() {
         applicationMembershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
         ClientMembership cm = clientMembershipService.grant(clientA.registeredClientId(), appA.id(), tenantA.id(), aliceA.id(), adminA.id());
@@ -228,6 +241,7 @@ class ClientMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("revoke: deletes the membership and its role-assignment join rows; role itself survives")
     void revokeRemovesRowAndRoleAssignments() {
         Role viewer = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
         applicationMembershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
@@ -246,6 +260,7 @@ class ClientMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("A Role still assigned to a client membership cannot be deleted (RESTRICT)")
     void roleAssignedToClientMembershipCannotBeDeleted() {
         Role viewer = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
         applicationMembershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
@@ -257,6 +272,7 @@ class ClientMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("Revoking an application membership cascades to all of its derived client memberships")
     void revokingApplicationMembershipCascadesClientMemberships() {
         // PRD #39 decision 4: hard FK + CASCADE from client_membership.application_membership_id
         // means revoking App Membership atomically revokes all derived Client Memberships.
@@ -272,6 +288,7 @@ class ClientMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("Deleting a client cascades to its client memberships")
     void deletingClientCascadesClientMembership() {
         applicationMembershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
         ClientMembership cm = clientMembershipService.grant(clientA.registeredClientId(), appA.id(), tenantA.id(), aliceA.id(), adminA.id());
@@ -282,6 +299,7 @@ class ClientMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("Deleting a user cascades to all of their client memberships")
     void deletingUserCascadesClientMembership() {
         applicationMembershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
         clientMembershipService.grant(clientA.registeredClientId(), appA.id(), tenantA.id(), aliceA.id(), adminA.id());
@@ -292,6 +310,7 @@ class ClientMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("Deleting the granter (admin) nullifies granted_by on existing client memberships")
     void deletingGranterNullifiesGrantedBy() {
         applicationMembershipService.grant(appA.id(), tenantA.id(), bobA.id(), adminA.id());
         ClientMembership cm = clientMembershipService.grant(
@@ -305,6 +324,7 @@ class ClientMembershipServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("listGrantableUsers: includes only app members who don't yet have a client membership")
     void listGrantableUsersOnlyIncludesAppMembersWithoutClientMembership() {
         // alice & bob both have App Membership for appA; alice already has Client Membership.
         applicationMembershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());

--- a/src/test/java/com/stucray/limen/management/memberships/MembersControllerIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/memberships/MembersControllerIntegrationTest.java
@@ -11,6 +11,7 @@ import com.stucray.limen.tenant.TenantStatus;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -35,6 +36,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@DisplayName("MembersController (per-application member CRUD on the management UI)")
 class MembersControllerIntegrationTest {
 
     @Autowired MockMvc mockMvc;
@@ -80,6 +82,7 @@ class MembersControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("Owner can list an application's members")
     void ownerCanListMembers() throws Exception {
         membershipRepository.save(new ApplicationMembership(
             null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), java.util.Set.of()
@@ -91,6 +94,7 @@ class MembersControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("Owner can grant an application membership; granted_by is the authenticated owner")
     void ownerCanGrantMembership() throws Exception {
         mockMvc.perform(post("/manage/t/members-corp-a/applications/" + appA.id() + "/members")
                 .session(sessionA).with(csrf())
@@ -108,6 +112,7 @@ class MembersControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("Granting an existing member again re-renders the form with 'already a member'")
     void duplicateGrantRedisplaysFormWithError() throws Exception {
         membershipRepository.save(new ApplicationMembership(
             null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), java.util.Set.of()
@@ -121,6 +126,7 @@ class MembersControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("Owner can assign multiple roles to an application membership via the edit form")
     void ownerCanAssignRolesViaEditForm() throws Exception {
         ApplicationMembership m = membershipRepository.save(new ApplicationMembership(
             null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), java.util.Set.of()
@@ -139,6 +145,7 @@ class MembersControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("Submitting edit with an unknown roleId re-renders with a 'Role not found' error; row unchanged")
     void editFormSubmitWithUnknownRoleIdRedisplaysFormWithError() throws Exception {
         ApplicationMembership m = membershipRepository.save(new ApplicationMembership(
             null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), java.util.Set.of()
@@ -155,6 +162,7 @@ class MembersControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("Edit form GET renders the existing application membership and the available roles")
     void editFormGetRendersTemplateWithMembershipDetails() throws Exception {
         ApplicationMembership m = membershipRepository.save(new ApplicationMembership(
             null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), java.util.Set.of()
@@ -169,6 +177,7 @@ class MembersControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("New-grant form GET lists grantable users (excludes existing members)")
     void newFormGetRendersGrantableUsersExcludingExistingMembers() throws Exception {
         // alice is grantable initially.
         mockMvc.perform(get("/manage/t/members-corp-a/applications/" + appA.id() + "/members/new")
@@ -178,6 +187,7 @@ class MembersControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("Submitting edit with no roleIds clears all role assignments on the membership")
     void editFormSubmitWithNoRoleIdsClearsAssignments() throws Exception {
         Role viewer = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
         ApplicationMembership m = membershipRepository.save(new ApplicationMembership(
@@ -193,6 +203,7 @@ class MembersControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("Owner can revoke an application membership via POST /members/{id}/delete")
     void ownerCanRevokeMembership() throws Exception {
         ApplicationMembership m = membershipRepository.save(new ApplicationMembership(
             null, aliceA.id(), appA.id(), LocalDateTime.now(), ownerA.id(), java.util.Set.of()
@@ -206,6 +217,7 @@ class MembersControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("Tenant B session is force-redirected to tenant A's login when reaching tenant A's members")
     void tenantBSessionCannotReachTenantAMembers() throws Exception {
         userRepository.save(new User(null, tenantB.id(), "ownerB", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
         MvcResult loginB = mockMvc.perform(post("/manage/t/members-corp-b/login")
@@ -221,6 +233,7 @@ class MembersControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("Applications-list page links each row to its /members page")
     void membersLinkAppearsOnApplicationsList() throws Exception {
         mockMvc.perform(get("/manage/t/members-corp-a/applications").session(sessionA))
             .andExpect(status().isOk())

--- a/src/test/java/com/stucray/limen/management/roles/RoleManagementServiceIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/roles/RoleManagementServiceIntegrationTest.java
@@ -7,6 +7,7 @@ import com.stucray.limen.tenant.Tenant;
 import com.stucray.limen.tenant.TenantRepository;
 import com.stucray.limen.tenant.TenantStatus;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -20,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
+@DisplayName("RoleManagementService (per-application role CRUD)")
 class RoleManagementServiceIntegrationTest {
 
     @Autowired RoleManagementService roleManagementService;
@@ -51,6 +53,7 @@ class RoleManagementServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("createRole: persists row scoped to the (application, tenant)")
     void createRoleStoresAndReturnsRow() {
         Role created = roleManagementService.createRole(appA.id(), tenantA.id(), "viewer", "Read-only access");
 
@@ -61,6 +64,7 @@ class RoleManagementServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("Duplicate role name within the same application is rejected")
     void duplicateNameWithinSameApplicationIsRejected() {
         roleManagementService.createRole(appA.id(), tenantA.id(), "viewer", null);
 
@@ -70,6 +74,7 @@ class RoleManagementServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("The same role name is allowed across two applications — uniqueness is per-application")
     void sameNameAcrossDifferentApplicationsIsAllowed() {
         // Same tenant, different application — name reuse is fine because the
         // unique key is (application_id, name), not (tenant_id, name).
@@ -84,6 +89,7 @@ class RoleManagementServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("updateRole: renaming to a name already used by another role in the same app is rejected")
     void renameToExistingNameIsRejected() {
         roleManagementService.createRole(appA.id(), tenantA.id(), "viewer", null);
         Role editor = roleManagementService.createRole(appA.id(), tenantA.id(), "editor", null);
@@ -94,6 +100,7 @@ class RoleManagementServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("updateRole: changing the description while keeping the same name is allowed")
     void renamingToOwnNameIsAllowed() {
         Role role = roleManagementService.createRole(appA.id(), tenantA.id(), "viewer", "old desc");
 
@@ -104,6 +111,7 @@ class RoleManagementServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("Caller's tenantId mismatching the application's tenant: list/create return 'Application not found'")
     void crossTenantAccessRejected() {
         // appA belongs to tenantA. Calling with tenantB's id must throw.
         assertThatThrownBy(() -> roleManagementService.listRoles(appA.id(), tenantB.id()))
@@ -116,6 +124,7 @@ class RoleManagementServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("A role created in app A cannot be addressed through app B")
     void crossApplicationGetRejected() {
         // A role created in appA must not be addressable through appB even by
         // its owning tenant.
@@ -126,6 +135,7 @@ class RoleManagementServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("deleteRole: removes the row")
     void deleteRemovesRow() {
         Role role = roleManagementService.createRole(appA.id(), tenantA.id(), "viewer", null);
 
@@ -135,6 +145,7 @@ class RoleManagementServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("Deleting an application cascades to all of its roles")
     void deletingApplicationCascadesRoles() {
         Role role = roleManagementService.createRole(appA.id(), tenantA.id(), "viewer", null);
 

--- a/src/test/java/com/stucray/limen/management/roles/RolesControllerIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/roles/RolesControllerIntegrationTest.java
@@ -9,6 +9,7 @@ import com.stucray.limen.tenant.TenantStatus;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -30,6 +31,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@DisplayName("RolesController (per-application role CRUD on the management UI)")
 class RolesControllerIntegrationTest {
 
     @Autowired MockMvc mockMvc;
@@ -70,6 +72,7 @@ class RolesControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("Owner can list the application's roles")
     void ownerCanListRoles() throws Exception {
         roleRepository.save(new Role(null, appA.id(), "viewer", "read-only", LocalDateTime.now()));
 
@@ -79,6 +82,7 @@ class RolesControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("Owner can create a role via POST /roles")
     void ownerCanCreateRole() throws Exception {
         mockMvc.perform(post("/manage/t/roles-corp-a/applications/" + appA.id() + "/roles")
                 .session(sessionA).with(csrf())
@@ -91,6 +95,7 @@ class RolesControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("Creating a role with a name already used in the same app re-renders with 'already exists'")
     void duplicateNameRedisplaysFormWithError() throws Exception {
         roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
 
@@ -102,6 +107,7 @@ class RolesControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("Owner can edit a role's name and description via POST /roles/{id}/edit")
     void ownerCanEditRole() throws Exception {
         Role role = roleRepository.save(new Role(null, appA.id(), "old", "old desc", LocalDateTime.now()));
 
@@ -116,6 +122,7 @@ class RolesControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("Renaming a role to an existing name re-renders the form; row remains unchanged")
     void editWithDuplicateNameRedisplaysFormWithError() throws Exception {
         roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
         Role editor = roleRepository.save(new Role(null, appA.id(), "editor", null, LocalDateTime.now()));
@@ -131,6 +138,7 @@ class RolesControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("Edit form GET renders the existing role")
     void editFormGetRendersTemplateWithRole() throws Exception {
         Role role = roleRepository.save(new Role(null, appA.id(), "viewer", "read-only", LocalDateTime.now()));
 
@@ -141,12 +149,14 @@ class RolesControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("New-role form GET renders the template")
     void newFormGetRendersTemplate() throws Exception {
         mockMvc.perform(get("/manage/t/roles-corp-a/applications/" + appA.id() + "/roles/new").session(sessionA))
             .andExpect(status().isOk());
     }
 
     @Test
+    @DisplayName("Deleting a role still assigned to a membership re-renders the list with 'Cannot delete'")
     void deleteOfRoleAssignedToMembershipRedisplaysListWithError() throws Exception {
         // Insert a role then directly attach it to an application_membership_role
         // row so the FK ON DELETE RESTRICT fires when the role is deleted. Using
@@ -171,6 +181,7 @@ class RolesControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("Owner can delete an unassigned role via POST /roles/{id}/delete")
     void ownerCanDeleteRole() throws Exception {
         Role role = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
 
@@ -182,6 +193,7 @@ class RolesControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("Tenant B session is force-redirected to tenant A's login when reaching tenant A's roles")
     void tenantBSessionCannotReachTenantARoles() throws Exception {
         userRepository.save(new User(null, tenantB.id(), "ownerB", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
         MvcResult loginB = mockMvc.perform(post("/manage/t/roles-corp-b/login")
@@ -197,6 +209,7 @@ class RolesControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("Applications-list page links each row to its /roles page")
     void rolesLinkAppearsOnApplicationsList() throws Exception {
         mockMvc.perform(get("/manage/t/roles-corp-a/applications").session(sessionA))
             .andExpect(status().isOk())

--- a/src/test/java/com/stucray/limen/management/system/SystemAdminCrossTenantIsolationIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/system/SystemAdminCrossTenantIsolationIntegrationTest.java
@@ -7,6 +7,7 @@ import com.stucray.limen.tenant.TenantStatus;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -35,6 +36,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@DisplayName("System admin cannot cross into other tenants' management routes")
 class SystemAdminCrossTenantIsolationIntegrationTest {
 
     @Autowired MockMvc mockMvc;
@@ -75,6 +77,7 @@ class SystemAdminCrossTenantIsolationIntegrationTest {
     }
 
     @Test
+    @DisplayName("Sysadmin's session hitting /manage/t/acme/users is invalidated and redirected to /manage/t/acme/login")
     void systemAdminCannotReachAnotherTenantsManagementRoutes() throws Exception {
         mockMvc.perform(get("/manage/t/acme/users").session(sysadminSession))
             .andExpect(status().is3xxRedirection())

--- a/src/test/java/com/stucray/limen/management/system/SystemAdminIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/system/SystemAdminIntegrationTest.java
@@ -7,6 +7,7 @@ import com.stucray.limen.tenant.TenantStatus;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -28,6 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@DisplayName("System admin: tenant suspend / unsuspend / delete + tenant settings")
 class SystemAdminIntegrationTest {
 
     @Autowired MockMvc mockMvc;
@@ -62,6 +64,7 @@ class SystemAdminIntegrationTest {
     }
 
     @Test
+    @DisplayName("System admin can list all tenants at /manage/system/tenants")
     void adminCanListTenants() throws Exception {
         mockMvc.perform(get("/manage/system/tenants").session(adminSession))
             .andExpect(status().isOk())
@@ -69,6 +72,7 @@ class SystemAdminIntegrationTest {
     }
 
     @Test
+    @DisplayName("System admin can suspend a tenant — status flips to SUSPENDED")
     void adminCanSuspendTenant() throws Exception {
         mockMvc.perform(post("/manage/system/tenants/" + customerTenant.id() + "/suspend").session(adminSession).with(csrf()))
             .andExpect(status().is3xxRedirection());
@@ -78,6 +82,7 @@ class SystemAdminIntegrationTest {
     }
 
     @Test
+    @DisplayName("Login at a suspended tenant fails (redirects to ?error)")
     void suspendedTenantLoginIsBlocked() throws Exception {
         userRepository.save(new User(null, customerTenant.id(), "owner", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
         tenantRepository.save(customerTenant.withStatus(TenantStatus.SUSPENDED));
@@ -89,6 +94,7 @@ class SystemAdminIntegrationTest {
     }
 
     @Test
+    @DisplayName("System admin can unsuspend a tenant — status flips back to ACTIVE")
     void adminCanUnsuspendTenant() throws Exception {
         tenantRepository.save(customerTenant.withStatus(TenantStatus.SUSPENDED));
 
@@ -100,6 +106,7 @@ class SystemAdminIntegrationTest {
     }
 
     @Test
+    @DisplayName("System admin can delete a tenant")
     void adminCanDeleteTenant() throws Exception {
         mockMvc.perform(post("/manage/system/tenants/" + customerTenant.id() + "/delete").session(adminSession).with(csrf()))
             .andExpect(status().is3xxRedirection());
@@ -108,6 +115,7 @@ class SystemAdminIntegrationTest {
     }
 
     @Test
+    @DisplayName("The system tenant itself cannot be suspended")
     void systemTenantCannotBeSuspended() throws Exception {
         Tenant systemTenant = tenantRepository.findBySlug("system").orElseThrow();
 
@@ -119,6 +127,7 @@ class SystemAdminIntegrationTest {
     }
 
     @Test
+    @DisplayName("The system tenant itself cannot be deleted")
     void systemTenantCannotBeDeleted() throws Exception {
         Tenant systemTenant = tenantRepository.findBySlug("system").orElseThrow();
 
@@ -129,6 +138,7 @@ class SystemAdminIntegrationTest {
     }
 
     @Test
+    @DisplayName("A tenant owner can view their tenant settings and update its display name")
     void tenantOwnerCanViewAndUpdateTenantDetails() throws Exception {
         Tenant corp = tenantRepository.save(new Tenant(null, "my-corp", "My Corp", TenantStatus.ACTIVE, LocalDateTime.now()));
         userRepository.save(new User(null, corp.id(), "owner", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));

--- a/src/test/java/com/stucray/limen/management/users/UserDetailControllerIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/users/UserDetailControllerIntegrationTest.java
@@ -19,6 +19,7 @@ import com.stucray.limen.tenant.TenantStatus;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -46,6 +47,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@DisplayName("User detail page: read-only view of a user's application + client memberships")
 class UserDetailControllerIntegrationTest {
 
     @Autowired MockMvc mockMvc;
@@ -97,6 +99,7 @@ class UserDetailControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("Detail page lists each application membership with its roles, and nested client memberships with their roles, and links through to the per-app and per-client member pages")
     void detailPageRendersAppAndNestedClientMembershipsWithRoles() throws Exception {
         Role appAdmin = roleRepository.save(new Role(null, appA.id(), "app-admin", null, LocalDateTime.now()));
         Role viewer = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
@@ -126,6 +129,7 @@ class UserDetailControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("A user with no memberships renders an empty-state message")
     void detailPageShowsEmptyStateWhenUserHasNoMemberships() throws Exception {
         mockMvc.perform(get("/manage/t/user-detail-a/users/" + aliceA.id()).session(sessionA))
             .andExpect(status().isOk())
@@ -133,6 +137,7 @@ class UserDetailControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("Detail page is read-only — it has no edit/grant/delete buttons or membership-mutating forms")
     void detailPageHasNoEditOrGrantOrDeleteAffordances() throws Exception {
         Role viewer = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
         ApplicationMembership am = appMembershipRepository.save(new ApplicationMembership(
@@ -155,6 +160,7 @@ class UserDetailControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("A session for tenant B cannot view a user-detail page in tenant A — redirects to tenant A's login")
     void crossTenantSessionCannotReachUserDetail() throws Exception {
         userRepository.save(new User(null, tenantB.id(), "ownerB", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
         MvcResult loginB = mockMvc.perform(post("/manage/t/user-detail-b/login")
@@ -168,6 +174,7 @@ class UserDetailControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("On the users list page, each username links to that user's detail page")
     void usernameOnListPageLinksToDetail() throws Exception {
         mockMvc.perform(get("/manage/t/user-detail-a/users").session(sessionA))
             .andExpect(status().isOk())
@@ -177,6 +184,7 @@ class UserDetailControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("Empty-state still shows when other users in the same tenant have memberships but the target user does not")
     void detailPageRendersWhenMembershipsExistInOtherAppsButNotForThisUser() throws Exception {
         // Other user has memberships, target user does not — empty state still shows.
         User bob = userRepository.save(new User(null, tenantA.id(), "bob", passwordEncoder.encode("pass"), true, false, false, LocalDateTime.now()));

--- a/src/test/java/com/stucray/limen/management/users/UserManagementIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/users/UserManagementIntegrationTest.java
@@ -7,6 +7,7 @@ import com.stucray.limen.tenant.TenantStatus;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -29,6 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@DisplayName("Tenant user management: list / create / disable / delete / reset-password / grant-owner + change-password flow")
 class UserManagementIntegrationTest {
 
     @Autowired MockMvc mockMvc;
@@ -55,6 +57,7 @@ class UserManagementIntegrationTest {
     }
 
     @Test
+    @DisplayName("Tenant owner can GET /manage/t/{slug}/users and see the tenant's users")
     void ownerCanListUsers() throws Exception {
         mockMvc.perform(get("/manage/t/corp/users").session(ownerSession))
             .andExpect(status().isOk())
@@ -62,6 +65,7 @@ class UserManagementIntegrationTest {
     }
 
     @Test
+    @DisplayName("Creating a user persists them with mustChangePassword=true so they're forced to set a real password on first login")
     void ownerCanCreateUser() throws Exception {
         mockMvc.perform(post("/manage/t/corp/users").session(ownerSession).with(csrf())
                 .param("username", "alice").param("temporaryPassword", "temppass1"))
@@ -72,6 +76,7 @@ class UserManagementIntegrationTest {
     }
 
     @Test
+    @DisplayName("Tenant owner can disable a user and re-enable them, flipping the enabled flag in both directions")
     void ownerCanDisableAndEnableUser() throws Exception {
         User alice = userRepository.save(new User(null, tenant.id(), "alice", passwordEncoder.encode("pass"), true, false, false, LocalDateTime.now()));
 
@@ -85,6 +90,7 @@ class UserManagementIntegrationTest {
     }
 
     @Test
+    @DisplayName("Tenant owner can delete a user — the row is removed from the users table")
     void ownerCanDeleteUser() throws Exception {
         User alice = userRepository.save(new User(null, tenant.id(), "alice", passwordEncoder.encode("pass"), true, false, false, LocalDateTime.now()));
 
@@ -94,6 +100,7 @@ class UserManagementIntegrationTest {
     }
 
     @Test
+    @DisplayName("Reset-password sets a temporary password and flips mustChangePassword=true so the user must change it on next login")
     void ownerCanResetPassword() throws Exception {
         User alice = userRepository.save(new User(null, tenant.id(), "alice", passwordEncoder.encode("oldpass"), true, false, false, LocalDateTime.now()));
 
@@ -106,6 +113,7 @@ class UserManagementIntegrationTest {
     }
 
     @Test
+    @DisplayName("Tenant owner can grant the tenant-owner role to another user and revoke it again")
     void ownerCanGrantAndRevokeTenantOwnerRole() throws Exception {
         User alice = userRepository.save(new User(null, tenant.id(), "alice", passwordEncoder.encode("pass"), true, false, false, LocalDateTime.now()));
 
@@ -119,6 +127,7 @@ class UserManagementIntegrationTest {
     }
 
     @Test
+    @DisplayName("A user with mustChangePassword=true is redirected to the change-password page on every authenticated request")
     void userWithMustChangePasswordIsInterceptedToChangePasswordPage() throws Exception {
         userRepository.save(new User(null, tenant.id(), "newuser", passwordEncoder.encode("temp"), true, true, false, LocalDateTime.now()));
 
@@ -133,6 +142,7 @@ class UserManagementIntegrationTest {
     }
 
     @Test
+    @DisplayName("After successfully changing the password, mustChangePassword is cleared so the user can use the app normally")
     void mustChangePasswordClearedAfterChange() throws Exception {
         User newUser = userRepository.save(new User(null, tenant.id(), "newuser", passwordEncoder.encode("temp"), true, true, false, LocalDateTime.now()));
 
@@ -149,6 +159,7 @@ class UserManagementIntegrationTest {
     }
 
     @Test
+    @DisplayName("Mismatched new/confirm passwords re-render the form with an error and leave mustChangePassword=true")
     void changePasswordRedisplaysFormWhenNewAndConfirmDoNotMatch() throws Exception {
         User newUser = userRepository.save(new User(null, tenant.id(), "newuser", passwordEncoder.encode("temp"), true, true, false, LocalDateTime.now()));
 
@@ -167,6 +178,7 @@ class UserManagementIntegrationTest {
     }
 
     @Test
+    @DisplayName("Blank/whitespace new password re-renders the form with 'Password is required' and leaves mustChangePassword=true")
     void changePasswordRedisplaysFormWhenNewPasswordIsBlank() throws Exception {
         User newUser = userRepository.save(new User(null, tenant.id(), "newuser", passwordEncoder.encode("temp"), true, true, false, LocalDateTime.now()));
 
@@ -185,6 +197,7 @@ class UserManagementIntegrationTest {
     }
 
     @Test
+    @DisplayName("GET /manage/t/{slug}/change-password renders the form template with the tenant slug in the model")
     void changePasswordFormGetRendersTemplateWithSlug() throws Exception {
         mockMvc.perform(get("/manage/t/corp/change-password").session(ownerSession))
             .andExpect(status().isOk())

--- a/src/test/java/com/stucray/limen/oauth2/MembershipGateFilterUnitTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/MembershipGateFilterUnitTest.java
@@ -9,6 +9,7 @@ import com.stucray.limen.user.User;
 import jakarta.servlet.FilterChain;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -41,6 +42,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
  * exercise through the full SAS flow.
  */
 @ExtendWith(MockitoExtension.class)
+@DisplayName("MembershipGateFilter: branch coverage for /oauth2/authorize parameter shapes and redirect_uri fallback")
 class MembershipGateFilterUnitTest {
 
     @Mock RegisteredClientRepository registeredClientRepository;
@@ -68,6 +70,7 @@ class MembershipGateFilterUnitTest {
     }
 
     @Test
+    @DisplayName("Requests outside /oauth2/authorize pass straight through without consulting the registered-client or membership repos")
     void nonAuthorizeRequestPassesThroughWithoutLookup() throws Exception {
         MockHttpServletRequest req = new MockHttpServletRequest("GET", "/somewhere/else");
         MockHttpServletResponse res = new MockHttpServletResponse();
@@ -80,6 +83,7 @@ class MembershipGateFilterUnitTest {
     }
 
     @Test
+    @DisplayName("Unauthenticated /oauth2/authorize requests pass through (Spring Security will redirect to login)")
     void unauthenticatedRequestPassesThroughWithoutLookup() throws Exception {
         SecurityContextHolder.clearContext();
         MockHttpServletRequest req = newAuthorizeRequest();
@@ -93,6 +97,7 @@ class MembershipGateFilterUnitTest {
     }
 
     @Test
+    @DisplayName("Missing client_id parameter passes through — let Spring Authorization Server return invalid_request")
     void missingClientIdPassesThroughForSasToHandle() throws Exception {
         MockHttpServletRequest req = newAuthorizeRequest();
         // No client_id parameter set.
@@ -112,6 +117,7 @@ class MembershipGateFilterUnitTest {
     }
 
     @Test
+    @DisplayName("Unknown client_id passes through — let Spring Authorization Server return invalid_client")
     void unknownClientIdPassesThroughForSasToReportInvalidClient() throws Exception {
         MockHttpServletRequest req = newAuthorizeRequest();
         req.setParameter("client_id", "ghost-client");
@@ -132,6 +138,7 @@ class MembershipGateFilterUnitTest {
     }
 
     @Test
+    @DisplayName("With multiple registered redirect_uris and none in the request, the filter refuses to guess and returns 403 access_denied instead of redirecting")
     void multipleRegisteredRedirectsAndNoRequestedYields403() throws Exception {
         RegisteredClient client = pkceClientBuilder("multi-redirect-client")
             .redirectUri("http://localhost/cb1")
@@ -161,6 +168,7 @@ class MembershipGateFilterUnitTest {
     }
 
     @Test
+    @DisplayName("With exactly one registered redirect_uri and none in the request, the filter uses the registered one for the access_denied redirect")
     void singleRegisteredRedirectIsUsedAsFallbackWhenRequestOmitsIt() throws Exception {
         RegisteredClient client = pkceClientBuilder("single-redirect-client")
             .redirectUri("http://localhost/only-callback")
@@ -190,6 +198,7 @@ class MembershipGateFilterUnitTest {
     }
 
     @Test
+    @DisplayName("With no TenantScope bound, the membership check short-circuits and the filter denies access without ever calling the membership repo")
     void unboundTenantScopeFallsThroughToAccessDenied() throws Exception {
         RegisteredClient client = pkceClientBuilder("scoped-client")
             .redirectUri("http://localhost/callback")

--- a/src/test/java/com/stucray/limen/oauth2/OAuth2AuthorizeMembershipGateIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/OAuth2AuthorizeMembershipGateIntegrationTest.java
@@ -17,6 +17,7 @@ import com.stucray.limen.tenant.TenantProvisioningService;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -64,6 +65,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@DisplayName("/oauth2/authorize client-membership gate: deny unless (user, registered_client, tenant) has a membership row")
 class OAuth2AuthorizeMembershipGateIntegrationTest {
 
     @Autowired MockMvc mockMvc;
@@ -131,6 +133,7 @@ class OAuth2AuthorizeMembershipGateIntegrationTest {
     }
 
     @Test
+    @DisplayName("Authenticated user with no client_membership is rejected with access_denied (state preserved, no code issued)")
     void userWithoutClientMembershipIsDeniedAtAuthorize() throws Exception {
         TenantClient client = createPkceClient(alphaApp, alphaTenant, "no-membership-client");
 
@@ -145,6 +148,7 @@ class OAuth2AuthorizeMembershipGateIntegrationTest {
     }
 
     @Test
+    @DisplayName("Membership presence is the gate, not role count — a user with zero roles still gets a token (with an empty roles claim)")
     void userWithMembershipAndZeroRolesPassesGate() throws Exception {
         TenantClient client = createPkceClient(alphaApp, alphaTenant, "zero-roles-client");
         ClientMembershipTestFixture.grant(
@@ -162,6 +166,7 @@ class OAuth2AuthorizeMembershipGateIntegrationTest {
     }
 
     @Test
+    @DisplayName("A user with membership + roles gets an access token whose roles claim lists their granted role names")
     void userWithMembershipAndRolesGetsJwtWithRoles() throws Exception {
         TenantClient client = createPkceClient(alphaApp, alphaTenant, "with-roles-client");
         Role viewer = roleRepository.save(new Role(null, alphaApp.id(), "viewer", null, LocalDateTime.now()));
@@ -183,6 +188,7 @@ class OAuth2AuthorizeMembershipGateIntegrationTest {
     }
 
     @Test
+    @DisplayName("A user from tenant Beta logging into tenant Alpha's URL is rejected by TenantAccessFilter before the gate ever runs")
     void crossTenantUserIsRejectedBeforeReachingGate() throws Exception {
         // bob (Tenant Beta) attempting to login against Tenant Alpha's URL is
         // force-logged-out by TenantAccessFilter from v1 — login fails outright,

--- a/src/test/java/com/stucray/limen/oauth2/OAuth2ForcedPasswordChangeIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/OAuth2ForcedPasswordChangeIntegrationTest.java
@@ -14,6 +14,7 @@ import com.stucray.limen.tenant.TenantStatus;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -49,6 +50,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@DisplayName("OAuth2 forced-password-change: mustChangePassword=true intercepts the authorize flow until the password is reset")
 class OAuth2ForcedPasswordChangeIntegrationTest {
 
     @Autowired MockMvc mockMvc;
@@ -102,6 +104,7 @@ class OAuth2ForcedPasswordChangeIntegrationTest {
     }
 
     @Test
+    @DisplayName("During an /oauth2/authorize flow, a user with mustChangePassword=true is redirected to the tenant change-password page after login")
     void userWithMustChangePasswordRedirectedToChangePasswordPage() throws Exception {
         userRepository.save(new User(
             null, tenant.id(), "alice",
@@ -121,6 +124,7 @@ class OAuth2ForcedPasswordChangeIntegrationTest {
     }
 
     @Test
+    @DisplayName("Successful change-password clears mustChangePassword and resumes the saved /oauth2/authorize request, ultimately yielding an authorization code")
     void changePasswordResumesOAuth2FlowAndClearsFlag() throws Exception {
         User original = userRepository.save(new User(
             null, tenant.id(), "alice",
@@ -160,6 +164,7 @@ class OAuth2ForcedPasswordChangeIntegrationTest {
     }
 
     @Test
+    @DisplayName("Mismatched new/confirm re-renders the form and leaves mustChangePassword=true so the user remains gated")
     void mismatchedPasswordsRerendersFormAndDoesNotClearFlag() throws Exception {
         User original = userRepository.save(new User(
             null, tenant.id(), "alice",
@@ -183,6 +188,7 @@ class OAuth2ForcedPasswordChangeIntegrationTest {
     }
 
     @Test
+    @DisplayName("A user without mustChangePassword goes straight from login back to /oauth2/authorize without the change-password detour")
     void userWithoutMustChangePasswordCompletesNormally() throws Exception {
         userRepository.save(new User(
             null, tenant.id(), "bob",
@@ -202,6 +208,7 @@ class OAuth2ForcedPasswordChangeIntegrationTest {
     }
 
     @Test
+    @DisplayName("Blank/whitespace new password re-renders the form and leaves mustChangePassword=true")
     void blankNewPasswordRerendersFormAndDoesNotClearFlag() throws Exception {
         User original = userRepository.save(new User(
             null, tenant.id(), "alice",
@@ -224,6 +231,7 @@ class OAuth2ForcedPasswordChangeIntegrationTest {
     }
 
     @Test
+    @DisplayName("Direct change-password (no SavedRequest in cache) succeeds and falls back to the tenant home /t/{slug}/")
     void changePasswordWithoutSavedRequestRedirectsToTenantHome() throws Exception {
         // Direct visit to the change-password page (no prior /oauth2/authorize → no
         // SavedRequest in the cache); after success the controller should fall back
@@ -251,6 +259,7 @@ class OAuth2ForcedPasswordChangeIntegrationTest {
     }
 
     @Test
+    @DisplayName("GET /t/{slug}/change-password renders the change-password view for an authenticated mustChangePassword user")
     void changePasswordFormGetRendersChangePasswordView() throws Exception {
         userRepository.save(new User(
             null, tenant.id(), "alice",

--- a/src/test/java/com/stucray/limen/oauth2/OAuth2JwtRolesClaimIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/OAuth2JwtRolesClaimIntegrationTest.java
@@ -17,6 +17,7 @@ import com.stucray.limen.tenant.TenantProvisioningService;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -62,6 +63,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@DisplayName("OAuth2 access-token roles claim: end-to-end PKCE auth-code flow surfaces client_membership roles in the JWT")
 class OAuth2JwtRolesClaimIntegrationTest {
 
     @Autowired MockMvc mockMvc;
@@ -111,6 +113,7 @@ class OAuth2JwtRolesClaimIntegrationTest {
     }
 
     @Test
+    @DisplayName("End-user with client_membership + roles receives an access token whose roles claim lists the granted role names and whose iss is the per-tenant issuer")
     void jwtCarriesClientMembershipRolesForEndUser() throws Exception {
         // 1. Define Roles and a public PKCE Client.
         Role viewer = roleRepository.save(new Role(null, app.id(), "viewer", null, LocalDateTime.now()));
@@ -137,6 +140,7 @@ class OAuth2JwtRolesClaimIntegrationTest {
     }
 
     @Test
+    @DisplayName("Membership without any role grants still passes the gate — token issued with an empty roles claim")
     void jwtCarriesEmptyRolesWhenMembershipHasNoRolesAssigned() throws Exception {
         // Membership presence (not Role count) is the gate — Membership without
         // Roles passes the gate and yields a JWT with roles: [].

--- a/src/test/java/com/stucray/limen/oauth2/OAuth2TenantLoginControllerUnitTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/OAuth2TenantLoginControllerUnitTest.java
@@ -3,6 +3,7 @@ package com.stucray.limen.oauth2;
 import com.stucray.limen.tenant.Tenant;
 import com.stucray.limen.tenant.TenantRepository;
 import com.stucray.limen.tenant.TenantStatus;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -21,11 +22,13 @@ import static org.mockito.BDDMockito.given;
  * the unknown-slug redirect (previously uncovered) and the happy path.
  */
 @ExtendWith(MockitoExtension.class)
+@DisplayName("OAuth2TenantLoginController: branch coverage for the unknown-slug redirect and the happy path")
 class OAuth2TenantLoginControllerUnitTest {
 
     @Mock TenantRepository tenantRepository;
 
     @Test
+    @DisplayName("Unknown slug redirects to /manage/t/system/login and adds no tenant attributes to the model")
     void unknownSlugRedirectsToSystemLogin() {
         given(tenantRepository.findBySlug("does-not-exist")).willReturn(Optional.empty());
         OAuth2TenantLoginController controller = new OAuth2TenantLoginController(tenantRepository);
@@ -39,6 +42,7 @@ class OAuth2TenantLoginControllerUnitTest {
     }
 
     @Test
+    @DisplayName("Known slug renders the login view with tenantSlug and tenantName populated for the template")
     void knownSlugRendersLoginViewWithTenantAttributes() {
         Tenant alpha = new Tenant(1L, "alpha", "Alpha Corp", TenantStatus.ACTIVE, LocalDateTime.now());
         given(tenantRepository.findBySlug("alpha")).willReturn(Optional.of(alpha));

--- a/src/test/java/com/stucray/limen/oauth2/TenantAccessFilterIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/TenantAccessFilterIntegrationTest.java
@@ -7,6 +7,7 @@ import com.stucray.limen.tenant.TenantStatus;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -36,6 +37,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@DisplayName("TenantAccessFilter: a session whose principal belongs to a different tenant than the URL slug is force-logged-out")
 class TenantAccessFilterIntegrationTest {
 
     @Autowired MockMvc mockMvc;
@@ -64,6 +66,7 @@ class TenantAccessFilterIntegrationTest {
     }
 
     @Test
+    @DisplayName("Alpha-tenant session presented at /manage/t/beta/ is invalidated, redirected to beta's login, and is no longer authenticated for alpha either")
     void crossTenantManagementAccessForcesLogoutAndRedirect() throws Exception {
         MvcResult loginResult = mockMvc.perform(post("/manage/t/alpha/login")
                 .param("username", "owner")

--- a/src/test/java/com/stucray/limen/oauth2/TenantAwareOAuth2AuthorizationConsentServiceIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/TenantAwareOAuth2AuthorizationConsentServiceIntegrationTest.java
@@ -10,6 +10,7 @@ import com.stucray.limen.tenant.TenantRepository;
 import com.stucray.limen.tenant.TenantScope;
 import com.stucray.limen.tenant.TenantStatus;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -31,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
+@DisplayName("TenantAwareOAuth2AuthorizationConsentService: TenantScope-required save/find/remove with cross-tenant isolation")
 class TenantAwareOAuth2AuthorizationConsentServiceIntegrationTest {
 
     @Autowired OAuth2AuthorizationConsentService consentService;
@@ -85,6 +87,7 @@ class TenantAwareOAuth2AuthorizationConsentServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("save() without an active TenantScope throws IllegalStateException — refuses to write a tenantless row")
     void saveWithoutTenantScopeThrows() {
         OAuth2AuthorizationConsent consent = OAuth2AuthorizationConsent
             .withId(client.getId(), "alice")
@@ -97,6 +100,7 @@ class TenantAwareOAuth2AuthorizationConsentServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("findById() without an active TenantScope throws IllegalStateException — refuses to read across tenants")
     void findByIdWithoutTenantScopeThrows() {
         assertThatThrownBy(() -> consentService.findById(client.getId(), "alice"))
             .isInstanceOf(IllegalStateException.class)
@@ -104,6 +108,7 @@ class TenantAwareOAuth2AuthorizationConsentServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("remove() without an active TenantScope throws IllegalStateException — refuses to delete a tenantless row")
     void removeWithoutTenantScopeThrows() {
         OAuth2AuthorizationConsent consent = OAuth2AuthorizationConsent
             .withId(client.getId(), "alice")
@@ -116,6 +121,7 @@ class TenantAwareOAuth2AuthorizationConsentServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("A consent saved under tenant alpha is invisible to a findById() call running under tenant beta's scope")
     void crossTenantFindByIdReturnsNull() {
         TenantScope.run(alpha.slug(), alpha.id(), () -> {
             OAuth2AuthorizationConsent consent = OAuth2AuthorizationConsent
@@ -132,6 +138,7 @@ class TenantAwareOAuth2AuthorizationConsentServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("save() under TenantScope persists the calling tenant's id into the tenant_id column")
     void savePersistsTenantIdColumn() {
         TenantScope.run(alpha.slug(), alpha.id(), () -> {
             OAuth2AuthorizationConsent consent = OAuth2AuthorizationConsent
@@ -150,6 +157,7 @@ class TenantAwareOAuth2AuthorizationConsentServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("save() with the same (clientId, principal) within a tenant overwrites authorities — exactly one row remains")
     void updateOverwritesAuthoritiesWithinTenant() {
         TenantScope.run(alpha.slug(), alpha.id(), () -> {
             consentService.save(OAuth2AuthorizationConsent
@@ -178,6 +186,7 @@ class TenantAwareOAuth2AuthorizationConsentServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("remove() under tenant alpha deletes only alpha's consent row — a manually-planted beta row with the same (clientId, principal) survives")
     void removeDeletesOnlyCallingTenantsRow() {
         OAuth2AuthorizationConsent alphaConsent = OAuth2AuthorizationConsent
             .withId(client.getId(), "alice")

--- a/src/test/java/com/stucray/limen/oauth2/TenantAwareOAuth2AuthorizationServiceIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/TenantAwareOAuth2AuthorizationServiceIntegrationTest.java
@@ -10,6 +10,7 @@ import com.stucray.limen.tenant.TenantRepository;
 import com.stucray.limen.tenant.TenantScope;
 import com.stucray.limen.tenant.TenantStatus;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -33,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
+@DisplayName("TenantAwareOAuth2AuthorizationService: TenantScope-required save/findById/findByToken with cross-tenant isolation")
 class TenantAwareOAuth2AuthorizationServiceIntegrationTest {
 
     @Autowired OAuth2AuthorizationService authorizationService;
@@ -86,6 +88,7 @@ class TenantAwareOAuth2AuthorizationServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("save() without an active TenantScope throws IllegalStateException")
     void saveWithoutTenantScopeThrows() {
         OAuth2Authorization auth = buildAuthorizationWithAccessToken("alice", "tok-1");
 
@@ -95,6 +98,7 @@ class TenantAwareOAuth2AuthorizationServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("findById() without an active TenantScope throws IllegalStateException")
     void findByIdWithoutTenantScopeThrows() {
         assertThatThrownBy(() -> authorizationService.findById("any-id"))
             .isInstanceOf(IllegalStateException.class)
@@ -102,6 +106,7 @@ class TenantAwareOAuth2AuthorizationServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("findByToken() without an active TenantScope throws IllegalStateException")
     void findByTokenWithoutTenantScopeThrows() {
         assertThatThrownBy(() -> authorizationService.findByToken("any-token", OAuth2TokenType.ACCESS_TOKEN))
             .isInstanceOf(IllegalStateException.class)
@@ -109,6 +114,7 @@ class TenantAwareOAuth2AuthorizationServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("An authorization saved under tenant alpha is invisible to findById() running under tenant beta's scope")
     void crossTenantFindByIdReturnsNull() throws Exception {
         OAuth2Authorization saved = TenantScope.call(alpha.slug(), alpha.id(), () -> {
             OAuth2Authorization a = buildAuthorizationWithAccessToken("alice", "tok-alpha-1");
@@ -123,6 +129,7 @@ class TenantAwareOAuth2AuthorizationServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("A token issued under tenant alpha is resolvable by findByToken() under alpha but returns null under tenant beta's scope")
     void crossTenantFindByTokenReturnsNull() throws Exception {
         OAuth2Authorization saved = TenantScope.call(alpha.slug(), alpha.id(), () -> {
             OAuth2Authorization a = buildAuthorizationWithAccessToken("alice", "tok-alpha-2");
@@ -143,6 +150,7 @@ class TenantAwareOAuth2AuthorizationServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("save() under TenantScope persists the calling tenant's id into the oauth2_authorization.tenant_id column")
     void savePersistsTenantIdColumn() throws Exception {
         OAuth2Authorization saved = TenantScope.call(alpha.slug(), alpha.id(), () -> {
             OAuth2Authorization a = buildAuthorizationWithAccessToken("alice", "tok-alpha-3");

--- a/src/test/java/com/stucray/limen/oauth2/TenantIssuerContextFilterUnitTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/TenantIssuerContextFilterUnitTest.java
@@ -4,6 +4,7 @@ import com.stucray.limen.tenant.TenantScope;
 import jakarta.servlet.FilterChain;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -22,6 +23,7 @@ import static org.mockito.Mockito.verify;
  * the default-port branches in {@code buildBaseUrl}, which would silently
  * stamp wrong-issuer claims if broken.
  */
+@DisplayName("TenantIssuerContextFilter: branch coverage for no-tenant-scope short-circuit and buildBaseUrl default-port handling")
 class TenantIssuerContextFilterUnitTest {
 
     AuthorizationServerSettings baseSettings;
@@ -39,6 +41,7 @@ class TenantIssuerContextFilterUnitTest {
     }
 
     @Test
+    @DisplayName("With no TenantScope bound, the filter does not set an AuthorizationServerContext and just proceeds down the chain")
     void noTenantScopeLeavesContextUntouchedAndProceeds() throws Exception {
         MockHttpServletRequest req = new MockHttpServletRequest("GET", "/anything");
         MockHttpServletResponse res = new MockHttpServletResponse();
@@ -51,24 +54,28 @@ class TenantIssuerContextFilterUnitTest {
     }
 
     @Test
+    @DisplayName("http on the default port 80 produces an issuer URL with no explicit :80 segment")
     void httpOnPort80OmitsPortFromIssuer() throws Exception {
         String issuer = issuerFor("http", "auth.example.com", 80, "alpha");
         assertThat(issuer).isEqualTo("http://auth.example.com/t/alpha");
     }
 
     @Test
+    @DisplayName("https on the default port 443 produces an issuer URL with no explicit :443 segment")
     void httpsOnPort443OmitsPortFromIssuer() throws Exception {
         String issuer = issuerFor("https", "auth.example.com", 443, "alpha");
         assertThat(issuer).isEqualTo("https://auth.example.com/t/alpha");
     }
 
     @Test
+    @DisplayName("http on a non-default port (e.g. 8080) keeps the port in the issuer URL")
     void httpOnNonDefaultPortIncludesPortInIssuer() throws Exception {
         String issuer = issuerFor("http", "localhost", 8080, "alpha");
         assertThat(issuer).isEqualTo("http://localhost:8080/t/alpha");
     }
 
     @Test
+    @DisplayName("https on a non-default port (e.g. 8443) keeps the port in the issuer URL")
     void httpsOnNonDefaultPortIncludesPortInIssuer() throws Exception {
         String issuer = issuerFor("https", "auth.example.com", 8443, "alpha");
         assertThat(issuer).isEqualTo("https://auth.example.com:8443/t/alpha");

--- a/src/test/java/com/stucray/limen/oauth2/TenantJwkSourceUnitTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/TenantJwkSourceUnitTest.java
@@ -13,6 +13,7 @@ import com.stucray.limen.tenant.TenantScope;
 import com.stucray.limen.tenant.TenantStatus;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -37,6 +38,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
  * hit the issuer-with-slug → key happy path.
  */
 @ExtendWith(MockitoExtension.class)
+@DisplayName("TenantJwkSource: branch coverage for resolveTenantId() arms and the no-active-key error")
 class TenantJwkSourceUnitTest {
 
     @Mock TenantRepository tenantRepository;
@@ -59,6 +61,7 @@ class TenantJwkSourceUnitTest {
     }
 
     @Test
+    @DisplayName("Issuer URL containing /t/{slug} resolves the tenant via the repo and returns that tenant's active signing key")
     void issuerWithTenantSegmentResolvesViaRepositoryAndReturnsKey() throws Exception {
         setIssuer("https://auth.example.com/t/alpha");
         given(tenantRepository.findBySlug("alpha")).willReturn(Optional.of(alpha));
@@ -70,6 +73,7 @@ class TenantJwkSourceUnitTest {
     }
 
     @Test
+    @DisplayName("Issuer URL without a /t/{slug} segment falls back to the bound TenantScope and skips the repo lookup entirely")
     void issuerWithoutTenantSegmentFallsBackToTenantScope() throws Exception {
         setIssuer("https://auth.example.com");
         given(signingKeyStore.getActiveSigningKey(1L)).willReturn(alphaKey);
@@ -83,6 +87,7 @@ class TenantJwkSourceUnitTest {
     }
 
     @Test
+    @DisplayName("Issuer URL with an unknown slug falls back to the bound TenantScope rather than blowing up")
     void issuerWithUnknownSlugFallsBackToTenantScope() throws Exception {
         setIssuer("https://auth.example.com/t/ghost");
         given(tenantRepository.findBySlug("ghost")).willReturn(Optional.empty());
@@ -96,6 +101,7 @@ class TenantJwkSourceUnitTest {
     }
 
     @Test
+    @DisplayName("With neither AuthorizationServerContext nor TenantScope set, get() throws IllegalStateException and never touches the repo or key store")
     void noContextAndNoTenantScopeThrowsIllegalState() {
         assertThatThrownBy(() ->
             source.get(new JWKSelector(new com.nimbusds.jose.jwk.JWKMatcher.Builder().build()), null))
@@ -105,6 +111,7 @@ class TenantJwkSourceUnitTest {
     }
 
     @Test
+    @DisplayName("Tenant resolved but no active signing key — get() throws IllegalStateException naming the tenant id")
     void resolvedTenantWithNoActiveKeyThrowsIllegalState() {
         setIssuer("https://auth.example.com/t/alpha");
         given(tenantRepository.findBySlug("alpha")).willReturn(Optional.of(alpha));

--- a/src/test/java/com/stucray/limen/oauth2/TenantOAuth2RoutingIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/TenantOAuth2RoutingIntegrationTest.java
@@ -24,6 +24,7 @@ import com.stucray.limen.tenant.TenantStatus;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -63,6 +64,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@DisplayName("Per-tenant OAuth2 routing under /t/{slug}/: discovery, token, JWKS, userinfo, plus cross-tenant client isolation")
 class TenantOAuth2RoutingIntegrationTest {
 
     @Autowired MockMvc mockMvc;
@@ -112,6 +114,7 @@ class TenantOAuth2RoutingIntegrationTest {
     }
 
     @Test
+    @DisplayName("/t/{slug}/.well-known/openid-configuration advertises tenant-prefixed issuer, token, jwks, and authorization endpoints")
     void discoveryDocumentHasTenantIssuer() throws Exception {
         mockMvc.perform(get("/t/alpha-corp/.well-known/openid-configuration"))
             .andExpect(status().isOk())
@@ -122,12 +125,14 @@ class TenantOAuth2RoutingIntegrationTest {
     }
 
     @Test
+    @DisplayName("Discovery on an unknown tenant slug returns 404")
     void unknownTenantSlugReturns404() throws Exception {
         mockMvc.perform(get("/t/no-such-tenant/.well-known/openid-configuration"))
             .andExpect(status().isNotFound());
     }
 
     @Test
+    @DisplayName("Discovery on a SUSPENDED tenant returns 403 — the tenant exists but is shut off")
     void suspendedTenantReturns403() throws Exception {
         tenantRepository.save(new Tenant(
             null, "suspended-co", "Suspended Co", TenantStatus.SUSPENDED, LocalDateTime.now()
@@ -138,6 +143,7 @@ class TenantOAuth2RoutingIntegrationTest {
     }
 
     @Test
+    @DisplayName("client_credentials token flow at /t/{slug}/oauth2/token succeeds for a client created under that tenant")
     void clientCredentialsTokenFlowSucceedsForTenantClient() throws Exception {
         ClientCreationResult result = clientManagementService.createClient(
             alphaApp.id(), alphaCorpTenant.id(),
@@ -169,6 +175,7 @@ class TenantOAuth2RoutingIntegrationTest {
     }
 
     @Test
+    @DisplayName("A client registered under tenant alpha cannot exchange credentials at tenant beta's /oauth2/token — the request is rejected as 401")
     void crossTenantClientRejected() throws Exception {
         // Register a client under alpha-corp
         ClientCreationResult result = clientManagementService.createClient(
@@ -196,6 +203,7 @@ class TenantOAuth2RoutingIntegrationTest {
     }
 
     @Test
+    @DisplayName("client_credentials access token carries tenant + iss claims and an empty roles array")
     void clientCredentialsTokenIncludesTenantAndRolesClaims() throws Exception {
         ClientCreationResult result = clientManagementService.createClient(
             alphaApp.id(), alphaCorpTenant.id(),
@@ -228,6 +236,7 @@ class TenantOAuth2RoutingIntegrationTest {
     }
 
     @Test
+    @DisplayName("Full authorization-code + PKCE flow under /t/{slug}/ yields a token with tenant + iss claims for the end user")
     void authorizationCodePkceFlowProducesTokenWithTenantClaims() throws Exception {
         User alice = userRepository.save(new User(
             null, alphaCorpTenant.id(), "alice",
@@ -328,6 +337,7 @@ class TenantOAuth2RoutingIntegrationTest {
     }
 
     @Test
+    @DisplayName("Each tenant's JWKS endpoint serves only its own signing keys — alpha's token verifies against alpha's JWKS but not beta's")
     void tenantJwksEndpointsServeIsolatedKeys() throws Exception {
         ClientCreationResult result = clientManagementService.createClient(
             alphaApp.id(), alphaCorpTenant.id(),
@@ -375,6 +385,7 @@ class TenantOAuth2RoutingIntegrationTest {
     }
 
     @Test
+    @DisplayName("/t/{slug}/userinfo accepts a Bearer token from the same tenant and returns the user's claims")
     void userinfoEndpointReturnsClaimsForTenantUser() throws Exception {
         User bob = userRepository.save(new User(
             null, alphaCorpTenant.id(), "bob",

--- a/src/test/java/com/stucray/limen/security/JdbcSigningKeyStoreIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/security/JdbcSigningKeyStoreIntegrationTest.java
@@ -7,6 +7,7 @@ import com.stucray.limen.tenant.Tenant;
 import com.stucray.limen.tenant.TenantRepository;
 import com.stucray.limen.tenant.TenantStatus;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -21,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
+@DisplayName("JdbcSigningKeyStore (per-tenant RSA key storage)")
 class JdbcSigningKeyStoreIntegrationTest {
 
     @Autowired SigningKeyStore signingKeyStore;
@@ -37,6 +39,7 @@ class JdbcSigningKeyStoreIntegrationTest {
     }
 
     @Test
+    @DisplayName("Created key round-trips: getActiveSigningKey returns the key whose public JWK matches the stored row")
     void createThenGetReturnsKeyWithMatchingPublicJwk() throws Exception {
         signingKeyStore.createForTenant(tenant.id());
 
@@ -53,6 +56,7 @@ class JdbcSigningKeyStoreIntegrationTest {
     }
 
     @Test
+    @DisplayName("getJwkSet returns only public-key material — never the private exponent")
     void getJwkSetReturnsPublicKeysForTenant() throws Exception {
         signingKeyStore.createForTenant(tenant.id());
 
@@ -63,6 +67,7 @@ class JdbcSigningKeyStoreIntegrationTest {
     }
 
     @Test
+    @DisplayName("Stored private_key_ciphertext bytes contain no PEM, no JWK fields, and no PKCS#8 sequence header")
     void privateKeyCiphertextDoesNotContainPlaintextKeyMaterial() {
         signingKeyStore.createForTenant(tenant.id());
 
@@ -86,6 +91,7 @@ class JdbcSigningKeyStoreIntegrationTest {
     }
 
     @Test
+    @DisplayName("deleteForTenant removes all rows for the tenant (active and rotated)")
     void deleteForTenantRemovesAllRows() {
         signingKeyStore.createForTenant(tenant.id());
         assertThat(rowCount(tenant.id())).isEqualTo(1);
@@ -96,11 +102,13 @@ class JdbcSigningKeyStoreIntegrationTest {
     }
 
     @Test
+    @DisplayName("getActiveSigningKey returns null when no active row exists for the tenant")
     void getActiveSigningKeyReturnsNullWhenNoneExists() {
         assertThat(signingKeyStore.getActiveSigningKey(tenant.id())).isNull();
     }
 
     @Test
+    @DisplayName("Calling createForTenant twice violates the partial-unique index on (tenant_id, status='ACTIVE')")
     void createForTenantTwiceViolatesActiveUniqueConstraint() {
         signingKeyStore.createForTenant(tenant.id());
 

--- a/src/test/java/com/stucray/limen/tenant/TenantProvisioningServiceIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/tenant/TenantProvisioningServiceIntegrationTest.java
@@ -2,6 +2,7 @@ package com.stucray.limen.tenant;
 
 import com.stucray.limen.TestcontainersConfiguration;
 import com.stucray.limen.security.SigningKeyStore;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -16,6 +17,7 @@ import static org.mockito.Mockito.doThrow;
 
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
+@DisplayName("TenantProvisioningService (transactional create + delete)")
 class TenantProvisioningServiceIntegrationTest {
 
     @Autowired TenantProvisioningService service;
@@ -24,6 +26,7 @@ class TenantProvisioningServiceIntegrationTest {
     @MockitoSpyBean SigningKeyStore signingKeyStore;
 
     @Test
+    @DisplayName("createTenant inserts the tenant row AND provisions an active signing key in one transaction")
     void createTenantPersistsTenantAndActiveSigningKey() {
         String slug = "acme-" + System.nanoTime();
 
@@ -43,6 +46,7 @@ class TenantProvisioningServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("createTenant skips signing-key provisioning for the system tenant (no OAuth2 surface)")
     void createTenantSkipsSigningKeyForSystemSlug() {
         tenantRepository.findBySlug("system").ifPresent(t -> tenantRepository.deleteById(t.id()));
 
@@ -58,6 +62,7 @@ class TenantProvisioningServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("Signing-key failure rolls back the tenant insert — no orphaned tenant row")
     void signingKeyFailureRollsBackTenantInsert() {
         doThrow(new IllegalStateException("simulated key store failure"))
             .when(signingKeyStore).createForTenant(anyLong());
@@ -71,6 +76,7 @@ class TenantProvisioningServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("deleteTenant removes the tenant row and cascades to all of its signing keys")
     void deleteTenantCascadesToSigningKeys() {
         String slug = "deleteme-" + System.nanoTime();
         Tenant tenant = service.createTenant(slug, "Delete Me");


### PR DESCRIPTION
## Summary
- Adds class-level and method-level `@DisplayName` to all 43 test files (+368 lines, no production code touched).
- Class names: noun phrases describing the subject under test (no "Test" suffix).
- Method names: present-tense behavioural sentences that name the concrete inputs/outputs the method name elides; `should`/`test` prefixes avoided.
- `@ParameterizedTest`s keep their existing `name = "{0}"` argument and gain a class-level-style `@DisplayName` describing the parameterised behaviour.

The IntelliJ runner and surefire reports now read like a behavioural spec, e.g. _"Tenant user management: list / create / disable / delete / reset-password / grant-owner + change-password flow"_ instead of a camelCase class name.

## Test plan
- [x] \`./mvnw test\` — 287 tests, 0 failures, 0 errors, 0 skipped (55s)
- [x] \`./mvnw test-compile -q\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)