### PR TITLE
Build and publish container image to GHCR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+target/
+.git/
+.github/
+.idea/
+.vscode/
+.run/
+*.iml
+.claude/
+docs/
+research/
+scripts/
+*.md
+LICENSE
+docker-compose.yml
+.env
+.envrc
+pmd-ruleset.xml

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,66 @@
+name: Publish image
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*.*.*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: publish-image-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: build and push to ghcr.io
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 26 (Temurin)
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '26'
+          cache: maven
+
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=sha,format=short
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image with Paketo buildpacks
+        run: |
+          ./mvnw -B -ntp spring-boot:build-image \
+            -Dmaven.test.skip=true \
+            -Dspring-boot.build-image.imageName=ghcr.io/${{ github.repository }}:build \
+            -Dspring-boot.build-image.env.BP_JVM_VERSION=26
+
+      - name: Tag and push
+        run: |
+          set -euo pipefail
+          while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
+            docker tag "ghcr.io/${{ github.repository }}:build" "$tag"
+            docker push "$tag"
+          done <<< '${{ steps.meta.outputs.tags }}'

--- a/docs/CONTAINER.md
+++ b/docs/CONTAINER.md
@@ -1,0 +1,142 @@
+# Pulling the Limen container image
+
+## Where the image lives
+
+The Limen container image is published to **GitHub Container Registry**:
+
+```
+ghcr.io/stucray/limen
+```
+
+`.github/workflows/publish-image.yml` builds and pushes on every commit to
+`main`, every `v*.*.*` tag, and on manual `workflow_dispatch`. Tags emitted:
+
+| Tag                  | When                              |
+|----------------------|-----------------------------------|
+| `main`               | every push to `main` (moving)     |
+| `sha-<short>`        | every push to `main` (immutable)  |
+| `<x.y.z>`, `<x.y>`   | semver tag push (`v1.2.3`)        |
+| `latest`             | semver tag push only              |
+
+**The package is private.** Pulls require authentication.
+
+## Creating a pull token
+
+Use a **classic personal access token** with the `read:packages` scope.
+Fine-grained PATs do not currently grant access to user-namespaced GHCR
+packages, so the classic form is required for `ghcr.io/stucray/...`.
+
+1. Go to https://github.com/settings/tokens (Tokens — classic) → *Generate new token (classic)*
+2. Scope: tick **`read:packages`** only
+3. Set an expiration (90 days is a reasonable default)
+4. Save the token in your password manager / secret store
+
+In examples below, the token is referred to as `$GHCR_PAT`.
+
+## Pulling from a local machine
+
+```sh
+echo "$GHCR_PAT" | docker login ghcr.io -u stucray --password-stdin
+docker pull ghcr.io/stucray/limen:main
+```
+
+`docker login` writes the credential to `~/.docker/config.json` so
+subsequent pulls don't need to re-authenticate.
+
+## Pulling from another GitHub Actions workflow
+
+Two steps — one in the package settings, one in the consuming workflow.
+
+**1. Grant the consuming repo Read access**
+
+Visit
+https://github.com/users/stucray/packages/container/limen/settings →
+**Manage Actions access** → *Add Repository* → pick the consuming repo
+and assign the **Read** role.
+
+**2. Use the built-in `GITHUB_TOKEN` in that repo's workflow**
+
+```yaml
+permissions:
+  packages: read
+
+steps:
+  - uses: docker/login-action@v3
+    with:
+      registry: ghcr.io
+      username: ${{ github.actor }}
+      password: ${{ secrets.GITHUB_TOKEN }}
+  - run: docker pull ghcr.io/stucray/limen:main
+```
+
+No PAT needed — `GITHUB_TOKEN` is sufficient once the package settings
+list the repo with Read access.
+
+## Pulling on a Docker host (VM, dev box, server)
+
+Same as the local-machine flow:
+
+```sh
+echo "$GHCR_PAT" | docker login ghcr.io -u stucray --password-stdin
+docker pull ghcr.io/stucray/limen:main
+```
+
+`docker login` stores the credential as base64 in
+`~/.docker/config.json` — fine for personal hosts, not great for shared
+ones. Configure a credential helper if the host is shared:
+
+- macOS: `docker-credential-osxkeychain` (default in Docker Desktop)
+- Linux: `docker-credential-secretservice` (libsecret/GNOME Keyring) or
+  `docker-credential-pass` (pass + GPG)
+
+## Pulling on Kubernetes
+
+Create an `imagePullSecret` from the PAT:
+
+```sh
+kubectl create secret docker-registry ghcr-limen \
+  --docker-server=ghcr.io \
+  --docker-username=stucray \
+  --docker-password="$GHCR_PAT"
+```
+
+Reference it from the pod spec:
+
+```yaml
+spec:
+  imagePullSecrets:
+    - name: ghcr-limen
+  containers:
+    - name: limen
+      image: ghcr.io/stucray/limen:main
+```
+
+When the PAT expires, recreate the secret with the new value
+(`kubectl delete secret ghcr-limen` first, or use `kubectl create
+secret ... --dry-run=client -o yaml | kubectl apply -f -`).
+
+## Verifying after the first workflow run
+
+Walk this checklist once, after `publish-image.yml` has run on `main`
+for the first time:
+
+- [ ] Package appears at https://github.com/stucray?tab=packages and is
+      marked **Private**
+- [ ] Package settings show **Repository: `stucray/limen`** linked
+      (auto-set by Paketo's OCI image labels). If the link is empty,
+      add the following under `spring-boot-maven-plugin` in `pom.xml`
+      and re-run the workflow:
+      ```xml
+      <configuration>
+        <image>
+          <env>
+            <BP_OCI_SOURCE>https://github.com/stucray/limen</BP_OCI_SOURCE>
+          </env>
+        </image>
+      </configuration>
+      ```
+- [ ] **Manage Actions access** lists `stucray/limen` with the **Write**
+      role (lets future workflow runs overwrite tags)
+- [ ] `docker pull ghcr.io/stucray/limen:main` from a clean machine
+      returns 401 without auth (confirms private), and succeeds after
+      `docker login` with a PAT


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish-image.yml` that runs `spring-boot:build-image` (Paketo buildpacks via the existing `spring-boot-maven-plugin`) on pushes to `main`, on `v*.*.*` tags, and on `workflow_dispatch`, then tags and pushes to `ghcr.io/stucray/limen` with branch / short-SHA / semver / `latest` tags computed by `docker/metadata-action`.
- Adds `.dockerignore` to keep `.git`, `.claude`, IDE configs, docs, the local `docker-compose.yml`, and any `.env` out of the build context.
- Adds `docs/CONTAINER.md` describing how to authenticate against the **private** GHCR package from a local machine, another GitHub Actions workflow, a Docker host, or Kubernetes.
- No Dockerfile — the existing Spring Boot Maven plugin already handles JVM selection, layered jar extraction, non-root user, Memory Calculator, and base-OS patching via Paketo. Less to maintain than a hand-rolled multi-stage Dockerfile.

## Why this shape

- **Parallel with `ci.yml`, not chained.** Both fire on the same push; `main` is a moving tag overwritten by the next green build, and consumer-facing tags (`v*.*.*`, `latest`) only appear via explicit tag push — so a transient red main commit can't ship a release tag.
- **`BP_JVM_VERSION=26` is set explicitly.** The default for the bundled bellsoft-liberica buildpack is 21; without the override Paketo would silently downgrade.
- **Tests skipped inside the image build** (`-Dmaven.test.skip=true`). They need Testcontainers/Docker which isn't available inside the buildpack builder; `ci.yml` already runs them on the host on the same push.
- **Package stays private by default.** No visibility toggle needed; pull-time auth is documented in `docs/CONTAINER.md`.

## Verified locally

- `./mvnw spring-boot:build-image -Dmaven.test.skip=true -Dspring-boot.build-image.imageName=limen:dev -Dspring-boot.build-image.env.BP_JVM_VERSION=26` → Liberica 11.7.1 + JRE 26, BUILD SUCCESS in ~2:18 (warm cache), 372MB image, runs as uid 1002.

## Manual one-time setup after first successful workflow run

1. https://github.com/users/stucray/packages/container/limen/settings → **Manage Actions access** → add `stucray/limen` with **Write** role (lets future workflow runs overwrite tags)
2. Confirm Repository link shows `stucray/limen` (auto-set by Paketo's image labels). If not, add `<configuration><image><env><BP_OCI_SOURCE>https://github.com/stucray/limen</BP_OCI_SOURCE></env></image></configuration>` under `spring-boot-maven-plugin` in `pom.xml` and re-run.

Package stays **Private**. See `docs/CONTAINER.md` for how to pull (PAT setup, k8s `imagePullSecret`, granting other GitHub Actions workflows Read access).

## Test plan

- [ ] Merge to main → `Publish image` workflow runs, publishes `ghcr.io/stucray/limen:main` and `ghcr.io/stucray/limen:sha-<short>`
- [ ] Package appears in https://github.com/stucray?tab=packages and is marked **Private**
- [ ] `docker pull ghcr.io/stucray/limen:main` from a clean machine without auth returns 401; with `docker login ghcr.io` + a classic PAT (scope `read:packages`) it succeeds
- [ ] `docker run --rm -p 8090:8090 -e LIMEN_SECURITY_KEK=... -e SPRING_DATASOURCE_URL=... ghcr.io/stucray/limen:main` → `/actuator/health` returns `{"status":"UP"}`
- [ ] Push a `v0.1.0` tag → workflow publishes `0.1.0`, `0.1`, and `latest` tags from a single image hash
- [ ] Manual `workflow_dispatch` from the Actions tab succeeds