### PR TITLE
UI testing slice 1.3: tenant admin login + manage console home

### DIFF
--- a/src/main/resources/templates/manage/login.html
+++ b/src/main/resources/templates/manage/login.html
@@ -22,7 +22,7 @@
                 Password
                 <input type="password" name="password" required/>
             </label>
-            <button type="submit" class="btn--block">Sign in</button>
+            <button type="submit" class="btn--block" data-test-action="manage-login-submit">Sign in</button>
         </form>
     </article>
 </main>

--- a/src/test/java/com/stucray/limen/ui/journey/TenantAdminLoginJourneyUiIT.java
+++ b/src/test/java/com/stucray/limen/ui/journey/TenantAdminLoginJourneyUiIT.java
@@ -1,0 +1,26 @@
+package com.stucray.limen.ui.journey;
+
+import com.microsoft.playwright.Page;
+import com.stucray.limen.ui.pages.manage.ManageHomePage;
+import com.stucray.limen.ui.support.BaseUiIT;
+import com.stucray.limen.ui.support.LoginPageObject;
+import com.stucray.limen.ui.support.TestTenantFactory.SeededTenant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("A tenant administrator can sign in to the management console")
+class TenantAdminLoginJourneyUiIT extends BaseUiIT {
+
+    @Test
+    @DisplayName("happy path: signs in at /manage/t/{slug}/login and lands on the manage console home with tenant identity, welcome line, and admin nav tiles")
+    void happyPath(Page page) {
+        SeededTenant tenant = tenants.createTenant();
+
+        new LoginPageObject(page, baseUrl()).loginAsTenantAdmin(tenant);
+
+        new ManageHomePage(page, baseUrl(), tenant.slug())
+            .assertOnHomeForTenant(tenant.displayName())
+            .assertWelcomeForUser(tenant.adminUsername())
+            .assertTenantAdminNavTilesVisible();
+    }
+}

--- a/src/test/java/com/stucray/limen/ui/pages/manage/ManageHomePage.java
+++ b/src/test/java/com/stucray/limen/ui/pages/manage/ManageHomePage.java
@@ -1,0 +1,43 @@
+package com.stucray.limen.ui.pages.manage;
+
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.assertions.PlaywrightAssertions;
+import com.microsoft.playwright.options.AriaRole;
+
+public final class ManageHomePage {
+
+    private final Page page;
+    private final String baseUrl;
+    private final String slug;
+
+    public ManageHomePage(Page page, String baseUrl, String slug) {
+        this.page = page;
+        this.baseUrl = baseUrl;
+        this.slug = slug;
+    }
+
+    public ManageHomePage assertOnHomeForTenant(String tenantDisplayName) {
+        PlaywrightAssertions.assertThat(
+            page.getByRole(AriaRole.HEADING, new Page.GetByRoleOptions().setName(tenantDisplayName))
+        ).isVisible();
+        return this;
+    }
+
+    public ManageHomePage assertWelcomeForUser(String username) {
+        PlaywrightAssertions.assertThat(page.getByText("Welcome, " + username)).isVisible();
+        return this;
+    }
+
+    public ManageHomePage assertTenantAdminNavTilesVisible() {
+        PlaywrightAssertions.assertThat(
+            page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName("Users"))
+        ).isVisible();
+        PlaywrightAssertions.assertThat(
+            page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName("Applications"))
+        ).isVisible();
+        PlaywrightAssertions.assertThat(
+            page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName("Tenant Settings"))
+        ).isVisible();
+        return this;
+    }
+}


### PR DESCRIPTION
Closes #99 (slice 1.3 of PRD #96).

## Summary

- New `TenantAdminLoginJourneyUiIT` drives `LoginPageObject.loginAsTenantAdmin` end-to-end against a freshly-seeded tenant and asserts on `manage/home.html` (tenant heading, welcome line, admin nav tiles for Users / Applications / Tenant Settings).
- New `ManageHomePage` page object — the shared landing surface for the manage CRUD slices (#102/#103/#104/#105).
- Adds `data-test-action="manage-login-submit"` to `manage/login.html`. Slice 1.1 wired `LoginPageObject.loginAsTenantAdmin` but deferred the attribute to the slice that consumes it.

Asserts only on browser-visible state — no DB queries, no `@Autowired` repositories.

## Test plan

- [x] `./mvnw verify -Dit.test=TenantAdminLoginJourneyUiIT` passes locally
- [x] Full `./mvnw verify` passes locally (Surefire + Failsafe, 2 UI tests)
- [ ] CI green