### PR TITLE
Clarify next-snapshot default in docs/RELEASE.md

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -100,11 +100,23 @@ In ~6-8 minutes you'll have:
 
 ### Overriding the versions
 
-The defaults bump patch (`0.0.1` → `0.0.2-SNAPSHOT`). For a minor or major
-bump, fill the inputs:
+The defaults strip `-SNAPSHOT` from the current pom for the release version,
+then patch-bump that release for the next snapshot — e.g. current
+`0.0.1-SNAPSHOT` → release `0.0.1`, next `0.0.2-SNAPSHOT`.
 
-- **Release version**: `0.1.0`
-- **Next development version**: `0.2.0-SNAPSHOT`
+For a minor or major bump, fill **only** `release_version` and let
+`next_version` default. The patch-bump rule is applied to whatever release
+version you supply:
+
+| Release version | Default next snapshot |
+|---|---|
+| `0.1.0` | `0.1.1-SNAPSHOT` |
+| `1.0.0` | `1.0.1-SNAPSHOT` |
+| `2.4.7` | `2.4.8-SNAPSHOT` |
+
+If you want the next development line to track a different segment (say,
+`0.1.0` → `0.2.0-SNAPSHOT` to signal that minor work is starting), fill in
+**both** inputs explicitly.
 
 Validation: `next_version` must end in `-SNAPSHOT`; the tag must not already
 exist; the current pom version must end in `-SNAPSHOT`. If any fail, the run


### PR DESCRIPTION
## Summary

The example in *Overriding the versions* paired `release_version=0.1.0` with `next_version=0.2.0-SNAPSHOT`, which suggested a minor-bump release pairs with a minor-bump next snapshot. That's not what the workflow actually does — when `next_version` is left blank, it patch-bumps the release version (`0.1.0` → `0.1.1-SNAPSHOT`), matching Maven Release Plugin convention.

The workflow code itself is correct (`MA.MI.PA+1-SNAPSHOT` from the release version); only the doc example was misleading.

Replaces the misleading example with a small table showing the patch-bump rule applied to several release versions, and notes that filling **both** inputs is the way to override that default.

## Test plan

- [ ] No code changes — docs only