### PR TITLE
UI testing slice 1.5: create user (#103)

### DIFF
--- a/src/main/resources/templates/manage/users/list.html
+++ b/src/main/resources/templates/manage/users/list.html
@@ -13,7 +13,7 @@
             <h1>Users</h1>
             <p>Manage user accounts for this tenant.</p>
         </hgroup>
-        <a th:href="@{'/manage/t/' + ${slug} + '/users/new'}" class="btn">Add user</a>
+        <a th:href="@{'/manage/t/' + ${slug} + '/users/new'}" class="btn" data-test-action="users-new">Add user</a>
     </div>
 
     <table>

--- a/src/main/resources/templates/manage/users/new.html
+++ b/src/main/resources/templates/manage/users/new.html
@@ -27,7 +27,7 @@
             <input type="password" name="temporaryPassword" required/>
         </label>
         <div class="form-actions">
-            <button type="submit">Create user</button>
+            <button type="submit" data-test-action="users-create-submit">Create user</button>
             <a th:href="@{'/manage/t/' + ${slug} + '/users'}" class="btn btn--secondary">Cancel</a>
         </div>
     </form>

--- a/src/test/java/com/stucray/limen/ui/journey/ManageUsersCreateJourneyUiIT.java
+++ b/src/test/java/com/stucray/limen/ui/journey/ManageUsersCreateJourneyUiIT.java
@@ -1,0 +1,35 @@
+package com.stucray.limen.ui.journey;
+
+import com.microsoft.playwright.Page;
+import com.stucray.limen.ui.pages.manage.ManageHomePage;
+import com.stucray.limen.ui.support.BaseUiIT;
+import com.stucray.limen.ui.support.LoginPageObject;
+import com.stucray.limen.ui.support.TestTenantFactory.SeededTenant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+@DisplayName("A tenant administrator can create a user via the manage console")
+class ManageUsersCreateJourneyUiIT extends BaseUiIT {
+
+    @Test
+    @DisplayName("happy path: from the manage home, navigates to Users, fills the add-user form, submits, and the new user appears in the list")
+    void happyPath(Page page) {
+        SeededTenant tenant = tenants.createTenant();
+        String username = "newuser-" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+
+        new LoginPageObject(page, baseUrl()).loginAsTenantAdmin(tenant);
+
+        new ManageHomePage(page, baseUrl(), tenant.slug())
+            .clickUsers()
+            .assertOnList()
+            .clickAddUser()
+            .assertOnForm()
+            .fillUsername(username)
+            .fillTemporaryPassword("temp-secret-123")
+            .submit()
+            .assertOnList()
+            .assertUserVisible(username);
+    }
+}

--- a/src/test/java/com/stucray/limen/ui/pages/manage/ManageHomePage.java
+++ b/src/test/java/com/stucray/limen/ui/pages/manage/ManageHomePage.java
@@ -4,6 +4,7 @@ import com.microsoft.playwright.Page;
 import com.microsoft.playwright.assertions.PlaywrightAssertions;
 import com.microsoft.playwright.options.AriaRole;
 import com.stucray.limen.ui.pages.manage.applications.ManageApplicationsListPage;
+import com.stucray.limen.ui.pages.manage.users.ManageUsersListPage;
 
 public final class ManageHomePage {
 
@@ -21,6 +22,12 @@ public final class ManageHomePage {
         page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName("Applications")).click();
         page.waitForURL(baseUrl + "/manage/t/" + slug + "/applications");
         return new ManageApplicationsListPage(page, baseUrl, slug);
+    }
+
+    public ManageUsersListPage clickUsers() {
+        page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName("Users")).click();
+        page.waitForURL(baseUrl + "/manage/t/" + slug + "/users");
+        return new ManageUsersListPage(page, baseUrl, slug);
     }
 
     public ManageHomePage assertOnHomeForTenant(String tenantDisplayName) {

--- a/src/test/java/com/stucray/limen/ui/pages/manage/users/ManageUsersListPage.java
+++ b/src/test/java/com/stucray/limen/ui/pages/manage/users/ManageUsersListPage.java
@@ -1,0 +1,38 @@
+package com.stucray.limen.ui.pages.manage.users;
+
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.assertions.PlaywrightAssertions;
+import com.microsoft.playwright.options.AriaRole;
+
+public final class ManageUsersListPage {
+
+    private final Page page;
+    private final String baseUrl;
+    private final String slug;
+
+    public ManageUsersListPage(Page page, String baseUrl, String slug) {
+        this.page = page;
+        this.baseUrl = baseUrl;
+        this.slug = slug;
+    }
+
+    public ManageUsersListPage assertOnList() {
+        PlaywrightAssertions.assertThat(
+            page.getByRole(AriaRole.HEADING, new Page.GetByRoleOptions().setName("Users"))
+        ).isVisible();
+        return this;
+    }
+
+    public ManageUsersNewPage clickAddUser() {
+        page.getByTestId("users-new").click();
+        page.waitForURL(baseUrl + "/manage/t/" + slug + "/users/new");
+        return new ManageUsersNewPage(page, baseUrl, slug);
+    }
+
+    public ManageUsersListPage assertUserVisible(String username) {
+        PlaywrightAssertions.assertThat(
+            page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName(username))
+        ).isVisible();
+        return this;
+    }
+}

--- a/src/test/java/com/stucray/limen/ui/pages/manage/users/ManageUsersNewPage.java
+++ b/src/test/java/com/stucray/limen/ui/pages/manage/users/ManageUsersNewPage.java
@@ -1,0 +1,41 @@
+package com.stucray.limen.ui.pages.manage.users;
+
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.assertions.PlaywrightAssertions;
+import com.microsoft.playwright.options.AriaRole;
+
+public final class ManageUsersNewPage {
+
+    private final Page page;
+    private final String baseUrl;
+    private final String slug;
+
+    public ManageUsersNewPage(Page page, String baseUrl, String slug) {
+        this.page = page;
+        this.baseUrl = baseUrl;
+        this.slug = slug;
+    }
+
+    public ManageUsersNewPage assertOnForm() {
+        PlaywrightAssertions.assertThat(
+            page.getByRole(AriaRole.HEADING, new Page.GetByRoleOptions().setName("Add user"))
+        ).isVisible();
+        return this;
+    }
+
+    public ManageUsersNewPage fillUsername(String username) {
+        page.getByLabel("Username").fill(username);
+        return this;
+    }
+
+    public ManageUsersNewPage fillTemporaryPassword(String temporaryPassword) {
+        page.getByLabel("Temporary password").fill(temporaryPassword);
+        return this;
+    }
+
+    public ManageUsersListPage submit() {
+        page.getByTestId("users-create-submit").click();
+        page.waitForURL(baseUrl + "/manage/t/" + slug + "/users");
+        return new ManageUsersListPage(page, baseUrl, slug);
+    }
+}


### PR DESCRIPTION
## Summary
- New \`ManageUsersCreateJourneyUiIT\`: tenant admin signs in, navigates from home → Users → Add, fills username + temporary password, submits, and the new user appears in the list.
- Two new page objects under \`ui/pages/manage/users/\`: \`ManageUsersListPage\` (assert on list, click add, assert user visible) and \`ManageUsersNewPage\` (fill username/password, submit).
- \`ManageHomePage\` extended with \`clickUsers()\` returning a typed \`ManageUsersListPage\`.
- \`data-test-action\` attributes added to the consuming templates only: \`users-new\` (list \"Add user\" link), \`users-create-submit\` (new-form \"Create user\" button).
- Username is rendered as a clickable link in the list row, so the assertion uses \`getByRole(LINK, name=<username>)\`.

Closes #103.

## Test plan
- [x] \`./mvnw verify -Dit.test=ManageUsersCreateJourneyUiIT\` green locally.
- [x] Full Surefire (292) + Failsafe suites green locally.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)