### PR TITLE
UI testing slice 1.9: system admin login + tenants list

### DIFF
--- a/src/test/java/com/stucray/limen/ui/journey/SystemAdminTenantsJourneyUiIT.java
+++ b/src/test/java/com/stucray/limen/ui/journey/SystemAdminTenantsJourneyUiIT.java
@@ -1,0 +1,29 @@
+package com.stucray.limen.ui.journey;
+
+import com.microsoft.playwright.Page;
+import com.stucray.limen.ui.pages.manage.system.SystemTenantsListPage;
+import com.stucray.limen.ui.support.BaseUiIT;
+import com.stucray.limen.ui.support.LoginPageObject;
+import com.stucray.limen.ui.support.TestTenantFactory.SeededSystemAdmin;
+import com.stucray.limen.ui.support.TestTenantFactory.SeededTenant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("A system administrator can sign in and view the tenants list")
+class SystemAdminTenantsJourneyUiIT extends BaseUiIT {
+
+    @Test
+    @DisplayName("happy path: sysadmin signs in at /manage/t/system/login and the seeded tenant slug appears in the tenants list")
+    void happyPath(Page page) {
+        SeededTenant seeded = tenants.createTenant();
+        SeededSystemAdmin admin = tenants.createSystemAdmin();
+
+        new LoginPageObject(page, baseUrl())
+            .loginAsSystemAdmin(admin.username(), admin.password());
+
+        new SystemTenantsListPage(page, baseUrl())
+            .visit()
+            .assertOnTenantsList()
+            .assertTenantSlugVisible(seeded.slug());
+    }
+}

--- a/src/test/java/com/stucray/limen/ui/pages/manage/system/SystemTenantsListPage.java
+++ b/src/test/java/com/stucray/limen/ui/pages/manage/system/SystemTenantsListPage.java
@@ -1,0 +1,33 @@
+package com.stucray.limen.ui.pages.manage.system;
+
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.assertions.PlaywrightAssertions;
+import com.microsoft.playwright.options.AriaRole;
+
+public final class SystemTenantsListPage {
+
+    private final Page page;
+    private final String baseUrl;
+
+    public SystemTenantsListPage(Page page, String baseUrl) {
+        this.page = page;
+        this.baseUrl = baseUrl;
+    }
+
+    public SystemTenantsListPage visit() {
+        page.navigate(baseUrl + "/manage/system/tenants");
+        return this;
+    }
+
+    public SystemTenantsListPage assertOnTenantsList() {
+        PlaywrightAssertions.assertThat(
+            page.getByRole(AriaRole.HEADING, new Page.GetByRoleOptions().setName("Tenants"))
+        ).isVisible();
+        return this;
+    }
+
+    public SystemTenantsListPage assertTenantSlugVisible(String slug) {
+        PlaywrightAssertions.assertThat(page.getByText(slug)).isVisible();
+        return this;
+    }
+}

--- a/src/test/java/com/stucray/limen/ui/support/TestTenantFactory.java
+++ b/src/test/java/com/stucray/limen/ui/support/TestTenantFactory.java
@@ -2,6 +2,7 @@ package com.stucray.limen.ui.support;
 
 import com.stucray.limen.tenant.Tenant;
 import com.stucray.limen.tenant.TenantProvisioningService;
+import com.stucray.limen.tenant.TenantRepository;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -28,15 +29,18 @@ public class TestTenantFactory {
     private static final String SHARED_TEST_PASSWORD = "secret123";
 
     private final TenantProvisioningService tenantProvisioningService;
+    private final TenantRepository tenantRepository;
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
     public TestTenantFactory(
         TenantProvisioningService tenantProvisioningService,
+        TenantRepository tenantRepository,
         UserRepository userRepository,
         PasswordEncoder passwordEncoder
     ) {
         this.tenantProvisioningService = tenantProvisioningService;
+        this.tenantRepository = tenantRepository;
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
     }
@@ -62,6 +66,18 @@ public class TestTenantFactory {
             endUserUsername, SHARED_TEST_PASSWORD);
     }
 
+    @Transactional
+    public SeededSystemAdmin createSystemAdmin() {
+        String suffix = uniqueSuffix();
+        String username = "sysadmin-" + suffix;
+        Tenant systemTenant = tenantRepository.findBySlug("system")
+            .orElseThrow(() -> new IllegalStateException("system tenant not bootstrapped"));
+        String hash = passwordEncoder.encode(SHARED_TEST_PASSWORD);
+        userRepository.save(new User(
+            null, systemTenant.id(), username, hash, true, false, false, LocalDateTime.now()));
+        return new SeededSystemAdmin(username, SHARED_TEST_PASSWORD);
+    }
+
     private static String uniqueSuffix() {
         return UUID.randomUUID().toString().replace("-", "").substring(0, 8);
     }
@@ -75,4 +91,6 @@ public class TestTenantFactory {
         String endUserUsername,
         String endUserPassword
     ) {}
+
+    public record SeededSystemAdmin(String username, String password) {}
 }


### PR DESCRIPTION
Closes #101 (slice 1.9 of PRD #96).

## Summary

- New `SystemAdminTenantsJourneyUiIT` drives `LoginPageObject.loginAsSystemAdmin` end-to-end. Seeds a tenant via `TestTenantFactory`, signs in at `/manage/t/system/login`, navigates to `/manage/system/tenants`, and asserts the seeded tenant's slug renders in the list.
- New `SystemTenantsListPage` page object at `pages/manage/system/`.
- `TestTenantFactory.createSystemAdmin()` returns a uniquely-named system admin (`sysadmin-<suffix>`) attached to the bootstrap-created system tenant, so concurrent UI tests can't collide on the username.

No `data-test-action` attributes added — the page is visibility-only for this slice (no clicks). Tenant slugs render as `<code th:text="..."/>`, locatable via `getByText`.

## Test plan

- [x] `./mvnw verify -Dit.test=SystemAdminTenantsJourneyUiIT` passes locally
- [x] Full `./mvnw verify` passes locally
- [ ] CI green