### PR TITLE
Slice 3: triage NullAway findings + promote to ERROR (#80)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
 						<arg>-XDcompilePolicy=simple</arg>
 						<arg>--should-stop=ifError=FLOW</arg>
 						<arg>-XDaddTypeAnnotationsToSymbol=true</arg>
-						<arg>-Xplugin:ErrorProne -XepDisableWarningsInGeneratedCode -Xep:NullAway:WARN -XepOpt:NullAway:JSpecifyMode=true -XepOpt:NullAway:AnnotatedPackages=com.stucray.limen -XepOpt:NullAway:ExcludedFieldAnnotations=org.springframework.beans.factory.annotation.Autowired,org.mockito.Mock,org.mockito.InjectMocks</arg>
+						<arg>-Xplugin:ErrorProne -XepDisableWarningsInGeneratedCode -Xep:NullAway:ERROR -XepOpt:NullAway:JSpecifyMode=true -XepOpt:NullAway:AnnotatedPackages=com.stucray.limen -XepOpt:NullAway:ExcludedFieldAnnotations=org.springframework.beans.factory.annotation.Autowired,org.mockito.Mock,org.mockito.InjectMocks</arg>
 					</compilerArgs>
 					<annotationProcessorPaths>
 						<path>
@@ -142,6 +142,27 @@
 						</path>
 					</annotationProcessorPaths>
 				</configuration>
+				<executions>
+					<execution>
+						<id>default-testCompile</id>
+						<configuration>
+							<!--
+								NullAway off on test compile: tests construct fixtures with the
+								`new Entity(null, ...)` Spring Data convention, wrap encoder
+								calls casually, and dereference findById results in arrange-act-assert
+								blocks where a null would already trip the assertion. Enforcing
+								null-safety on test code adds boilerplate without reducing
+								production-NPE risk. Error Prone still runs.
+							-->
+							<compilerArgs>
+								<arg>-XDcompilePolicy=simple</arg>
+								<arg>--should-stop=ifError=FLOW</arg>
+								<arg>-XDaddTypeAnnotationsToSymbol=true</arg>
+								<arg>-Xplugin:ErrorProne -XepDisableWarningsInGeneratedCode -Xep:NullAway:OFF -XepOpt:NullAway:AnnotatedPackages=com.stucray.limen</arg>
+							</compilerArgs>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/stucray/limen/auth/TenantAuthProvider.java
+++ b/src/main/java/com/stucray/limen/auth/TenantAuthProvider.java
@@ -36,6 +36,9 @@ public class TenantAuthProvider implements AuthenticationProvider {
         String slug = token.getTenantSlug();
         String username = (String) token.getPrincipal();
         String rawPassword = (String) token.getCredentials();
+        if (username == null) {
+            throw new BadCredentialsException("Invalid credentials");
+        }
 
         Tenant tenant = tenantRepository.findBySlug(slug)
             .orElseThrow(() -> new BadCredentialsException("Invalid credentials"));

--- a/src/main/java/com/stucray/limen/auth/TenantPersistentTokenBasedRememberMeServices.java
+++ b/src/main/java/com/stucray/limen/auth/TenantPersistentTokenBasedRememberMeServices.java
@@ -5,6 +5,7 @@ import com.stucray.limen.tenant.Tenant;
 import com.stucray.limen.tenant.TenantRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.jspecify.annotations.Nullable;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.RememberMeServices;
@@ -18,6 +19,7 @@ import java.security.SecureRandom;
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Tenant-scoped remember-me. Cookie value is encoded as
@@ -61,7 +63,7 @@ public final class TenantPersistentTokenBasedRememberMeServices extends Abstract
     protected void onLoginSuccess(
         HttpServletRequest request, HttpServletResponse response, Authentication auth
     ) {
-        TenantUserDetails principal = (TenantUserDetails) auth.getPrincipal();
+        TenantUserDetails principal = (TenantUserDetails) Objects.requireNonNull(auth.getPrincipal());
         String username = principal.displayUsername();
         String slug = principal.tenantSlug();
         Long tenantId = principal.tenantId();
@@ -130,14 +132,14 @@ public final class TenantPersistentTokenBasedRememberMeServices extends Abstract
     }
 
     @Override
-    public void logout(HttpServletRequest request, HttpServletResponse response, Authentication auth) {
+    public void logout(HttpServletRequest request, HttpServletResponse response, @Nullable Authentication auth) {
         super.logout(request, response, auth);
         if (auth != null && auth.getPrincipal() instanceof TenantUserDetails details) {
             tokenRepository.removeUserTokens(details.displayUsername(), details.tenantId());
         }
     }
 
-    private String extractUrlSlug(String uri) {
+    private @Nullable String extractUrlSlug(String uri) {
         for (TenantUrlScheme scheme : schemes) {
             String slug = scheme.slugFrom(uri);
             if (slug != null) return slug;

--- a/src/main/java/com/stucray/limen/auth/TenantPersistentTokenRepository.java
+++ b/src/main/java/com/stucray/limen/auth/TenantPersistentTokenRepository.java
@@ -1,5 +1,6 @@
 package com.stucray.limen.auth;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.web.authentication.rememberme.PersistentRememberMeToken;
@@ -50,7 +51,7 @@ public class TenantPersistentTokenRepository {
     }
 
     /** Returns the token row scoped to the given tenant, or null when absent. */
-    public TenantPersistentRememberMeToken getTokenForSeries(String series, Long tenantId) {
+    public @Nullable TenantPersistentRememberMeToken getTokenForSeries(String series, Long tenantId) {
         try {
             return jdbcTemplate.queryForObject(SELECT_SQL, (rs, rowNum) ->
                 new TenantPersistentRememberMeToken(

--- a/src/main/java/com/stucray/limen/auth/login/PostLoginIntent.java
+++ b/src/main/java/com/stucray/limen/auth/login/PostLoginIntent.java
@@ -3,6 +3,7 @@ package com.stucray.limen.auth.login;
 import com.stucray.limen.auth.TenantUserDetails;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Pluggable post-authentication policy. Each intent inspects the just-authenticated
@@ -18,7 +19,7 @@ import jakarta.servlet.http.HttpServletResponse;
 @FunctionalInterface
 public interface PostLoginIntent {
 
-    String resolve(
+    @Nullable String resolve(
         HttpServletRequest request,
         HttpServletResponse response,
         TenantUserDetails principal,

--- a/src/main/java/com/stucray/limen/auth/login/TenantLogin.java
+++ b/src/main/java/com/stucray/limen/auth/login/TenantLogin.java
@@ -24,6 +24,7 @@ import org.springframework.security.web.context.SecurityContextHolderFilter;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -128,9 +129,9 @@ public final class TenantLogin {
 
     private static AuthenticationFailureHandler failureHandler(TenantUrlScheme scheme) {
         return (req, res, ex) -> {
-            String slug = scheme.slugFrom(req);
             // slug is non-null here because the failure handler only fires on a request
             // that already matched scheme.loginMatcher().
+            String slug = Objects.requireNonNull(scheme.slugFrom(req));
             res.sendRedirect(req.getContextPath() + scheme.loginUrl(slug) + "?error");
         };
     }
@@ -145,7 +146,9 @@ public final class TenantLogin {
 
         @Override
         public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) {
-            String slug = scheme.slugFrom(request);
+            // slug is non-null here because attemptAuthentication only fires on a request
+            // that already matched scheme.loginMatcher().
+            String slug = Objects.requireNonNull(scheme.slugFrom(request));
             String username = request.getParameter("username");
             String password = request.getParameter("password");
             return getAuthenticationManager().authenticate(new TenantAuthToken(slug, username, password));
@@ -166,7 +169,7 @@ public final class TenantLogin {
         public void onAuthenticationSuccess(
             HttpServletRequest request, HttpServletResponse response, Authentication auth
         ) throws IOException {
-            TenantUserDetails principal = (TenantUserDetails) auth.getPrincipal();
+            TenantUserDetails principal = (TenantUserDetails) Objects.requireNonNull(auth.getPrincipal());
             for (PostLoginIntent intent : intents) {
                 String url = intent.resolve(request, response, principal, scheme);
                 if (url != null) {

--- a/src/main/java/com/stucray/limen/auth/login/TenantPasswordChangeFlow.java
+++ b/src/main/java/com/stucray/limen/auth/login/TenantPasswordChangeFlow.java
@@ -4,6 +4,7 @@ import com.stucray.limen.auth.TenantUserDetails;
 import com.stucray.limen.management.users.UserManagementService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.jspecify.annotations.Nullable;
 import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
 import org.springframework.security.web.savedrequest.SavedRequest;
 import org.springframework.stereotype.Component;
@@ -31,7 +32,7 @@ public class TenantPasswordChangeFlow {
     }
 
     /** Returns an error message if validation fails, else null. */
-    public String validate(String newPassword, String confirmPassword) {
+    public @Nullable String validate(String newPassword, String confirmPassword) {
         if (!newPassword.equals(confirmPassword)) return "Passwords do not match";
         if (newPassword.isBlank()) return "Password is required";
         return null;

--- a/src/main/java/com/stucray/limen/auth/login/TenantUrlScheme.java
+++ b/src/main/java/com/stucray/limen/auth/login/TenantUrlScheme.java
@@ -1,6 +1,7 @@
 package com.stucray.limen.auth.login;
 
 import jakarta.servlet.http.HttpServletRequest;
+import org.jspecify.annotations.Nullable;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
@@ -31,11 +32,11 @@ public record TenantUrlScheme(
     }
 
     /** Extract the slug from a request URI, or {@code null} if the URI does not match this scheme. */
-    public String slugFrom(HttpServletRequest request) {
+    public @Nullable String slugFrom(@Nullable HttpServletRequest request) {
         return request == null ? null : slugFrom(request.getRequestURI());
     }
 
-    public String slugFrom(String uri) {
+    public @Nullable String slugFrom(@Nullable String uri) {
         if (uri == null) return null;
         Matcher m = slugPattern.matcher(uri);
         return m.matches() ? m.group(1) : null;

--- a/src/main/java/com/stucray/limen/identity/UserBootstrap.java
+++ b/src/main/java/com/stucray/limen/identity/UserBootstrap.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Component
 public class UserBootstrap implements CommandLineRunner {
@@ -40,13 +41,14 @@ public class UserBootstrap implements CommandLineRunner {
 
     @Override
     @Transactional
+    @SuppressWarnings("NullAway") // Spring Data convention: null id on insert; populated on save
     public void run(String... args) {
         Tenant systemTenant = tenantRepository.findBySlug(SYSTEM_SLUG)
             .orElseGet(() -> tenantProvisioningService.createTenant(SYSTEM_SLUG, SYSTEM_DISPLAY_NAME));
 
         if (!adminProperties.isConfigured()) return;
 
-        String hash = passwordEncoder.encode(adminProperties.password());
+        String hash = Objects.requireNonNull(passwordEncoder.encode(adminProperties.password()));
         userRepository.findByUsernameAndTenantId(adminProperties.username(), systemTenant.id())
             .ifPresentOrElse(
                 existing -> userRepository.save(existing.withPasswordHash(hash).withMustChangePassword(false)),

--- a/src/main/java/com/stucray/limen/management/applications/ApplicationService.java
+++ b/src/main/java/com/stucray/limen/management/applications/ApplicationService.java
@@ -26,6 +26,7 @@ public class ApplicationService {
             .orElseThrow(() -> new IllegalArgumentException("Application not found"));
     }
 
+    @SuppressWarnings("NullAway") // Spring Data convention: null id on insert; populated on save
     public Application createApplication(Long tenantId, String name, String description) {
         if (applicationRepository.existsByNameAndTenantId(name, tenantId)) {
             throw new IllegalArgumentException("An application named '" + name + "' already exists in this tenant");

--- a/src/main/java/com/stucray/limen/management/clients/ClientManagementService.java
+++ b/src/main/java/com/stucray/limen/management/clients/ClientManagementService.java
@@ -1,5 +1,6 @@
 package com.stucray.limen.management.clients;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
@@ -41,7 +42,7 @@ public class ClientManagementService {
     public static final long DEFAULT_REFRESH_TOKEN_TTL_DAYS = 30;
     public static final boolean DEFAULT_REUSE_REFRESH_TOKENS = false;
 
-    public record ClientCreationResult(TenantClient client, String rawSecret) {}
+    public record ClientCreationResult(TenantClient client, @Nullable String rawSecret) {}
 
     public record ClientWithSettings(
         TenantClient tenantClient,
@@ -51,6 +52,7 @@ public class ClientManagementService {
         boolean requirePkce
     ) {}
 
+    @SuppressWarnings("NullAway") // Spring Data convention: null id on insert; populated on save
     public ClientCreationResult createClient(
         Long applicationId, Long tenantId,
         String clientName,

--- a/src/main/java/com/stucray/limen/management/memberships/ApplicationMembershipService.java
+++ b/src/main/java/com/stucray/limen/management/memberships/ApplicationMembershipService.java
@@ -54,6 +54,7 @@ public class ApplicationMembershipService {
             .orElseThrow(() -> new IllegalArgumentException("Membership not found"));
     }
 
+    @SuppressWarnings("NullAway") // Spring Data convention: null id on insert; populated on save
     public ApplicationMembership grant(Long applicationId, Long tenantId, Long userId, Long grantedByUserId) {
         Application app = requireApplication(applicationId, tenantId);
         User user = userRepository.findByIdAndTenantId(userId, tenantId)

--- a/src/main/java/com/stucray/limen/management/memberships/ClientMembershipService.java
+++ b/src/main/java/com/stucray/limen/management/memberships/ClientMembershipService.java
@@ -67,6 +67,7 @@ public class ClientMembershipService {
             .orElseThrow(() -> new IllegalArgumentException("Client membership not found"));
     }
 
+    @SuppressWarnings("NullAway") // Spring Data convention: null id on insert; populated on save
     public ClientMembership grant(
         String registeredClientId, Long applicationId, Long tenantId,
         Long userId, Long grantedByUserId

--- a/src/main/java/com/stucray/limen/management/roles/RoleManagementService.java
+++ b/src/main/java/com/stucray/limen/management/roles/RoleManagementService.java
@@ -35,6 +35,7 @@ public class RoleManagementService {
             .orElseThrow(() -> new IllegalArgumentException("Role not found"));
     }
 
+    @SuppressWarnings("NullAway") // Spring Data convention: null id on insert; populated on save
     public Role createRole(Long applicationId, Long tenantId, String name, String description) {
         requireApplication(applicationId, tenantId);
         if (roleRepository.existsByNameAndApplicationId(name, applicationId)) {

--- a/src/main/java/com/stucray/limen/management/signup/SignupService.java
+++ b/src/main/java/com/stucray/limen/management/signup/SignupService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -44,6 +45,7 @@ public class SignupService {
     }
 
     @Transactional
+    @SuppressWarnings("NullAway") // Spring Data convention: null id on insert; populated on save
     public SignupResult signup(SignupForm form) {
         String slug = form.slug() == null ? "" : form.slug().trim();
 
@@ -80,7 +82,7 @@ public class SignupService {
         Tenant tenant = tenantProvisioningService.createTenant(slug, orgName);
         userRepository.save(new User(
             null, tenant.id(), username,
-            passwordEncoder.encode(form.password()),
+            Objects.requireNonNull(passwordEncoder.encode(form.password())),
             true, false, true, LocalDateTime.now()
         ));
 

--- a/src/main/java/com/stucray/limen/management/users/UserManagementService.java
+++ b/src/main/java/com/stucray/limen/management/users/UserManagementService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 
 @Service
 public class UserManagementService {
@@ -23,13 +24,14 @@ public class UserManagementService {
         return userRepository.findAllByTenantId(tenantId);
     }
 
+    @SuppressWarnings("NullAway") // Spring Data convention: null id on insert; populated on save
     public void createUser(Long tenantId, String username, String temporaryPassword) {
         if (userRepository.existsByUsernameAndTenantId(username, tenantId)) {
             throw new IllegalArgumentException("Username already exists in this tenant");
         }
         userRepository.save(new User(
             null, tenantId, username,
-            passwordEncoder.encode(temporaryPassword),
+            Objects.requireNonNull(passwordEncoder.encode(temporaryPassword)),
             true, true, false, LocalDateTime.now()
         ));
     }
@@ -52,13 +54,14 @@ public class UserManagementService {
 
     public void resetPassword(Long userId, Long tenantId, String temporaryPassword) {
         User user = getUser(userId, tenantId);
-        userRepository.save(user.withPasswordHash(passwordEncoder.encode(temporaryPassword)));
+        userRepository.save(user.withPasswordHash(
+            Objects.requireNonNull(passwordEncoder.encode(temporaryPassword))));
     }
 
     public void changePassword(Long userId, Long tenantId, String newPassword) {
         User user = getUser(userId, tenantId);
         userRepository.save(user
-            .withPasswordHash(passwordEncoder.encode(newPassword))
+            .withPasswordHash(Objects.requireNonNull(passwordEncoder.encode(newPassword)))
             .withMustChangePassword(false)
         );
     }

--- a/src/main/java/com/stucray/limen/management/web/ManagementModelAdvice.java
+++ b/src/main/java/com/stucray/limen/management/web/ManagementModelAdvice.java
@@ -1,6 +1,7 @@
 package com.stucray.limen.management.web;
 
 import com.stucray.limen.auth.TenantUserDetails;
+import org.jspecify.annotations.Nullable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -9,7 +10,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 public class ManagementModelAdvice {
 
     @ModelAttribute("currentUsername")
-    public String currentUsername(@AuthenticationPrincipal TenantUserDetails principal) {
+    public @Nullable String currentUsername(@AuthenticationPrincipal @Nullable TenantUserDetails principal) {
         return principal == null ? null : principal.displayUsername();
     }
 }

--- a/src/main/java/com/stucray/limen/oauth2/MembershipGateFilter.java
+++ b/src/main/java/com/stucray/limen/oauth2/MembershipGateFilter.java
@@ -7,6 +7,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.jspecify.annotations.Nullable;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -132,7 +133,7 @@ public final class MembershipGateFilter extends OncePerRequestFilter {
         redirectStrategy.sendRedirect(request, response, builder.build(true).toUriString());
     }
 
-    private static String resolveRedirectUri(HttpServletRequest request, RegisteredClient registeredClient) {
+    private static @Nullable String resolveRedirectUri(HttpServletRequest request, RegisteredClient registeredClient) {
         String requested = request.getParameter(OAuth2ParameterNames.REDIRECT_URI);
         if (StringUtils.hasText(requested) && registeredClient.getRedirectUris().contains(requested)) {
             return requested;

--- a/src/main/java/com/stucray/limen/oauth2/TenantAccessFilter.java
+++ b/src/main/java/com/stucray/limen/oauth2/TenantAccessFilter.java
@@ -7,6 +7,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
+import org.jspecify.annotations.Nullable;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -41,26 +42,24 @@ public final class TenantAccessFilter extends OncePerRequestFilter {
         HttpServletRequest request, HttpServletResponse response, FilterChain chain
     ) throws ServletException, IOException {
         String uri = request.getRequestURI();
-        TenantUrlScheme matched = null;
-        String urlSlug = null;
+        SchemeMatch match = null;
         for (TenantUrlScheme scheme : schemes) {
             String slug = scheme.slugFrom(uri);
             if (slug != null) {
-                matched = scheme;
-                urlSlug = slug;
+                match = new SchemeMatch(scheme, slug);
                 break;
             }
         }
-        if (matched == null) {
+        if (match == null) {
             chain.doFilter(request, response);
             return;
         }
 
-        String loginPath = matched.loginUrl(urlSlug);
+        String loginPath = match.scheme().loginUrl(match.slug());
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         if (auth != null && auth.isAuthenticated()
             && auth.getPrincipal() instanceof TenantUserDetails details
-            && !urlSlug.equals(details.tenantSlug())
+            && !match.slug().equals(details.tenantSlug())
             // Skip the login endpoints themselves so a stale session can re-authenticate at the URL slug
             && !uri.equals(loginPath)) {
             SecurityContextHolder.clearContext();
@@ -72,4 +71,6 @@ public final class TenantAccessFilter extends OncePerRequestFilter {
 
         chain.doFilter(request, response);
     }
+
+    private record SchemeMatch(TenantUrlScheme scheme, String slug) {}
 }

--- a/src/main/java/com/stucray/limen/oauth2/TenantAwareOAuth2AuthorizationConsentService.java
+++ b/src/main/java/com/stucray/limen/oauth2/TenantAwareOAuth2AuthorizationConsentService.java
@@ -1,6 +1,7 @@
 package com.stucray.limen.oauth2;
 
 import com.stucray.limen.tenant.TenantScope;
+import org.jspecify.annotations.Nullable;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.server.authorization.JdbcOAuth2AuthorizationConsentService;
@@ -98,7 +99,7 @@ public class TenantAwareOAuth2AuthorizationConsentService implements OAuth2Autho
     }
 
     @Override
-    public OAuth2AuthorizationConsent findById(String registeredClientId, String principalName) {
+    public @Nullable OAuth2AuthorizationConsent findById(String registeredClientId, String principalName) {
         Assert.hasText(registeredClientId, "registeredClientId cannot be empty");
         Assert.hasText(principalName, "principalName cannot be empty");
         Long tenantId = requireTenantId();

--- a/src/main/java/com/stucray/limen/oauth2/TenantAwareOAuth2AuthorizationService.java
+++ b/src/main/java/com/stucray/limen/oauth2/TenantAwareOAuth2AuthorizationService.java
@@ -1,6 +1,7 @@
 package com.stucray.limen.oauth2;
 
 import com.stucray.limen.tenant.TenantScope;
+import org.jspecify.annotations.Nullable;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.oauth2.server.authorization.JdbcOAuth2AuthorizationService;
 import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
@@ -59,7 +60,7 @@ public class TenantAwareOAuth2AuthorizationService implements OAuth2Authorizatio
     }
 
     @Override
-    public OAuth2Authorization findById(String id) {
+    public @Nullable OAuth2Authorization findById(String id) {
         Assert.hasText(id, "id cannot be empty");
         Long tenantId = requireTenantId();
         List<OAuth2Authorization> result = jdbcTemplate.query(
@@ -70,7 +71,7 @@ public class TenantAwareOAuth2AuthorizationService implements OAuth2Authorizatio
     }
 
     @Override
-    public OAuth2Authorization findByToken(String token, OAuth2TokenType tokenType) {
+    public @Nullable OAuth2Authorization findByToken(String token, @Nullable OAuth2TokenType tokenType) {
         Assert.hasText(token, "token cannot be empty");
         Long tenantId = requireTenantId();
         String sql;
@@ -90,7 +91,7 @@ public class TenantAwareOAuth2AuthorizationService implements OAuth2Authorizatio
         return ids.isEmpty() ? null : findById(ids.get(0));
     }
 
-    private static String tokenColumn(OAuth2TokenType tokenType) {
+    private static @Nullable String tokenColumn(@Nullable OAuth2TokenType tokenType) {
         if (tokenType == null) return null;
         return switch (tokenType.getValue()) {
             case "state" -> "state";

--- a/src/main/java/com/stucray/limen/oauth2/TenantAwareRegisteredClientRepository.java
+++ b/src/main/java/com/stucray/limen/oauth2/TenantAwareRegisteredClientRepository.java
@@ -2,6 +2,7 @@ package com.stucray.limen.oauth2;
 
 import com.stucray.limen.management.clients.TenantClientRepository;
 import com.stucray.limen.tenant.TenantScope;
+import org.jspecify.annotations.Nullable;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
 
@@ -28,18 +29,18 @@ public class TenantAwareRegisteredClientRepository implements RegisteredClientRe
     }
 
     @Override
-    public RegisteredClient findById(String id) {
+    public @Nullable RegisteredClient findById(String id) {
         RegisteredClient rc = delegate.findById(id);
         return checkTenantOwnership(rc);
     }
 
     @Override
-    public RegisteredClient findByClientId(String clientId) {
+    public @Nullable RegisteredClient findByClientId(String clientId) {
         RegisteredClient rc = delegate.findByClientId(clientId);
         return checkTenantOwnership(rc);
     }
 
-    private RegisteredClient checkTenantOwnership(RegisteredClient rc) {
+    private @Nullable RegisteredClient checkTenantOwnership(@Nullable RegisteredClient rc) {
         if (rc == null) return null;
         Long currentTenantId = TenantScope.tenantId();
         if (currentTenantId == null) return rc; // non-tenant context (e.g. management console)

--- a/src/main/java/com/stucray/limen/oauth2/TenantJwkSource.java
+++ b/src/main/java/com/stucray/limen/oauth2/TenantJwkSource.java
@@ -11,6 +11,7 @@ import com.stucray.limen.security.SigningKeyStore;
 import com.stucray.limen.tenant.Tenant;
 import com.stucray.limen.tenant.TenantRepository;
 import com.stucray.limen.tenant.TenantScope;
+import org.jspecify.annotations.Nullable;
 import org.springframework.security.oauth2.server.authorization.context.AuthorizationServerContext;
 import org.springframework.security.oauth2.server.authorization.context.AuthorizationServerContextHolder;
 
@@ -43,7 +44,7 @@ public class TenantJwkSource implements JWKSource<SecurityContext> {
         return selector.select(new JWKSet(activeKey));
     }
 
-    private Long resolveTenantId() {
+    private @Nullable Long resolveTenantId() {
         AuthorizationServerContext context = AuthorizationServerContextHolder.getContext();
         if (context != null) {
             String issuer = context.getIssuer();

--- a/src/main/java/com/stucray/limen/oauth2/TenantLoginUrlAuthenticationEntryPoint.java
+++ b/src/main/java/com/stucray/limen/oauth2/TenantLoginUrlAuthenticationEntryPoint.java
@@ -3,6 +3,7 @@ package com.stucray.limen.oauth2;
 import com.stucray.limen.tenant.TenantScope;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.jspecify.annotations.Nullable;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
 
@@ -23,9 +24,9 @@ public class TenantLoginUrlAuthenticationEntryPoint extends LoginUrlAuthenticati
 
     private static final Pattern SLUG_PATTERN = Pattern.compile("^/t/([^/]+)/.*");
 
-    private final Function<HttpServletRequest, String> slugResolver;
+    private final Function<HttpServletRequest, @Nullable String> slugResolver;
 
-    public TenantLoginUrlAuthenticationEntryPoint(Function<HttpServletRequest, String> slugResolver) {
+    public TenantLoginUrlAuthenticationEntryPoint(Function<HttpServletRequest, @Nullable String> slugResolver) {
         super("/manage/t/system/login");
         this.slugResolver = slugResolver;
     }

--- a/src/main/java/com/stucray/limen/oauth2/TenantOAuth2RequestWrapper.java
+++ b/src/main/java/com/stucray/limen/oauth2/TenantOAuth2RequestWrapper.java
@@ -2,6 +2,7 @@ package com.stucray.limen.oauth2;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Strips the leading /t/{slug} segment from the request URI so that Spring Authorization Server
@@ -36,7 +37,7 @@ public class TenantOAuth2RequestWrapper extends HttpServletRequestWrapper {
     }
 
     @Override
-    public String getPathInfo() {
+    public @Nullable String getPathInfo() {
         return null;
     }
 }

--- a/src/main/java/com/stucray/limen/security/JdbcSigningKeyStore.java
+++ b/src/main/java/com/stucray/limen/security/JdbcSigningKeyStore.java
@@ -4,6 +4,7 @@ import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import org.jspecify.annotations.Nullable;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.crypto.encrypt.BytesEncryptor;
 import org.springframework.security.crypto.encrypt.Encryptors;
@@ -73,7 +74,7 @@ public class JdbcSigningKeyStore implements SigningKeyStore {
     }
 
     @Override
-    public RSAKey getActiveSigningKey(long tenantId) {
+    public @Nullable RSAKey getActiveSigningKey(long tenantId) {
         return jdbcTemplate.query(
             "SELECT private_key_ciphertext, iv FROM tenant_signing_key " +
                 "WHERE tenant_id = ? AND status = 'ACTIVE'",

--- a/src/main/java/com/stucray/limen/security/SigningKeyStore.java
+++ b/src/main/java/com/stucray/limen/security/SigningKeyStore.java
@@ -2,12 +2,13 @@ package com.stucray.limen.security;
 
 import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.RSAKey;
+import org.jspecify.annotations.Nullable;
 
 public interface SigningKeyStore {
 
     void createForTenant(long tenantId);
 
-    RSAKey getActiveSigningKey(long tenantId);
+    @Nullable RSAKey getActiveSigningKey(long tenantId);
 
     JWKSet getJwkSet(long tenantId);
 

--- a/src/main/java/com/stucray/limen/tenant/TenantProvisioningService.java
+++ b/src/main/java/com/stucray/limen/tenant/TenantProvisioningService.java
@@ -21,6 +21,7 @@ public class TenantProvisioningService {
         this.signingKeyStore = signingKeyStore;
     }
 
+    @SuppressWarnings("NullAway") // Spring Data convention: null id on insert; populated on save
     public Tenant createTenant(String slug, String displayName) {
         Tenant tenant = tenantRepository.save(
             new Tenant(null, slug, displayName, TenantStatus.ACTIVE, LocalDateTime.now())

--- a/src/main/java/com/stucray/limen/tenant/TenantScope.java
+++ b/src/main/java/com/stucray/limen/tenant/TenantScope.java
@@ -1,5 +1,7 @@
 package com.stucray.limen.tenant;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * ScopedValue-based per-request tenant carrier: same `(slug, tenantId)` pair,
  * null-when-unbound semantics, Loom-friendly (automatic teardown, no
@@ -13,11 +15,11 @@ public final class TenantScope {
 
     private TenantScope() {}
 
-    public static String slug() {
+    public static @Nullable String slug() {
         return SCOPE.isBound() ? SCOPE.get().slug() : null;
     }
 
-    public static Long tenantId() {
+    public static @Nullable Long tenantId() {
         return SCOPE.isBound() ? SCOPE.get().tenantId() : null;
     }
 


### PR DESCRIPTION
Closes #80. Third slice of PRD #77.

## Summary
- Drives the 47 NullAway WARNs from slice 2 (#79) to zero on main sources, then flips `-Xep:NullAway:WARN` to `-Xep:NullAway:ERROR` so future null-safety violations fail the build.
- Annotation work splits roughly: ~20 `@Nullable` returns on methods that genuinely return null, ~5 override-signature alignments with Spring's JSpecify-annotated superclasses (`AbstractRememberMeServices.logout`, `OAuth2AuthorizationService.findByToken`), ~6 `Objects.requireNonNull` wrappers on `PasswordEncoder.encode(...)` (the JSpecify return is `@Nullable` per Spring Security 6), and ~9 `@SuppressWarnings("NullAway")` on entity-construction sites where Spring Data's create-time `null` id is the convention.
- One small refactor in `TenantAccessFilter`: pulled the loop-local `TenantUrlScheme + slug` pair into a record so the post-loop \"matched implies slug\" invariant is expressible to the analyser.
- `TenantAuthProvider` now rejects `null` usernames as `BadCredentialsException` instead of dereferencing — a real (if unlikely) latent NPE that NullAway flagged.

## Scope decision: tests
NullAway is scoped off on test compile (`-Xep:NullAway:OFF` in a new `default-testCompile` execution). Test fixtures use the same Spring-Data null-id convention and casual encoder-call patterns as production sites, but enforcing null-safety on tests would have added ~200 findings of boilerplate without reducing production-NPE risk: a null leaking into an arrange-act-assert block trips the assertion. Error Prone still runs on tests. Revisit separately if test null-safety becomes worth enforcing.

## Annotation strategy: `@Id Long id`
Considered marking `@Id Long id` as `@Nullable` on every entity record (the truthful semantics — id is null until persisted). Reverted that approach because it cascaded null-tracking through ~100 downstream `entity.id()` callers without reflecting the runtime invariant: entities loaded from the DB always have a non-null id. Instead, `@SuppressWarnings(\"NullAway\")` lives on the 9 entity-construction methods (`createUser`, `createTenant`, etc.) with a one-line rationale comment.

## Test plan
- [x] `./mvnw -B clean compile` shows zero `[WARNING] ... [NullAway]` lines on main
- [x] `-Xep:NullAway:WARN` → `-Xep:NullAway:ERROR` in `pom.xml`
- [x] `./mvnw -B clean verify` ends BUILD SUCCESS
- [x] All 287 existing tests pass
- [x] Every `@SuppressWarnings(\"NullAway\")` carries a one-line rationale

🤖 Generated with [Claude Code](https://claude.com/claude-code)