### PR TITLE
Walking skeleton: Playwright UI testing harness + Tenant Signup journey

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,23 @@ jobs:
           java-version: '26'
           cache: maven
 
+      # Cache the Playwright browser binaries (~150 MB Chromium) downloaded by
+      # Playwright on first `Playwright.create()`. Keyed on pom.xml so a bump
+      # of the Playwright version invalidates the cache; restore-keys lets us
+      # fall back to any prior cache for the same OS to avoid a full miss when
+      # unrelated deps change.
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pom.xml') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+
       # Single Maven phase that does everything: compile, Error Prone +
-      # NullAway (errors fail the build), unit + integration tests, JaCoCo
-      # coverage check, and the PMD complexity report.
+      # NullAway (errors fail the build), unit + integration tests
+      # (Surefire + Failsafe-driven Playwright UI tests), JaCoCo coverage
+      # check, and the PMD complexity report.
       - name: Verify (compile + Error Prone + NullAway + tests + JaCoCo + PMD report)
         run: ./mvnw -B -ntp verify
 
@@ -72,5 +86,18 @@ jobs:
         with:
           name: jacoco-report
           path: target/site/jacoco
+          if-no-files-found: ignore
+          retention-days: 14
+
+      # Playwright traces (zipped, replayable in the trace viewer) and final-
+      # state screenshots are written under target/playwright-artifacts/ ONLY
+      # when a UI test fails. Uploaded on failure so reviewers can replay the
+      # test step-by-step against full DOM snapshots.
+      - name: Upload Playwright traces and screenshots on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-artifacts
+          path: target/playwright-artifacts/
           if-no-files-found: ignore
           retention-days: 14

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,8 @@
 		<maven.compiler.target>26</maven.compiler.target>
 		<error-prone.version>2.49.0</error-prone.version>
 		<nullaway.version>0.13.4</nullaway.version>
+		<playwright.version>1.50.0</playwright.version>
+		<maven-failsafe-plugin.version>3.5.4</maven-failsafe-plugin.version>
 		<maven-jxr-plugin.version>3.6.0</maven-jxr-plugin.version>
 		<maven-pmd-plugin.version>3.28.0</maven-pmd-plugin.version>
 		<!--
@@ -113,6 +115,12 @@
 			<artifactId>testcontainers-postgresql</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.microsoft.playwright</groupId>
+			<artifactId>playwright</artifactId>
+			<version>${playwright.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -179,6 +187,27 @@
 						<LIMEN_SECURITY_KEK>dGVzdC1rZWstdGVzdC1rZWstdGVzdC1rZWstdGVzdC0=</LIMEN_SECURITY_KEK>
 					</environmentVariables>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>${maven-failsafe-plugin.version}</version>
+				<configuration>
+					<includes>
+						<include>**/*UiIT.java</include>
+					</includes>
+					<environmentVariables>
+						<LIMEN_SECURITY_KEK>dGVzdC1rZWstdGVzdC1rZWstdGVzdC1rZWstdGVzdC0=</LIMEN_SECURITY_KEK>
+					</environmentVariables>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.jacoco</groupId>

--- a/src/main/resources/templates/landing.html
+++ b/src/main/resources/templates/landing.html
@@ -23,7 +23,7 @@
     <article class="card card--auth">
         <h2>Create a new organization</h2>
         <p class="muted">Set up a new tenant and become its first owner.</p>
-        <a href="/signup" class="btn btn--secondary btn--block">Sign up</a>
+        <a href="/signup" class="btn btn--secondary btn--block" data-test-action="landing-signup">Sign up</a>
     </article>
 </main>
 </body>

--- a/src/main/resources/templates/signup.html
+++ b/src/main/resources/templates/signup.html
@@ -37,7 +37,7 @@
                 <span class="form-error" th:if="${errorField == 'password'}" th:text="${errorMessage}"></span>
             </label>
 
-            <button type="submit" class="btn--block">Create account</button>
+            <button type="submit" class="btn--block" data-test-action="signup-submit">Create account</button>
         </form>
     </article>
 </main>

--- a/src/test/java/com/stucray/limen/ui/journey/SignupJourneyUiIT.java
+++ b/src/test/java/com/stucray/limen/ui/journey/SignupJourneyUiIT.java
@@ -1,0 +1,35 @@
+package com.stucray.limen.ui.journey;
+
+import com.microsoft.playwright.Page;
+import com.stucray.limen.ui.pages.LandingPage;
+import com.stucray.limen.ui.support.BaseUiIT;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+@DisplayName("A new tenant administrator can sign up via the landing page")
+class SignupJourneyUiIT extends BaseUiIT {
+
+    @Test
+    @DisplayName("happy path: lands on /, follows Sign up, submits the form, redirects to the new tenant's login page with a registered banner")
+    void happyPath(Page page) {
+        String suffix = uniqueSuffix();
+        String slug = "t-" + suffix;
+        String orgName = "Acme " + suffix;
+        String username = "owner-" + suffix;
+        String password = "secret123";
+
+        new LandingPage(page, baseUrl())
+            .visit()
+            .clickSignUp()
+            .fillForm(orgName, slug, username, password)
+            .submit(slug)
+            .assertOnLoginForTenant(orgName)
+            .assertJustRegisteredBannerVisible();
+    }
+
+    private static String uniqueSuffix() {
+        return UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+    }
+}

--- a/src/test/java/com/stucray/limen/ui/journey/SignupJourneyUiIT.java
+++ b/src/test/java/com/stucray/limen/ui/journey/SignupJourneyUiIT.java
@@ -27,10 +27,6 @@ class SignupJourneyUiIT extends BaseUiIT {
             .submit(slug)
             .assertOnLoginForTenant(orgName)
             .assertJustRegisteredBannerVisible();
-
-        // INTENTIONAL FAILURE — verifying Playwright trace + screenshot artifact
-        // upload on the CI failure path. Reverted in the next commit.
-        throw new AssertionError("intentional failure to exercise CI artifact upload");
     }
 
     private static String uniqueSuffix() {

--- a/src/test/java/com/stucray/limen/ui/journey/SignupJourneyUiIT.java
+++ b/src/test/java/com/stucray/limen/ui/journey/SignupJourneyUiIT.java
@@ -27,6 +27,10 @@ class SignupJourneyUiIT extends BaseUiIT {
             .submit(slug)
             .assertOnLoginForTenant(orgName)
             .assertJustRegisteredBannerVisible();
+
+        // INTENTIONAL FAILURE — verifying Playwright trace + screenshot artifact
+        // upload on the CI failure path. Reverted in the next commit.
+        throw new AssertionError("intentional failure to exercise CI artifact upload");
     }
 
     private static String uniqueSuffix() {

--- a/src/test/java/com/stucray/limen/ui/pages/LandingPage.java
+++ b/src/test/java/com/stucray/limen/ui/pages/LandingPage.java
@@ -1,0 +1,24 @@
+package com.stucray.limen.ui.pages;
+
+import com.microsoft.playwright.Page;
+
+public final class LandingPage {
+
+    private final Page page;
+    private final String baseUrl;
+
+    public LandingPage(Page page, String baseUrl) {
+        this.page = page;
+        this.baseUrl = baseUrl;
+    }
+
+    public LandingPage visit() {
+        page.navigate(baseUrl + "/");
+        return this;
+    }
+
+    public SignupPage clickSignUp() {
+        page.getByTestId("landing-signup").click();
+        return new SignupPage(page, baseUrl);
+    }
+}

--- a/src/test/java/com/stucray/limen/ui/pages/SignupPage.java
+++ b/src/test/java/com/stucray/limen/ui/pages/SignupPage.java
@@ -1,0 +1,29 @@
+package com.stucray.limen.ui.pages;
+
+import com.microsoft.playwright.Page;
+import com.stucray.limen.ui.pages.manage.ManageLoginPage;
+
+public final class SignupPage {
+
+    private final Page page;
+    private final String baseUrl;
+
+    public SignupPage(Page page, String baseUrl) {
+        this.page = page;
+        this.baseUrl = baseUrl;
+    }
+
+    public SignupPage fillForm(String organizationName, String slug, String username, String password) {
+        page.getByLabel("Organization name").fill(organizationName);
+        page.getByLabel("Slug").fill(slug);
+        page.getByLabel("Username").fill(username);
+        page.getByLabel("Password").fill(password);
+        return this;
+    }
+
+    public ManageLoginPage submit(String expectedSlug) {
+        page.getByTestId("signup-submit").click();
+        page.waitForURL(baseUrl + "/manage/t/" + expectedSlug + "/login**");
+        return new ManageLoginPage(page, baseUrl, expectedSlug);
+    }
+}

--- a/src/test/java/com/stucray/limen/ui/pages/manage/ManageLoginPage.java
+++ b/src/test/java/com/stucray/limen/ui/pages/manage/ManageLoginPage.java
@@ -1,0 +1,44 @@
+package com.stucray.limen.ui.pages.manage;
+
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.assertions.PlaywrightAssertions;
+import com.microsoft.playwright.options.AriaRole;
+
+public final class ManageLoginPage {
+
+    private final Page page;
+    private final String baseUrl;
+    private final String slug;
+
+    public ManageLoginPage(Page page, String baseUrl, String slug) {
+        this.page = page;
+        this.baseUrl = baseUrl;
+        this.slug = slug;
+    }
+
+    public ManageLoginPage visit() {
+        page.navigate(baseUrl + "/manage/t/" + slug + "/login");
+        return this;
+    }
+
+    public ManageLoginPage assertOnLoginForTenant(String expectedDisplayName) {
+        PlaywrightAssertions.assertThat(page.getByRole(AriaRole.HEADING, new Page.GetByRoleOptions().setName("Sign in"))).isVisible();
+        PlaywrightAssertions.assertThat(page.getByText(expectedDisplayName)).isVisible();
+        return this;
+    }
+
+    public ManageLoginPage assertJustRegisteredBannerVisible() {
+        PlaywrightAssertions.assertThat(page.getByText("Account created — please sign in.")).isVisible();
+        return this;
+    }
+
+    public ManageLoginPage fill(String username, String password) {
+        page.getByLabel("Username").fill(username);
+        page.getByLabel("Password").fill(password);
+        return this;
+    }
+
+    public void submit() {
+        page.getByTestId("manage-login-submit").click();
+    }
+}

--- a/src/test/java/com/stucray/limen/ui/support/BaseUiIT.java
+++ b/src/test/java/com/stucray/limen/ui/support/BaseUiIT.java
@@ -1,0 +1,34 @@
+package com.stucray.limen.ui.support;
+
+import com.stucray.limen.TestcontainersConfiguration;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Base class for Playwright-driven UI tests.
+ *
+ * <p>Boots a real application instance with the existing Testcontainers Postgres,
+ * picks a random port, and wires {@link PlaywrightExtension} so test methods can
+ * declare a {@link com.microsoft.playwright.Page} parameter.
+ *
+ * <p>Subclasses use {@link #baseUrl()} to build absolute URLs — page objects should
+ * receive it via constructor.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import(TestcontainersConfiguration.class)
+@ExtendWith(PlaywrightExtension.class)
+public abstract class BaseUiIT {
+
+    @LocalServerPort
+    protected int port;
+
+    @Autowired
+    protected TestTenantFactory tenants;
+
+    protected String baseUrl() {
+        return "http://localhost:" + port;
+    }
+}

--- a/src/test/java/com/stucray/limen/ui/support/LoginPageObject.java
+++ b/src/test/java/com/stucray/limen/ui/support/LoginPageObject.java
@@ -1,0 +1,52 @@
+package com.stucray.limen.ui.support;
+
+import com.microsoft.playwright.Page;
+import com.stucray.limen.ui.support.TestTenantFactory.SeededTenant;
+
+/**
+ * Per-role login helpers. All three drive the real login form (no test-only backdoor,
+ * no synthesised SecurityContext) — login is exercised on every test that uses these.
+ *
+ * <p>Methods perform the navigate + fill + submit + wait-for-navigation. Callers
+ * construct the next typed page object themselves (each post-login surface lives in its
+ * own slice, see PRD #96 for the journey breakdown).
+ *
+ * <p>Slice 1.1 ships these helpers wired but only exercises {@link #loginAsTenantAdmin}
+ * indirectly via the signup journey's redirect target. The {@code data-test-action}
+ * attributes on the per-role submit buttons land with the slices that consume them
+ * (#98 / #99 / #101).
+ */
+public final class LoginPageObject {
+
+    private final Page page;
+    private final String baseUrl;
+
+    public LoginPageObject(Page page, String baseUrl) {
+        this.page = page;
+        this.baseUrl = baseUrl;
+    }
+
+    public void loginAsTenantAdmin(SeededTenant tenant) {
+        page.navigate(baseUrl + "/manage/t/" + tenant.slug() + "/login");
+        page.getByLabel("Username").fill(tenant.adminUsername());
+        page.getByLabel("Password").fill(tenant.adminPassword());
+        page.getByTestId("manage-login-submit").click();
+        page.waitForURL(baseUrl + "/manage/t/" + tenant.slug() + "/**");
+    }
+
+    public void loginAsEndUser(SeededTenant tenant) {
+        page.navigate(baseUrl + "/t/" + tenant.slug() + "/login");
+        page.getByLabel("Username").fill(tenant.endUserUsername());
+        page.getByLabel("Password").fill(tenant.endUserPassword());
+        page.getByTestId("login-submit").click();
+        page.waitForURL(baseUrl + "/t/" + tenant.slug() + "/**");
+    }
+
+    public void loginAsSystemAdmin(String username, String password) {
+        page.navigate(baseUrl + "/manage/t/system/login");
+        page.getByLabel("Username").fill(username);
+        page.getByLabel("Password").fill(password);
+        page.getByTestId("manage-login-submit").click();
+        page.waitForURL(baseUrl + "/manage/t/system/**");
+    }
+}

--- a/src/test/java/com/stucray/limen/ui/support/PlaywrightExtension.java
+++ b/src/test/java/com/stucray/limen/ui/support/PlaywrightExtension.java
@@ -1,0 +1,145 @@
+package com.stucray.limen.ui.support;
+
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
+import com.microsoft.playwright.Tracing;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * JUnit 5 extension that owns the Playwright lifecycle for UI tests.
+ *
+ * <p>One Playwright + Browser per JVM (expensive); a fresh BrowserContext + Page per test
+ * (cheap, naturally isolated). Tracing runs on every test; on failure, the trace is
+ * persisted and a final-state screenshot is captured. Both land under
+ * {@code target/playwright-artifacts/<TestClass>/<testMethod>/} for CI artifact upload.
+ *
+ * <p>Tests get their {@link Page} via JUnit parameter injection — declare {@code Page page}
+ * as a test method parameter.
+ *
+ * <p>Headless by default. Override locally with {@code -Dplaywright.headless=false}.
+ */
+public class PlaywrightExtension implements BeforeAllCallback, BeforeEachCallback, AfterEachCallback, ParameterResolver {
+
+    private static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace.create(PlaywrightExtension.class);
+    private static final String PAGE_KEY = "page";
+    private static final String CONTEXT_KEY = "context";
+    private static final String TRACE_PATH_KEY = "trace-path";
+    private static final String SCREENSHOT_PATH_KEY = "screenshot-path";
+
+    private static final Object LOCK = new Object();
+    private static volatile Playwright playwright;
+    private static volatile Browser browser;
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        ensureBrowserStarted();
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContext) throws IOException {
+        ensureBrowserStarted();
+
+        Path artifactDir = artifactDir(extensionContext);
+        Files.createDirectories(artifactDir);
+
+        BrowserContext browserContext = browser.newContext();
+        browserContext.tracing().start(new Tracing.StartOptions()
+            .setScreenshots(true)
+            .setSnapshots(true)
+            .setSources(false));
+        Page page = browserContext.newPage();
+
+        ExtensionContext.Store store = extensionContext.getStore(NAMESPACE);
+        store.put(CONTEXT_KEY, browserContext);
+        store.put(PAGE_KEY, page);
+        store.put(TRACE_PATH_KEY, artifactDir.resolve("trace.zip"));
+        store.put(SCREENSHOT_PATH_KEY, artifactDir.resolve("screenshot.png"));
+    }
+
+    @Override
+    public void afterEach(ExtensionContext extensionContext) {
+        ExtensionContext.Store store = extensionContext.getStore(NAMESPACE);
+        BrowserContext browserContext = store.get(CONTEXT_KEY, BrowserContext.class);
+        Page page = store.get(PAGE_KEY, Page.class);
+        Path tracePath = store.get(TRACE_PATH_KEY, Path.class);
+        Path screenshotPath = store.get(SCREENSHOT_PATH_KEY, Path.class);
+
+        boolean failed = extensionContext.getExecutionException().isPresent();
+        try {
+            if (failed) {
+                browserContext.tracing().stop(new Tracing.StopOptions().setPath(tracePath));
+                if (page != null && !page.isClosed()) {
+                    page.screenshot(new Page.ScreenshotOptions().setPath(screenshotPath).setFullPage(true));
+                }
+            } else {
+                browserContext.tracing().stop();
+            }
+        } finally {
+            if (browserContext != null) {
+                browserContext.close();
+            }
+        }
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        Class<?> type = parameterContext.getParameter().getType();
+        return type == Page.class || type == BrowserContext.class;
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        ExtensionContext.Store store = extensionContext.getStore(NAMESPACE);
+        Class<?> type = parameterContext.getParameter().getType();
+        if (type == Page.class) {
+            return store.get(PAGE_KEY, Page.class);
+        }
+        return store.get(CONTEXT_KEY, BrowserContext.class);
+    }
+
+    private static void ensureBrowserStarted() {
+        if (browser != null) {
+            return;
+        }
+        synchronized (LOCK) {
+            if (browser != null) {
+                return;
+            }
+            playwright = Playwright.create();
+            playwright.selectors().setTestIdAttribute("data-test-action");
+            boolean headless = !"false".equalsIgnoreCase(System.getProperty("playwright.headless", "true"));
+            browser = playwright.chromium().launch(new BrowserType.LaunchOptions().setHeadless(headless));
+            Runtime.getRuntime().addShutdownHook(new Thread(PlaywrightExtension::closeBrowser, "playwright-shutdown"));
+        }
+    }
+
+    private static void closeBrowser() {
+        try {
+            if (browser != null) {
+                browser.close();
+            }
+        } finally {
+            if (playwright != null) {
+                playwright.close();
+            }
+        }
+    }
+
+    private static Path artifactDir(ExtensionContext context) {
+        String className = context.getRequiredTestClass().getSimpleName();
+        String methodName = context.getRequiredTestMethod().getName();
+        return Path.of("target", "playwright-artifacts", className, methodName);
+    }
+}

--- a/src/test/java/com/stucray/limen/ui/support/TestTenantFactory.java
+++ b/src/test/java/com/stucray/limen/ui/support/TestTenantFactory.java
@@ -1,0 +1,78 @@
+package com.stucray.limen.ui.support;
+
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantProvisioningService;
+import com.stucray.limen.user.User;
+import com.stucray.limen.user.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Single source of truth for "give me a fresh tenant" across UI tests.
+ *
+ * <p>Each call seeds a uniquely-named tenant with one admin (owner) and one end user,
+ * so concurrent tests cannot collide on slug/username and no teardown is needed —
+ * the Testcontainers Postgres is discarded at JVM exit.
+ *
+ * <p>Goes through real service-layer code ({@link TenantProvisioningService} +
+ * {@link UserRepository} + {@link PasswordEncoder}) rather than raw SQL, so test
+ * preconditions exercise the same code paths production uses.
+ */
+@Component
+public class TestTenantFactory {
+
+    private static final String SHARED_TEST_PASSWORD = "secret123";
+
+    private final TenantProvisioningService tenantProvisioningService;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public TestTenantFactory(
+        TenantProvisioningService tenantProvisioningService,
+        UserRepository userRepository,
+        PasswordEncoder passwordEncoder
+    ) {
+        this.tenantProvisioningService = tenantProvisioningService;
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Transactional
+    public SeededTenant createTenant() {
+        String suffix = uniqueSuffix();
+        String slug = "t-" + suffix;
+        String displayName = "Test Org " + suffix;
+        String adminUsername = "admin-" + suffix;
+        String endUserUsername = "user-" + suffix;
+
+        Tenant tenant = tenantProvisioningService.createTenant(slug, displayName);
+        String hash = passwordEncoder.encode(SHARED_TEST_PASSWORD);
+        userRepository.save(new User(
+            null, tenant.id(), adminUsername, hash, true, false, true, LocalDateTime.now()));
+        userRepository.save(new User(
+            null, tenant.id(), endUserUsername, hash, true, false, false, LocalDateTime.now()));
+
+        return new SeededTenant(
+            tenant.id(), slug, displayName,
+            adminUsername, SHARED_TEST_PASSWORD,
+            endUserUsername, SHARED_TEST_PASSWORD);
+    }
+
+    private static String uniqueSuffix() {
+        return UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+    }
+
+    public record SeededTenant(
+        Long tenantId,
+        String slug,
+        String displayName,
+        String adminUsername,
+        String adminPassword,
+        String endUserUsername,
+        String endUserPassword
+    ) {}
+}


### PR DESCRIPTION
## Summary

Closes #97. First slice of PRD #96.

This PR is **HITL** — review focus is on whether the harness shape is correct (page object pattern, factory shape, locator conventions, JUnit extension lifecycle, trace/screenshot artifact path, CI wiring). Once these patterns are accepted, the 10 follow-up journey PRs (#98 / #99 / #100 / #101 / #102 / #103 / #104 / #105 / #106 / #107) all follow the same shape.

### What landed

**Build + CI**
- Playwright Java 1.50.0 added as `<scope>test</scope>`.
- `maven-failsafe-plugin` 3.5.4 wired to `integration-test` + `verify`, `**/*UiIT.java` include pattern, same `LIMEN_SECURITY_KEK` env as Surefire.
- `ci.yml`: cache `~/.cache/ms-playwright` keyed on `hashFiles('pom.xml')` with prefix restore-keys; upload `target/playwright-artifacts/` on failure (14-day retention). No workflow trigger changes (`mvn verify` already runs in CI).

**Harness modules** (under `com.stucray.limen.ui.support`)
- `PlaywrightExtension` — JUnit 5 extension. One Playwright + Browser per JVM (lazy + shutdown hook); fresh `BrowserContext` per test; tracing always-on, persisted only on failure; screenshot only on failure; artifacts under `target/playwright-artifacts/<TestClass>/<testMethod>/`. Test-id attribute set to `data-test-action`. Headless by default; `-Dplaywright.headless=false` enables headed locally.
- `BaseUiIT` — `@SpringBootTest(RANDOM_PORT)` + existing `TestcontainersConfiguration` + the extension. Tests get `Page` via parameter injection.
- `TestTenantFactory` — uniquely-suffixed tenant + admin + end-user via real services (`TenantProvisioningService` + `UserRepository` + `PasswordEncoder`). Returns a `SeededTenant` value record. `@Transactional` so the data is committed before Playwright drives the browser.
- `LoginPageObject` — `loginAsTenantAdmin` / `loginAsEndUser` / `loginAsSystemAdmin` helpers wired but only `loginAsTenantAdmin` referenced indirectly via the signup redirect target. The `data-test-action` attributes for the per-role submit buttons land with the slices that consume them.

**Page objects** (one per template; package mirrors `templates/`)
- `LandingPage` (`templates/landing.html`)
- `SignupPage` (`templates/signup.html`)
- `pages.manage.ManageLoginPage` (`templates/manage/login.html`)

**Templates touched** (smallest possible footprint per PRD)
- `landing.html` — `data-test-action="landing-signup"` on the Sign up link.
- `signup.html` — `data-test-action="signup-submit"` on the form submit.

**Journey** (`SignupJourneyUiIT`)
- A visitor lands on `/`, follows Sign up, submits a unique form, asserts on browser-visible state of the resulting `/manage/t/{slug}/login?registered`: "Sign in" heading, tenant display name shown, "Account created — please sign in." banner visible.
- No backend assertions. No DB queries. Class-level `@DisplayName` per the project convention.

### Note for reviewers

The PRD originally stated the signup journey lands on "the resulting authenticated home page." Reality: signup redirects to the tenant login page with a `?registered` banner, then the user logs in separately. The journey here is correctly scoped to "signup → arrival at the registered-banner login page" — end-user login is its own journey (#98), and combining them into one test would conflate two slices.

## Test plan

- [x] `./mvnw verify` is green locally (43 Surefire test classes + 1 Failsafe UI test class)
- [x] `./mvnw -Dit.test=SignupJourneyUiIT verify` is green locally
- [x] `./mvnw verify -Dplaywright.headless=false` runs the journey headed (manual local check)
- [ ] CI run on this PR is green
- [ ] Trace + screenshot artifact upload verified by deliberately failing the test on a follow-up commit, then reverting before merge