### PR TITLE
Automate snapshot→release→next-snapshot release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,125 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Release version (default: strip -SNAPSHOT from current pom)'
+        required: false
+      next_version:
+        description: 'Next development version (default: bump patch + -SNAPSHOT)'
+        required: false
+      dry_run:
+        description: 'Dry run (no push, no Release)'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: cut release
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      # --- PROJECT-SPECIFIC: test-time env vars ---
+      # Add any secrets your `mvn verify` needs. Leave the block empty if none.
+      LIMEN_SECURITY_KEK: ${{ secrets.LIMEN_SECURITY_KEK_TEST }}
+    steps:
+      - name: Checkout main with PAT
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          token: ${{ secrets.RELEASE_TOKEN }}
+          fetch-depth: 0
+
+      - name: Read Java version from pom
+        id: jv
+        run: |
+          set -euo pipefail
+          v=$(grep -m1 '<java.version>' pom.xml | sed 's/.*>\(.*\)<.*/\1/')
+          [ -n "$v" ] || { echo "::error::Could not find <java.version> property in pom.xml"; exit 1; }
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+
+      - name: Set up JDK (Temurin)
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: ${{ steps.jv.outputs.version }}
+          cache: maven
+
+      - name: Configure git identity
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Compute versions and guards
+        id: vers
+        run: |
+          set -euo pipefail
+          CURRENT=$(./mvnw -B -ntp help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "Current pom version: $CURRENT"
+          [[ "$CURRENT" == *-SNAPSHOT ]] || { echo "::error::Current version $CURRENT is not a -SNAPSHOT; refusing to release."; exit 1; }
+          REL="${{ inputs.release_version }}"
+          [ -z "$REL" ] && REL="${CURRENT%-SNAPSHOT}"
+          NEXT="${{ inputs.next_version }}"
+          if [ -z "$NEXT" ]; then
+            IFS=. read -r MA MI PA <<<"$REL"
+            NEXT="${MA}.${MI}.$((PA+1))-SNAPSHOT"
+          fi
+          [[ "$NEXT" == *-SNAPSHOT ]] || { echo "::error::next_version $NEXT must end in -SNAPSHOT."; exit 1; }
+          if git ls-remote --tags origin "refs/tags/v$REL" | grep -q .; then
+            echo "::error::Tag v$REL already exists on origin."
+            exit 1
+          fi
+          echo "release=$REL" >> "$GITHUB_OUTPUT"
+          echo "next=$NEXT"   >> "$GITHUB_OUTPUT"
+          {
+            echo "## Plan"
+            echo "- Current: \`$CURRENT\`"
+            echo "- Release: \`$REL\`  (tag \`v$REL\`)"
+            echo "- Next:    \`$NEXT\`"
+            echo "- Dry run: \`${{ inputs.dry_run }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Set release version
+        run: ./mvnw -B -ntp org.codehaus.mojo:versions-maven-plugin:2.16.2:set -DnewVersion=${{ steps.vers.outputs.release }} -DgenerateBackupPoms=false -DprocessAllModules=true
+
+      - name: Verify release build
+        run: ./mvnw -B -ntp verify
+
+      - name: Commit and tag release
+        run: |
+          git add pom.xml
+          git commit -m "Release ${{ steps.vers.outputs.release }}"
+          git tag -a "v${{ steps.vers.outputs.release }}" -m "Release ${{ steps.vers.outputs.release }}"
+
+      - name: Set next snapshot version
+        run: ./mvnw -B -ntp org.codehaus.mojo:versions-maven-plugin:2.16.2:set -DnewVersion=${{ steps.vers.outputs.next }} -DgenerateBackupPoms=false -DprocessAllModules=true
+
+      - name: Commit next snapshot
+        run: |
+          git add pom.xml
+          git commit -m "Prepare for next development iteration: ${{ steps.vers.outputs.next }}"
+
+      - name: Push (atomic)
+        if: ${{ !inputs.dry_run }}
+        run: git push --atomic origin main "v${{ steps.vers.outputs.release }}"
+
+      - name: Create GitHub Release
+        if: ${{ !inputs.dry_run }}
+        run: gh release create "v${{ steps.vers.outputs.release }}" --generate-notes --title "v${{ steps.vers.outputs.release }}"
+
+      - name: Dry-run summary
+        if: ${{ inputs.dry_run }}
+        run: |
+          {
+            echo "## Dry run complete — no push, no Release"
+            echo "Tag and commits exist locally only and will be discarded with the runner."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,161 @@
+# Cutting a release
+
+This repo's release process is fully automated by `.github/workflows/release.yml`.
+One click in the Actions tab cuts a versioned release: it strips `-SNAPSHOT`,
+runs the test suite, tags `vX.Y.Z`, publishes the container image, creates a
+GitHub Release, and bumps `main` to the next development snapshot.
+
+## What the workflow does
+
+When you click *Run workflow*, in order:
+
+1. Checks out `main` and reads `<java.version>` from `pom.xml`
+2. Computes the release version (current pom version with `-SNAPSHOT` stripped)
+   and the next snapshot version (patch+1, with `-SNAPSHOT` re-appended)
+3. Refuses to run if any guard fails: current version isn't a snapshot, the
+   `vX.Y.Z` tag already exists on origin, or `next_version` doesn't end in
+   `-SNAPSHOT`
+4. Rewrites `pom.xml` to the release version via `versions:set`
+5. Runs `./mvnw verify` — the same pipeline `ci.yml` runs (Error Prone +
+   NullAway + tests + JaCoCo + PMD)
+6. Commits `Release X.Y.Z` and tags `vX.Y.Z`
+7. Rewrites `pom.xml` to the next snapshot version and commits
+   `Prepare for next development iteration: X.Y.Z+1-SNAPSHOT`
+8. Pushes both commits and the tag to `main` atomically (`git push --atomic`)
+9. Creates a GitHub Release with auto-generated notes (PR titles since the
+   previous tag)
+10. The tag push triggers `publish-image.yml`, which builds and pushes
+    `ghcr.io/stucray/limen:X.Y.Z`, `:X.Y`, and `:latest` to GHCR
+
+## One-time setup
+
+Before the first release ever, two manual steps. (Already done? Skip to the
+next section.)
+
+### 1. Create a fine-grained PAT
+
+Go to https://github.com/settings/personal-access-tokens → *Generate new token*:
+
+- **Resource owner**: your account
+- **Repository access**: *Only select repositories* → `stucray/limen`
+- **Repository permissions**:
+  - **Contents**: Read and write
+- **Expiration**: 90 days (set a calendar reminder for renewal)
+
+Save the token value somewhere safe — you can't see it again after this page.
+
+### 2. Store the PAT as a repo secret
+
+Repo → Settings → Secrets and variables → Actions → *New repository secret*:
+
+- **Name**: `RELEASE_TOKEN` (must be this exact name)
+- **Value**: the PAT
+
+That's it. No ruleset changes are needed because the existing `main-protection`
+ruleset already lets the Admin role bypass the PR-required rule, and the PAT
+carries your admin role.
+
+## Cutting a release
+
+### First, dry-run
+
+Always dry-run the first release of a session, especially for the first-ever
+release of the project.
+
+1. Repo → Actions → **Release** → *Run workflow*
+2. Branch: `main`
+3. Tick **Dry run**
+4. Leave **Release version** and **Next development version** blank
+5. *Run workflow*
+
+In the run summary you'll see:
+
+```
+## Plan
+- Current: 0.0.1-SNAPSHOT
+- Release: 0.0.1  (tag v0.0.1)
+- Next:    0.0.2-SNAPSHOT
+- Dry run: true
+```
+
+`mvn verify` will run end-to-end. Nothing is pushed; no tag, commit, or Release
+appears on origin. The runner is discarded.
+
+### Real release
+
+If the dry-run looked right:
+
+1. Repo → Actions → **Release** → *Run workflow*
+2. Branch: `main`
+3. Leave **Dry run** unticked
+4. Leave both version inputs blank
+5. *Run workflow*
+
+In ~6-8 minutes you'll have:
+
+- A new tag `vX.Y.Z` on `main`
+- Two new commits: `Release X.Y.Z` and `Prepare for next development iteration: X.Y.Z+1-SNAPSHOT`
+- A GitHub Release at `https://github.com/stucray/limen/releases/tag/vX.Y.Z`
+- The image published at `ghcr.io/stucray/limen:X.Y.Z` (also `:X.Y` and `:latest`) — a separate `publish-image.yml` run handles this and takes another ~1 min after the tag push
+
+### Overriding the versions
+
+The defaults bump patch (`0.0.1` → `0.0.2-SNAPSHOT`). For a minor or major
+bump, fill the inputs:
+
+- **Release version**: `0.1.0`
+- **Next development version**: `0.2.0-SNAPSHOT`
+
+Validation: `next_version` must end in `-SNAPSHOT`; the tag must not already
+exist; the current pom version must end in `-SNAPSHOT`. If any fail, the run
+stops with a clear error before any commits are made.
+
+## After the release
+
+Locally:
+
+```sh
+git pull
+./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout
+# 0.0.2-SNAPSHOT
+```
+
+To pull the new image (see also `docs/CONTAINER.md`):
+
+```sh
+echo "$GHCR_PAT" | docker login ghcr.io -u stucray --password-stdin
+docker pull ghcr.io/stucray/limen:0.0.1
+```
+
+## Maintenance
+
+- **PAT renewal**: when the 90-day clock runs out, the workflow fails at
+  *Checkout* with a 401. Generate a new PAT (same permissions), update the
+  `RELEASE_TOKEN` secret, you're back in business. Set a calendar reminder.
+- **`gh release --generate-notes`**: pulls PR titles since the previous tag.
+  Write good PR titles and you get good release notes for free.
+
+## Reusing this workflow in another Maven project
+
+The workflow file is **portable** — it never references this repo's name. Drop
+`.github/workflows/release.yml` into another single-module or multi-module
+Maven project and adjust two things in the YAML:
+
+1. **The `env:` block under the job.** List any secrets your tests need.
+   Limen has `LIMEN_SECURITY_KEK`. Most projects have something. Delete the
+   block entirely if `mvn verify` runs with no env.
+
+2. **The Java-version lookup.** The workflow reads `<java.version>` from
+   `pom.xml` via a `grep` line. If your project pins Java only via
+   `maven.compiler.source` or similar, change the property name in the grep.
+
+Per repo, repeat the **One-time setup** section above (create a PAT scoped to
+the new repo, store as `RELEASE_TOKEN` secret). The secret name stays the same
+across repos.
+
+Multi-module projects are already handled — `versions:set` runs with
+`-DprocessAllModules=true`, which is a no-op on single-module poms.
+
+If the new repo doesn't have a tag-driven downstream workflow (image build,
+deploy, etc.), the release workflow still works — it just stops at "tag is
+pushed and the GitHub Release is created."


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml` plus `docs/RELEASE.md` (how-to). One-click `workflow_dispatch` release that:

1. Strips `-SNAPSHOT` from pom.xml (default: `0.0.1-SNAPSHOT` → `0.0.1`)
2. Runs `./mvnw verify` against the release-version commit
3. Commits `Release X.Y.Z` and tags `vX.Y.Z`
4. Bumps to the next development snapshot (patch+1 by default) and commits the bump
5. Pushes both commits and the tag atomically to `main`
6. Creates a GitHub Release with auto-generated notes (PR titles since the previous tag)

The `vX.Y.Z` tag push triggers the existing `publish-image.yml`, which builds and pushes `ghcr.io/stucray/limen:X.Y.Z`, `:X.Y`, and `:latest` to GHCR — image-build logic stays single-sourced.

## Inputs (all optional)

| Input | Default | Notes |
|---|---|---|
| `release_version` | strip `-SNAPSHOT` from pom | Override for minor/major bumps |
| `next_version` | bump patch + `-SNAPSHOT` | Override to skip ahead |
| `dry_run` | `false` | Runs versions:set + verify + local commits, skips push and Release |

## Manual one-time setup before the first release

1. **Create a fine-grained PAT** at https://github.com/settings/personal-access-tokens scoped to `stucray/limen`, with `Contents: Read and write`. Recommend 90-day expiration with a renewal reminder.
2. **Store as repo secret `RELEASE_TOKEN`** under Settings → Secrets and variables → Actions.

No branch-ruleset change required — `main-protection` already lists `RepositoryRole=Admin` as a bypass actor with `bypass_mode: always`, so the PAT (owned by an admin) bypasses the required-PR rule.

`docs/RELEASE.md` walks through this in detail, including a "Reusing in another project" section.

## Why a PAT and not GITHUB_TOKEN

The default `GITHUB_TOKEN` runs as the github-actions[bot] user, which is not in the ruleset's bypass list. Adding the bot to the bypass list would loosen `main-protection` for every workflow with `contents: write`. A repo-scoped admin PAT keeps the bypass narrow to this one workflow.

## Why decoupled from publish-image.yml

The release workflow's job ends at `git push`. Image build/push is the existing `publish-image.yml`'s responsibility — it already triggers on `v*.*.*` tags and emits the right tag set. Avoids duplicating the buildpack invocation.

## Portability

The workflow YAML never references `stucray/limen`, so it's drop-in for any single-module or multi-module Maven project. Only two project-specific bits in the file:

1. The `env:` block under the job — list any secrets your tests need (Limen has `LIMEN_SECURITY_KEK`)
2. The `<java.version>` property in `pom.xml` — workflow reads it dynamically; if your project pins Java elsewhere, change the `grep` line in `Read Java version from pom`

The PAT and `RELEASE_TOKEN` secret are per-repo (a PAT is a credential and has to match the repo it authenticates against). The secret *name* stays `RELEASE_TOKEN` across repos.

Multi-module covered via `-DprocessAllModules=true`.

## Test plan

- [ ] Create the `RELEASE_TOKEN` secret per setup steps above
- [ ] Trigger the workflow with `dry_run=true`, blank inputs → workflow summary shows planned versions; no commits or tags appear on origin
- [ ] Trigger with `dry_run=false`, blank inputs → `v0.0.1` tag, `0.0.1` Release, two commits on `main`, `publish-image.yml` fires and publishes `ghcr.io/stucray/limen:0.0.1` / `:0.0` / `:latest`
- [ ] Pull from a clean machine: `docker login ghcr.io … && docker pull ghcr.io/stucray/limen:0.0.1` → `/actuator/health` UP
- [ ] After release, `./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout` on a fresh `git pull` returns `0.0.2-SNAPSHOT`
- [ ] Failure paths: trigger with current version not a snapshot, an existing tag, or a `next_version` missing `-SNAPSHOT` — all should fail at the guards step with clear errors