### PR TITLE
Ignore Claude Code runtime + local-settings files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ build/
 .vscode/
 .envrc
 /scripts/install-direnv-hook.sh
+
+### Claude Code ###
+.claude/scheduled_tasks.lock
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
- Adds two narrow rules to \`.gitignore\` so they apply to every contributor on every clone, not just individuals who happen to set them up in their global gitignore.

\`\`\`
.claude/scheduled_tasks.lock
.claude/settings.local.json
\`\`\`

- \`scheduled_tasks.lock\` is a per-session lock file (sessionId, pid, acquiredAt) that Claude Code rewrites every time it starts — committing it would churn on every push.
- \`settings.local.json\` holds per-user permission choices.
- Shared \`.claude/skills/\` content (e.g. \`coverage-report/SKILL.md\`) stays tracked.

## Test plan
- [x] \`git check-ignore -v .claude/scheduled_tasks.lock\` resolves via the repo's \`.gitignore\` (no longer requires the user's global ignore).
- [x] \`git status\` no longer surfaces the lock file as untracked.
- [x] \`.claude/skills/coverage-report/SKILL.md\` remains tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)