### PR TITLE
Block git commit/push on main via PreToolUse hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.command // empty' | { read -r cmd; blocked=false; case \"$cmd\" in *\"git commit\"*|*\"git push\"*) blocked=true;; esac; case \"$cmd\" in *\"--dry-run\"*) blocked=false;; esac; if $blocked; then branch=$(git -C /Users/scray/dev/projects/limen rev-parse --abbrev-ref HEAD 2>/dev/null); if [ \"$branch\" = \"main\" ]; then echo \"Refusing to git commit/push on main — create a feature branch first: git checkout -b <name>\" >&2; exit 2; fi; fi; }"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a project-scoped Claude Code `PreToolUse` Bash hook in `.claude/settings.json` that blocks `git commit` / `git push` while HEAD points at `main`.
- Allows `--dry-run` variants; silent on every other Bash command.
- Local belt-and-braces companion to the GitHub branch ruleset that already prevents direct pushes to `main`.

## Test plan
- [x] Pipe-tested the hook command on five payloads (commit on main → block; push on main → block; status → allow; ls → allow; commit --dry-run → allow) plus a non-main branch via a temp repo.
- [ ] Open `/hooks` (or restart Claude Code) so the watcher picks up the new file, then try `git commit -m foo` on `main` — should be blocked with the stderr message.
- [x] Exercise the ruleset by merging this PR (no direct push to `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)