### PR TITLE
UI testing slice 1.8: landing page slug forwarder (#100)

### DIFF
--- a/src/main/resources/templates/landing.html
+++ b/src/main/resources/templates/landing.html
@@ -16,7 +16,7 @@
                 Organization slug
                 <input type="text" name="slug" placeholder="acme"/>
             </label>
-            <button type="submit" class="btn--block">Continue</button>
+            <button type="submit" class="btn--block" data-test-action="landing-continue">Continue</button>
         </form>
     </article>
 

--- a/src/test/java/com/stucray/limen/ui/journey/LandingForwarderJourneyUiIT.java
+++ b/src/test/java/com/stucray/limen/ui/journey/LandingForwarderJourneyUiIT.java
@@ -1,0 +1,24 @@
+package com.stucray.limen.ui.journey;
+
+import com.microsoft.playwright.Page;
+import com.stucray.limen.ui.pages.LandingPage;
+import com.stucray.limen.ui.support.BaseUiIT;
+import com.stucray.limen.ui.support.TestTenantFactory.SeededTenant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("A visitor entering a tenant slug on the landing page is forwarded to that tenant's login")
+class LandingForwarderJourneyUiIT extends BaseUiIT {
+
+    @Test
+    @DisplayName("happy path: typing a slug at / and submitting lands on /manage/t/{slug}/login with the tenant display name visible")
+    void happyPath(Page page) {
+        SeededTenant tenant = tenants.createTenant();
+
+        new LandingPage(page, baseUrl())
+            .visit()
+            .fillSlug(tenant.slug())
+            .clickContinue(tenant.slug())
+            .assertOnLoginForTenant(tenant.displayName());
+    }
+}

--- a/src/test/java/com/stucray/limen/ui/pages/LandingPage.java
+++ b/src/test/java/com/stucray/limen/ui/pages/LandingPage.java
@@ -1,6 +1,7 @@
 package com.stucray.limen.ui.pages;
 
 import com.microsoft.playwright.Page;
+import com.stucray.limen.ui.pages.manage.ManageLoginPage;
 
 public final class LandingPage {
 
@@ -20,5 +21,16 @@ public final class LandingPage {
     public SignupPage clickSignUp() {
         page.getByTestId("landing-signup").click();
         return new SignupPage(page, baseUrl);
+    }
+
+    public LandingPage fillSlug(String slug) {
+        page.getByLabel("Organization slug").fill(slug);
+        return this;
+    }
+
+    public ManageLoginPage clickContinue(String slug) {
+        page.getByTestId("landing-continue").click();
+        page.waitForURL(baseUrl + "/manage/t/" + slug + "/login");
+        return new ManageLoginPage(page, baseUrl, slug);
     }
 }


### PR DESCRIPTION
## Summary
- New `LandingForwarderJourneyUiIT`: visitor lands on `/`, types a tenant slug, submits, and lands on the tenant's management login with the display name visible.
- Extends `LandingPage` with `fillSlug()` + `clickContinue(slug)` (the latter `waitForURL`s the management-login redirect and returns a typed `ManageLoginPage`).
- Adds \`data-test-action=\"landing-continue\"\` to \`templates/landing.html\`.

Closes #100.

## Note on contract
The issue text says the forwarder routes to \`/t/{slug}/login\`, but the actual implementation (\`RedirectLoginController\`) redirects to \`/manage/t/{slug}/login\`. The test asserts on the real contract — \"browser-visible state\" is the source of truth per the PRD.

## Test plan
- [x] \`./mvnw verify -Dit.test=LandingForwarderJourneyUiIT\` green locally.
- [x] Full Surefire (292) + Failsafe suites green locally.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)