### PR TITLE
UI testing slice 1.4: create application (#102)

### DIFF
--- a/src/main/resources/templates/manage/applications/list.html
+++ b/src/main/resources/templates/manage/applications/list.html
@@ -13,7 +13,7 @@
             <h1>Applications</h1>
             <p>Application registrations and their roles, clients, and members.</p>
         </hgroup>
-        <a th:href="@{'/manage/t/' + ${slug} + '/applications/new'}" class="btn">New application</a>
+        <a th:href="@{'/manage/t/' + ${slug} + '/applications/new'}" class="btn" data-test-action="apps-new">New application</a>
     </div>
 
     <p class="form-error" th:if="${errorMessage}" th:text="${errorMessage}"></p>

--- a/src/main/resources/templates/manage/applications/new.html
+++ b/src/main/resources/templates/manage/applications/new.html
@@ -27,7 +27,7 @@
             <textarea name="description" th:text="${description}"></textarea>
         </label>
         <div class="form-actions">
-            <button type="submit">Create</button>
+            <button type="submit" data-test-action="apps-create-submit">Create</button>
             <a th:href="@{'/manage/t/' + ${slug} + '/applications'}" class="btn btn--secondary">Cancel</a>
         </div>
     </form>

--- a/src/test/java/com/stucray/limen/ui/journey/ManageApplicationsCreateJourneyUiIT.java
+++ b/src/test/java/com/stucray/limen/ui/journey/ManageApplicationsCreateJourneyUiIT.java
@@ -1,0 +1,35 @@
+package com.stucray.limen.ui.journey;
+
+import com.microsoft.playwright.Page;
+import com.stucray.limen.ui.pages.manage.ManageHomePage;
+import com.stucray.limen.ui.support.BaseUiIT;
+import com.stucray.limen.ui.support.LoginPageObject;
+import com.stucray.limen.ui.support.TestTenantFactory.SeededTenant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+@DisplayName("A tenant administrator can create an application via the manage console")
+class ManageApplicationsCreateJourneyUiIT extends BaseUiIT {
+
+    @Test
+    @DisplayName("happy path: from the manage home, navigates to Applications, fills the new-application form, submits, and the new app appears in the list")
+    void happyPath(Page page) {
+        SeededTenant tenant = tenants.createTenant();
+        String appName = "App " + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+
+        new LoginPageObject(page, baseUrl()).loginAsTenantAdmin(tenant);
+
+        new ManageHomePage(page, baseUrl(), tenant.slug())
+            .clickApplications()
+            .assertOnList()
+            .clickNewApplication()
+            .assertOnForm()
+            .fillName(appName)
+            .fillDescription("Created from a Playwright test.")
+            .submit()
+            .assertOnList()
+            .assertApplicationVisible(appName);
+    }
+}

--- a/src/test/java/com/stucray/limen/ui/pages/manage/ManageHomePage.java
+++ b/src/test/java/com/stucray/limen/ui/pages/manage/ManageHomePage.java
@@ -3,6 +3,7 @@ package com.stucray.limen.ui.pages.manage;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.assertions.PlaywrightAssertions;
 import com.microsoft.playwright.options.AriaRole;
+import com.stucray.limen.ui.pages.manage.applications.ManageApplicationsListPage;
 
 public final class ManageHomePage {
 
@@ -14,6 +15,12 @@ public final class ManageHomePage {
         this.page = page;
         this.baseUrl = baseUrl;
         this.slug = slug;
+    }
+
+    public ManageApplicationsListPage clickApplications() {
+        page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName("Applications")).click();
+        page.waitForURL(baseUrl + "/manage/t/" + slug + "/applications");
+        return new ManageApplicationsListPage(page, baseUrl, slug);
     }
 
     public ManageHomePage assertOnHomeForTenant(String tenantDisplayName) {

--- a/src/test/java/com/stucray/limen/ui/pages/manage/applications/ManageApplicationsListPage.java
+++ b/src/test/java/com/stucray/limen/ui/pages/manage/applications/ManageApplicationsListPage.java
@@ -1,0 +1,38 @@
+package com.stucray.limen.ui.pages.manage.applications;
+
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.assertions.PlaywrightAssertions;
+import com.microsoft.playwright.options.AriaRole;
+
+public final class ManageApplicationsListPage {
+
+    private final Page page;
+    private final String baseUrl;
+    private final String slug;
+
+    public ManageApplicationsListPage(Page page, String baseUrl, String slug) {
+        this.page = page;
+        this.baseUrl = baseUrl;
+        this.slug = slug;
+    }
+
+    public ManageApplicationsListPage assertOnList() {
+        PlaywrightAssertions.assertThat(
+            page.getByRole(AriaRole.HEADING, new Page.GetByRoleOptions().setName("Applications"))
+        ).isVisible();
+        return this;
+    }
+
+    public ManageApplicationsNewPage clickNewApplication() {
+        page.getByTestId("apps-new").click();
+        page.waitForURL(baseUrl + "/manage/t/" + slug + "/applications/new");
+        return new ManageApplicationsNewPage(page, baseUrl, slug);
+    }
+
+    public ManageApplicationsListPage assertApplicationVisible(String applicationName) {
+        PlaywrightAssertions.assertThat(
+            page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName(applicationName))
+        ).isVisible();
+        return this;
+    }
+}

--- a/src/test/java/com/stucray/limen/ui/pages/manage/applications/ManageApplicationsNewPage.java
+++ b/src/test/java/com/stucray/limen/ui/pages/manage/applications/ManageApplicationsNewPage.java
@@ -1,0 +1,41 @@
+package com.stucray.limen.ui.pages.manage.applications;
+
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.assertions.PlaywrightAssertions;
+import com.microsoft.playwright.options.AriaRole;
+
+public final class ManageApplicationsNewPage {
+
+    private final Page page;
+    private final String baseUrl;
+    private final String slug;
+
+    public ManageApplicationsNewPage(Page page, String baseUrl, String slug) {
+        this.page = page;
+        this.baseUrl = baseUrl;
+        this.slug = slug;
+    }
+
+    public ManageApplicationsNewPage assertOnForm() {
+        PlaywrightAssertions.assertThat(
+            page.getByRole(AriaRole.HEADING, new Page.GetByRoleOptions().setName("New application"))
+        ).isVisible();
+        return this;
+    }
+
+    public ManageApplicationsNewPage fillName(String name) {
+        page.getByLabel("Name").fill(name);
+        return this;
+    }
+
+    public ManageApplicationsNewPage fillDescription(String description) {
+        page.getByLabel("Description").fill(description);
+        return this;
+    }
+
+    public ManageApplicationsListPage submit() {
+        page.getByTestId("apps-create-submit").click();
+        page.waitForURL(baseUrl + "/manage/t/" + slug + "/applications");
+        return new ManageApplicationsListPage(page, baseUrl, slug);
+    }
+}


### PR DESCRIPTION
## Summary
- New `ManageApplicationsCreateJourneyUiIT`: tenant admin signs in, navigates from home → Applications → New, fills name + description, submits, and the new app appears in the list.
- Two new page objects under `ui/pages/manage/applications/`: `ManageApplicationsListPage` (assert on list, click new, assert app visible) and `ManageApplicationsNewPage` (fill name/description, submit).
- `ManageHomePage` extended with `clickApplications()` returning a typed `ManageApplicationsListPage`.
- \`data-test-action\` attributes added to the two consuming templates only: \`apps-new\` (list \"New application\" link) and \`apps-create-submit\` (new-form \"Create\" button).
- App name in the list is rendered as a clickable link, so the assertion uses \`getByRole(LINK, name=<appName>)\` per the locator-strategy ban on \`getByText\` for clickable elements.

Closes #102.

## Test plan
- [x] \`./mvnw verify -Dit.test=ManageApplicationsCreateJourneyUiIT\` green locally.
- [x] Full Surefire (292) + Failsafe suites green locally.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)