### PR TITLE
Add minimal end-user home page at /t/{slug}/ (unblocks UI testing slice #98)

### DIFF
--- a/src/main/java/com/stucray/limen/enduser/web/EndUserHomeController.java
+++ b/src/main/java/com/stucray/limen/enduser/web/EndUserHomeController.java
@@ -1,0 +1,24 @@
+package com.stucray.limen.enduser.web;
+
+import com.stucray.limen.auth.TenantUserDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Controller
+public class EndUserHomeController {
+
+    @GetMapping("/t/{slug}/")
+    public String home(
+        @PathVariable String slug,
+        @AuthenticationPrincipal TenantUserDetails principal,
+        Model model
+    ) {
+        model.addAttribute("slug", slug);
+        model.addAttribute("tenantName", principal.tenant().displayName());
+        model.addAttribute("username", principal.displayUsername());
+        return "t/home";
+    }
+}

--- a/src/main/java/com/stucray/limen/oauth2/OAuth2LoginSecurityConfig.java
+++ b/src/main/java/com/stucray/limen/oauth2/OAuth2LoginSecurityConfig.java
@@ -6,18 +6,24 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
- * SecurityFilterChain for the OAuth2 end-user login surface (/t/*&#47;login,
- * /t/*&#47;change-password). Sits between the SAS chain (HIGHEST_PRECEDENCE) and
- * the management chain (Order 2). Form-login wiring is delegated to {@link TenantLogin};
+ * SecurityFilterChain for the end-user tenant surface ({@code /t/**}): login,
+ * change-password, post-login home, and logout. Sits between the SAS chain
+ * (HIGHEST_PRECEDENCE, which still claims {@code /t/*&#47;oauth2/...}) and the
+ * management chain (Order 2). Form-login wiring is delegated to {@link TenantLogin};
  * everything left here is distinctive to this surface (URL scope, CSRF, request cache,
- * tenant-aware entry point).
+ * tenant-aware entry point, logout).
  */
 @Configuration
 @Order(1)
@@ -37,11 +43,12 @@ public class OAuth2LoginSecurityConfig {
     @Bean
     public SecurityFilterChain oauth2LoginFilterChain(HttpSecurity http) throws Exception {
         HttpSessionRequestCache requestCache = new HttpSessionRequestCache();
+        Pattern logoutSlugPattern = Pattern.compile(".*/t/([^/]+)/logout$");
 
         login.applyTo(http, oauth2UrlScheme);
 
         http
-            .securityMatcher("/t/*/login", "/t/*/change-password")
+            .securityMatcher("/t/**")
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/t/*/login").permitAll()
                 .anyRequest().authenticated()
@@ -50,6 +57,18 @@ public class OAuth2LoginSecurityConfig {
             .exceptionHandling(ex -> ex.authenticationEntryPoint(
                 TenantLoginUrlAuthenticationEntryPoint.fromUrl()
             ))
+            .logout(logout -> logout
+                .logoutRequestMatcher(PathPatternRequestMatcher.withDefaults()
+                    .matcher(HttpMethod.POST, "/t/*/logout"))
+                .logoutSuccessHandler((req, res, auth) -> {
+                    String redirectUrl = "/";
+                    Matcher m = logoutSlugPattern.matcher(req.getRequestURI());
+                    if (m.matches()) redirectUrl = "/t/" + m.group(1) + "/login";
+                    res.sendRedirect(redirectUrl);
+                })
+                .deleteCookies("JSESSIONID", "remember-me")
+                .invalidateHttpSession(true)
+            )
             .csrf(csrf -> csrf
                 .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
                 .csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler())

--- a/src/main/resources/templates/t/home.html
+++ b/src/main/resources/templates/t/home.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{fragments/layout :: layout(~{::title}, ~{::main})}">
+<head><title th:text="|${tenantName} — Limen|">Limen</title></head>
+<body>
+<main class="container">
+    <hgroup>
+        <h1 th:text="${tenantName}">Tenant</h1>
+        <p>Signed in as <span th:text="${username}">user</span>.</p>
+    </hgroup>
+    <form method="post" th:action="@{/t/{slug}/logout(slug=${slug})}">
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+        <button type="submit" class="btn--ghost">Sign out</button>
+    </form>
+</main>
+</body>
+</html>

--- a/src/test/java/com/stucray/limen/enduser/EndUserHomeIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/enduser/EndUserHomeIntegrationTest.java
@@ -1,0 +1,142 @@
+package com.stucray.limen.enduser;
+
+import com.stucray.limen.TestcontainersConfiguration;
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.tenant.TenantStatus;
+import com.stucray.limen.user.User;
+import com.stucray.limen.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.LocalDateTime;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@DisplayName("End-user surface: post-login home page at /t/{slug}/")
+class EndUserHomeIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired TenantRepository tenantRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired PasswordEncoder passwordEncoder;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    Tenant testTenant;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.execute("DELETE FROM client_membership");
+        jdbcTemplate.execute("DELETE FROM application_membership_role");
+        jdbcTemplate.execute("DELETE FROM application_membership");
+        jdbcTemplate.execute("DELETE FROM role");
+        jdbcTemplate.execute("DELETE FROM oauth2_registered_client WHERE application_id IS NOT NULL");
+        jdbcTemplate.execute("DELETE FROM applications");
+        jdbcTemplate.execute("DELETE FROM users");
+        jdbcTemplate.execute("DELETE FROM tenants WHERE slug != 'system'");
+        jdbcTemplate.execute("DELETE FROM persistent_logins");
+
+        testTenant = tenantRepository.save(new Tenant(
+            null, "alpha-corp", "Alpha Corp", TenantStatus.ACTIVE, LocalDateTime.now()
+        ));
+        userRepository.save(new User(
+            null, testTenant.id(), "alice",
+            passwordEncoder.encode("password"),
+            true, false, false, LocalDateTime.now()
+        ));
+    }
+
+    @Test
+    @DisplayName("Successful end-user login redirects to /t/{slug}/")
+    void successfulLoginRedirectsToHome() throws Exception {
+        mockMvc.perform(post("/t/alpha-corp/login")
+                .param("username", "alice")
+                .param("password", "password")
+                .with(csrf()))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/t/alpha-corp/"));
+    }
+
+    @Test
+    @DisplayName("Unauthenticated GET /t/{slug}/ is redirected to that tenant's login page")
+    void unauthenticatedAccessRedirectsToLogin() throws Exception {
+        mockMvc.perform(get("/t/alpha-corp/"))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/t/alpha-corp/login"));
+    }
+
+    @Test
+    @DisplayName("Authenticated end user can GET /t/{slug}/ and sees the tenant display name plus their username")
+    void authenticatedUserCanAccessHome() throws Exception {
+        MvcResult loginResult = mockMvc.perform(post("/t/alpha-corp/login")
+                .param("username", "alice")
+                .param("password", "password")
+                .with(csrf()))
+            .andReturn();
+
+        MockHttpSession session = (MockHttpSession) loginResult.getRequest().getSession(false);
+
+        mockMvc.perform(get("/t/alpha-corp/").session(session))
+            .andExpect(status().isOk())
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("Alpha Corp")))
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("alice")));
+    }
+
+    @Test
+    @DisplayName("Cross-tenant access: TenantAccessFilter force-logs out and redirects to the URL slug's login page")
+    void crossTenantAccessIsBlocked() throws Exception {
+        MvcResult loginResult = mockMvc.perform(post("/t/alpha-corp/login")
+                .param("username", "alice")
+                .param("password", "password")
+                .with(csrf()))
+            .andReturn();
+
+        MockHttpSession session = (MockHttpSession) loginResult.getRequest().getSession(false);
+
+        tenantRepository.save(new Tenant(
+            null, "beta-corp", "Beta Corp", TenantStatus.ACTIVE, LocalDateTime.now()
+        ));
+
+        mockMvc.perform(get("/t/beta-corp/").session(session))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/t/beta-corp/login"));
+    }
+
+    @Test
+    @DisplayName("POST /t/{slug}/logout invalidates the session and redirects to that tenant's login page")
+    void logoutInvalidatesSessionAndRedirects() throws Exception {
+        MvcResult loginResult = mockMvc.perform(post("/t/alpha-corp/login")
+                .param("username", "alice")
+                .param("password", "password")
+                .with(csrf()))
+            .andReturn();
+
+        MockHttpSession session = (MockHttpSession) loginResult.getRequest().getSession(false);
+
+        mockMvc.perform(post("/t/alpha-corp/logout").session(session).with(csrf()))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/t/alpha-corp/login"));
+
+        mockMvc.perform(get("/t/alpha-corp/").session(session))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/t/alpha-corp/login"));
+    }
+}


### PR DESCRIPTION
## Summary
Closes the documented \"403-after-direct-login\" gap on the end-user surface: `TenantLoginAutoConfig.oauth2UrlScheme` already declares `/t/{slug}/` as the post-login redirect target, but no controller mapped that path. An end user authenticating at `/t/{slug}/login` was redirected to `/t/{slug}/` and bounced to a 403 by `DefaultSecurityConfig`'s catchall. This PR adds the missing home and widens the OAuth2 filter chain to cover the broader end-user surface.

This is a separate PR from any UI-testing slice on purpose: the design call (\"should standalone end-user login have a home at all?\") got its own discussion before any test slice is allowed to assume a UI exists. The chosen stance was option (a) — minimal landing page now, future surface (profile, your-apps, etc.) can grow on top.

## Changes
- **`EndUserHomeController`** — `@GetMapping(\"/t/{slug}/\")` reads `@AuthenticationPrincipal TenantUserDetails`, passes `slug`, `tenantName`, `username` to a `t/home` view. Mirrors `ManagementHomeController`.
- **`templates/t/home.html`** — minimal page extending the simple `fragments/layout` shell (same one used by `login.html`). Contains the tenant name, \"Signed in as {user}\", and a sign-out form. Avoids reusing `fragments/layout-authed` because that fragment hard-codes its sign-out form to `/manage/logout`.
- **`OAuth2LoginSecurityConfig`** — `securityMatcher` widened from `(\"/t/*/login\",\"/t/*/change-password\")` to `(\"/t/**\")`; added a `.logout()` config matching POST `/t/*/logout` that invalidates session + remember-me and redirects to the same tenant's login page. The SAS chain (`HIGHEST_PRECEDENCE`) still claims `/t/{slug}/oauth2/...`, so this widening only catches the form-login surface.
- Cross-tenant defence-in-depth is **free**: `TenantAccessFilter` is already installed by `TenantLogin.applyTo()` and uses the registered `oauth2UrlScheme` to force-logout + redirect any authenticated session whose principal slug differs from the URL slug.

## Test plan
- [x] `EndUserHomeIntegrationTest` covers: happy-path login redirect to `/t/{slug}/`; authenticated GET returns 200 with tenant name + username visible; unauthenticated GET redirects to `/t/{slug}/login`; cross-tenant access force-logs out and redirects to the URL slug's login; POST `/t/{slug}/logout` invalidates the session and redirects.
- [x] Full Surefire suite (292 tests, including all OAuth2 + management chain tests) green locally.
- [ ] CI green.

## Why this matters / what it unblocks
The UI-testing PRD (issue #96) had three slices stuck behind this gap:
- #98 (end-user login journey)
- #106 (forced password change)
- #107 (OAuth2 authorize flow)

All three assert on landing at `/t/{slug}/` post-login. With this PR merged, those slices become mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)