### PR TITLE
UI testing slice 1.2: end-user login + post-login home (#98)

### DIFF
--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -22,7 +22,7 @@
                 <input type="checkbox" name="remember-me"/>
                 Remember me for 14 days
             </label>
-            <button type="submit" class="btn--block">Sign in</button>
+            <button type="submit" class="btn--block" data-test-action="login-submit">Sign in</button>
         </form>
     </article>
 </main>

--- a/src/test/java/com/stucray/limen/ui/journey/EndUserLoginJourneyUiIT.java
+++ b/src/test/java/com/stucray/limen/ui/journey/EndUserLoginJourneyUiIT.java
@@ -1,0 +1,25 @@
+package com.stucray.limen.ui.journey;
+
+import com.microsoft.playwright.Page;
+import com.stucray.limen.ui.pages.enduser.EndUserHomePage;
+import com.stucray.limen.ui.support.BaseUiIT;
+import com.stucray.limen.ui.support.LoginPageObject;
+import com.stucray.limen.ui.support.TestTenantFactory.SeededTenant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("An end user can sign in to their tenant via /t/{slug}/login")
+class EndUserLoginJourneyUiIT extends BaseUiIT {
+
+    @Test
+    @DisplayName("happy path: signs in at /t/{slug}/login and lands on the end-user home with tenant identity and a 'Signed in as ...' line")
+    void happyPath(Page page) {
+        SeededTenant tenant = tenants.createTenant();
+
+        new LoginPageObject(page, baseUrl()).loginAsEndUser(tenant);
+
+        new EndUserHomePage(page, baseUrl(), tenant.slug())
+            .assertOnHomeForTenant(tenant.displayName())
+            .assertSignedInAs(tenant.endUserUsername());
+    }
+}

--- a/src/test/java/com/stucray/limen/ui/pages/enduser/EndUserHomePage.java
+++ b/src/test/java/com/stucray/limen/ui/pages/enduser/EndUserHomePage.java
@@ -1,0 +1,30 @@
+package com.stucray.limen.ui.pages.enduser;
+
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.assertions.PlaywrightAssertions;
+import com.microsoft.playwright.options.AriaRole;
+
+public final class EndUserHomePage {
+
+    private final Page page;
+    private final String baseUrl;
+    private final String slug;
+
+    public EndUserHomePage(Page page, String baseUrl, String slug) {
+        this.page = page;
+        this.baseUrl = baseUrl;
+        this.slug = slug;
+    }
+
+    public EndUserHomePage assertOnHomeForTenant(String tenantDisplayName) {
+        PlaywrightAssertions.assertThat(
+            page.getByRole(AriaRole.HEADING, new Page.GetByRoleOptions().setName(tenantDisplayName))
+        ).isVisible();
+        return this;
+    }
+
+    public EndUserHomePage assertSignedInAs(String username) {
+        PlaywrightAssertions.assertThat(page.getByText("Signed in as " + username)).isVisible();
+        return this;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `EndUserLoginJourneyUiIT` — Playwright journey covering happy-path end-user login at `/t/{slug}/login` and the post-login landing at `/t/{slug}/`.
- New `EndUserHomePage` page object under `ui/pages/enduser/` with `assertOnHomeForTenant` + `assertSignedInAs`, matching the `ManageHomePage` shape established in slice 1.3.
- Adds `data-test-action=\"login-submit\"` to `templates/login.html` (the consuming slice landing the attribute, per slice-1.1 convention).

Closes #98. Unblocked by the end-user home page that shipped in PR #111.

## Test plan
- [x] `./mvnw verify -Dit.test=EndUserLoginJourneyUiIT` green locally.
- [x] Full Surefire (292) + Failsafe suites green locally.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)