### PR TITLE
Slice 4: PMD complexity report (report-only) + JXR (closes #81)

### DIFF
--- a/pmd-ruleset.xml
+++ b/pmd-ruleset.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<ruleset name="Limen complexity ruleset"
+    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+
+    <description>
+        Complexity-only ruleset. PMD is configured as a reporting tool, not
+        a gate — findings are surfaced in target/pmd.html and stdout, but the
+        build does not fail. Add or remove rules as understanding of the
+        codebase's natural numbers grows.
+    </description>
+
+    <!-- "Method does too much" signals -->
+    <rule ref="category/java/design.xml/CognitiveComplexity"/>
+    <rule ref="category/java/design.xml/CyclomaticComplexity"/>
+    <rule ref="category/java/design.xml/NPathComplexity"/>
+    <rule ref="category/java/design.xml/NcssCount"/>
+    <rule ref="category/java/design.xml/ExcessiveParameterList"/>
+
+    <!-- "Class does too much" signals -->
+    <rule ref="category/java/design.xml/GodClass"/>
+    <rule ref="category/java/design.xml/TooManyFields"/>
+    <rule ref="category/java/design.xml/TooManyMethods"/>
+    <rule ref="category/java/design.xml/ExcessivePublicCount"/>
+</ruleset>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,13 @@
 		<maven.compiler.target>26</maven.compiler.target>
 		<error-prone.version>2.49.0</error-prone.version>
 		<nullaway.version>0.13.4</nullaway.version>
+		<maven-jxr-plugin.version>3.6.0</maven-jxr-plugin.version>
+		<maven-pmd-plugin.version>3.28.0</maven-pmd-plugin.version>
+		<!--
+			maven-pmd-plugin 3.28.0 bundles PMD 7.17, which doesn't support Java 26
+			classfiles (major version 70). Override to 7.21.0+ via plugin dependencies.
+		-->
+		<pmd.version>7.24.0</pmd.version>
 	</properties>
 
 	<dependencies>
@@ -192,6 +199,66 @@
 						</goals>
 					</execution>
 				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jxr-plugin</artifactId>
+				<version>${maven-jxr-plugin.version}</version>
+				<executions>
+					<execution>
+						<id>jxr-source-xref</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>jxr</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-pmd-plugin</artifactId>
+				<version>${maven-pmd-plugin.version}</version>
+				<configuration>
+					<rulesets>
+						<ruleset>${project.basedir}/pmd-ruleset.xml</ruleset>
+					</rulesets>
+					<format>html</format>
+					<linkXRef>true</linkXRef>
+					<printFailingErrors>true</printFailingErrors>
+					<skipPmdError>true</skipPmdError>
+					<includeTests>false</includeTests>
+				</configuration>
+				<executions>
+					<execution>
+						<id>pmd-report</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>pmd</goal>
+						</goals>
+					</execution>
+				</executions>
+				<dependencies>
+					<dependency>
+						<groupId>net.sourceforge.pmd</groupId>
+						<artifactId>pmd-core</artifactId>
+						<version>${pmd.version}</version>
+					</dependency>
+					<dependency>
+						<groupId>net.sourceforge.pmd</groupId>
+						<artifactId>pmd-java</artifactId>
+						<version>${pmd.version}</version>
+					</dependency>
+					<dependency>
+						<groupId>net.sourceforge.pmd</groupId>
+						<artifactId>pmd-javascript</artifactId>
+						<version>${pmd.version}</version>
+					</dependency>
+					<dependency>
+						<groupId>net.sourceforge.pmd</groupId>
+						<artifactId>pmd-jsp</artifactId>
+						<version>${pmd.version}</version>
+					</dependency>
+				</dependencies>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
## Summary

- Adds `maven-jxr-plugin` (3.6.0) + `maven-pmd-plugin` (3.28.0) bound to `verify`. PMD runs `pmd:pmd` (report-only, never fails the build); JXR produces the clickable source xref.
- Custom `pmd-ruleset.xml` at repo root — complexity-only: cognitive / cyclomatic / NPath / NCSS / parameter-list, plus class-level GodClass / TooManyFields / TooManyMethods / ExcessivePublicCount. Test sources excluded.
- Bumps the bundled PMD via plugin `<dependencies>` from 7.17 → 7.24.0 so Java 26 classfiles parse.

## Findings (six on main source, default thresholds)

| File | Rule | Detail |
|---|---|---|
| `TenantPersistentTokenBasedRememberMeServices.processAutoLoginCookie` | CyclomaticComplexity | 16 |
| `ClientManagementController.createClient` | ExcessiveParameterList | 14 params |
| `ClientManagementService.createClient` | ExcessiveParameterList | 12 params |
| `SignupService.signup` | CyclomaticComplexity | 14 |
| `UserManagementController` | TooManyMethods | — |
| `TenantAccessFilter.doFilterInternal` | CyclomaticComplexity | 10 |

Build still exits 0 — these are visibility, not gates. Triage / threshold-tuning is future work, not part of #77.

## Plan corrections worth folding back

These differ from the master plan / PRD #77 wording — slice 5 (#82) needs the corrected paths in its CI artifact-upload step.

1. **PMD 7.17 doesn't support Java 26 classfiles** (major version 70). Symptom on first run: `IllegalArgumentException: Unsupported class file major version 70` followed by a `StackOverflowError` in `TypeOps.isSubClassOfNoInterface`. Fix: pin `pmd.version=7.24.0` and override `pmd-core` / `pmd-java` / `pmd-javascript` / `pmd-jsp` via `<dependencies>` on the plugin block. (Java 26 support landed in PMD 7.21.)
2. **`<linkXref>` is the wrong element name** — the actual parameter is `<linkXRef>` (capital R). Maven warned `Parameter 'linkXref' is unknown for plugin 'maven-pmd-plugin:3.28.0:pmd (pmd-report)'` and silently ignored it. Default is already `true` so this was cosmetic, but corrected for clarity.
3. **Output paths in maven-pmd-plugin 3.28.0 land under `target/reports/`, not `target/`**. Actual paths:
   - `target/pmd.xml`         (root, default-named)
   - `target/reports/pmd.html` (HTML format)
   - `target/reports/xref/`    (JXR xref tree)

   Slice 5 (#82) CI artifact-upload paths must be:
   ```yaml
   path: |
     target/pmd.html
     target/pmd.xml
     target/reports/pmd.html
     target/reports/xref
   ```
   (or just `target/reports` and `target/pmd.xml`).

## Test plan

- [x] `./mvnw -B clean verify` → 287/287 tests pass; build exits 0
- [x] `target/pmd.xml` exists, contains 6 violations
- [x] `target/reports/pmd.html` exists and renders
- [x] `target/reports/xref/` populated with HTML for every `.java` file
- [x] PMD logs `PMD version: 7.24.0`
- [ ] Reviewer opens `target/reports/pmd.html` locally and confirms it links into the xref tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)