### PR TITLE
Slice 5: first GitHub Actions CI workflow (closes #82)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: build, test, static analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      LIMEN_SECURITY_KEK: ${{ secrets.LIMEN_SECURITY_KEK_TEST }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 26 (Temurin)
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '26'
+          cache: maven
+
+      - name: Verify (compile + Error Prone + NullAway + tests + JaCoCo + PMD report)
+        run: ./mvnw -B -ntp verify
+
+      - name: Upload PMD complexity report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: pmd-complexity-report
+          path: |
+            target/pmd.xml
+            target/reports/pmd.html
+            target/reports/xref
+          if-no-files-found: ignore
+          retention-days: 30
+
+      - name: Upload JaCoCo report on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: jacoco-report
+          path: target/site/jacoco
+          if-no-files-found: ignore
+          retention-days: 14


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` — first CI for the project.
- Runs `./mvnw -B -ntp verify` on push to `main` and PRs to `main`, exercising Error Prone + NullAway + PMD + 287 tests + JaCoCo (slices 1–4).
- Uploads PMD complexity report as `pmd-complexity-report` artifact on every run (30 days). Uploads JaCoCo HTML only on failure (14 days).

## Notes vs. PRD #77

- **PMD artifact paths** match the actual maven-pmd-plugin 3.28.0 + JXR 3.6.0 defaults, not the original PRD wording (which said `target/pmd.html` + `target/site/xref/`):
  - `target/pmd.xml` (root)
  - `target/reports/pmd.html`
  - `target/reports/xref`
- **`actions/upload-artifact@v7`** — bumped from `v5` in the master plan; v7 is the latest as of 2026-05-01.
- **`LIMEN_SECURITY_KEK_TEST`** secret confirmed set on the repo (created 2026-05-01 09:30 UTC).

## Test plan

- [ ] Workflow runs and goes green on this PR before merge
- [ ] `pmd-complexity-report` artifact appears on the run summary and is downloadable
- [ ] `jacoco-report` artifact does **not** appear (it should only show on failure)
- [ ] After merge, the next push to `main` triggers a green run

🤖 Generated with [Claude Code](https://claude.com/claude-code)