### PR TITLE
Switch git-on-main hook to JSON permissionDecision

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.command // empty' | { read -r cmd; blocked=false; case \"$cmd\" in *\"git commit\"*|*\"git push\"*) blocked=true;; esac; case \"$cmd\" in *\"--dry-run\"*) blocked=false;; esac; if $blocked; then branch=$(git -C /Users/scray/dev/projects/limen rev-parse --abbrev-ref HEAD 2>/dev/null); if [ \"$branch\" = \"main\" ]; then echo \"Refusing to git commit/push on main — create a feature branch first: git checkout -b <name>\" >&2; exit 2; fi; fi; }"
+            "command": "cmd=$(jq -r '.tool_input.command // empty'); blocked=false; case \"$cmd\" in *\"git commit\"*|*\"git push\"*) blocked=true;; esac; case \"$cmd\" in *\"--dry-run\"*) blocked=false;; esac; if $blocked; then branch=$(git -C /Users/scray/dev/projects/limen rev-parse --abbrev-ref HEAD 2>/dev/null); if [ \"$branch\" = \"main\" ]; then jq -nc --arg msg \"Refusing to git commit/push on main — create a feature branch first: git checkout -b <name>\" '{hookSpecificOutput:{hookEventName:\"PreToolUse\",permissionDecision:\"deny\",permissionDecisionReason:$msg}}'; fi; fi"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Changes the `PreToolUse` Bash hook to emit `hookSpecificOutput.permissionDecision: "deny"` JSON instead of relying on `exit 2`.
- Reason: the exit-2 form is bypassed for tool calls that already match a `permissions.allow` rule (the user has a global `Bash(git *)` allow rule, which is why direct `git commit` calls were going through unblocked even though the hook was loaded). The JSON `permissionDecision` form is authoritative and overrides allow rules.
- Also switches `read -r cmd` to `cmd=$(jq -r …)` so multi-line bash commands are scanned in full (not just the first line).

## Test plan
- [x] Pipe-tested the new command on three fixtures (block on `git commit`, allow `git status`, block on multi-line containing `git commit`).
- [x] Roundtripped the JSON-escaped command via `jq -r` and re-ran — output is the deny JSON.
- [ ] After merge: open `/hooks` (or restart) so the watcher picks up the new file content, then run `git commit --allow-empty -m foo` on `main` — should now actually be denied (vs. silently allowed under the previous version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)