### PR TITLE
UI testing slice 1.6: create OAuth2 client (#104)

### DIFF
--- a/src/main/resources/templates/manage/clients/list.html
+++ b/src/main/resources/templates/manage/clients/list.html
@@ -15,7 +15,7 @@
             <h1>Clients</h1>
             <p>OAuth clients for <strong th:text="${app.name()}">app</strong>.</p>
         </hgroup>
-        <a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/clients/new'}" class="btn">New client</a>
+        <a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/clients/new'}" class="btn" data-test-action="clients-new">New client</a>
     </div>
 
     <div class="alert alert--secret" th:if="${clientSecret}">

--- a/src/main/resources/templates/manage/clients/new.html
+++ b/src/main/resources/templates/manage/clients/new.html
@@ -64,7 +64,7 @@
         </fieldset>
 
         <div class="form-actions">
-            <button type="submit">Create client</button>
+            <button type="submit" data-test-action="clients-create-submit">Create client</button>
             <a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/clients'}" class="btn btn--secondary">Cancel</a>
         </div>
     </form>

--- a/src/test/java/com/stucray/limen/ui/journey/ManageClientsCreateJourneyUiIT.java
+++ b/src/test/java/com/stucray/limen/ui/journey/ManageClientsCreateJourneyUiIT.java
@@ -1,0 +1,40 @@
+package com.stucray.limen.ui.journey;
+
+import com.microsoft.playwright.Page;
+import com.stucray.limen.ui.pages.manage.ManageHomePage;
+import com.stucray.limen.ui.support.BaseUiIT;
+import com.stucray.limen.ui.support.LoginPageObject;
+import com.stucray.limen.ui.support.TestTenantFactory.SeededApplication;
+import com.stucray.limen.ui.support.TestTenantFactory.SeededTenant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+@DisplayName("A tenant administrator can create an OAuth2 client under an application via the manage console")
+class ManageClientsCreateJourneyUiIT extends BaseUiIT {
+
+    @Test
+    @DisplayName("happy path: from the manage home, navigates to Applications, opens the seeded app's Clients list, fills the new-client form, submits, and the new client appears in the list")
+    void happyPath(Page page) {
+        SeededTenant tenant = tenants.createTenant();
+        SeededApplication app = tenants.seedApplication(tenant);
+        String clientName = "Client " + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+
+        new LoginPageObject(page, baseUrl()).loginAsTenantAdmin(tenant);
+
+        new ManageHomePage(page, baseUrl(), tenant.slug())
+            .clickApplications()
+            .assertOnList()
+            .assertApplicationVisible(app.name())
+            .clickClientsForApplication(app.name())
+            .assertOnList()
+            .clickNewClient()
+            .assertOnForm()
+            .fillName(clientName)
+            .checkClientCredentialsGrant()
+            .submit()
+            .assertOnList()
+            .assertClientVisible(clientName);
+    }
+}

--- a/src/test/java/com/stucray/limen/ui/pages/manage/applications/ManageApplicationsListPage.java
+++ b/src/test/java/com/stucray/limen/ui/pages/manage/applications/ManageApplicationsListPage.java
@@ -1,8 +1,10 @@
 package com.stucray.limen.ui.pages.manage.applications;
 
+import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.assertions.PlaywrightAssertions;
 import com.microsoft.playwright.options.AriaRole;
+import com.stucray.limen.ui.pages.manage.applications.clients.ManageApplicationClientsListPage;
 
 public final class ManageApplicationsListPage {
 
@@ -34,5 +36,14 @@ public final class ManageApplicationsListPage {
             page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName(applicationName))
         ).isVisible();
         return this;
+    }
+
+    public ManageApplicationClientsListPage clickClientsForApplication(String applicationName) {
+        page.locator("tr")
+            .filter(new Locator.FilterOptions().setHasText(applicationName))
+            .getByRole(AriaRole.LINK, new Locator.GetByRoleOptions().setName("Clients"))
+            .click();
+        page.waitForURL(baseUrl + "/manage/t/" + slug + "/applications/*/clients");
+        return new ManageApplicationClientsListPage(page, baseUrl, slug);
     }
 }

--- a/src/test/java/com/stucray/limen/ui/pages/manage/applications/clients/ManageApplicationClientsListPage.java
+++ b/src/test/java/com/stucray/limen/ui/pages/manage/applications/clients/ManageApplicationClientsListPage.java
@@ -1,0 +1,38 @@
+package com.stucray.limen.ui.pages.manage.applications.clients;
+
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.assertions.PlaywrightAssertions;
+import com.microsoft.playwright.options.AriaRole;
+
+public final class ManageApplicationClientsListPage {
+
+    private final Page page;
+    private final String baseUrl;
+    private final String slug;
+
+    public ManageApplicationClientsListPage(Page page, String baseUrl, String slug) {
+        this.page = page;
+        this.baseUrl = baseUrl;
+        this.slug = slug;
+    }
+
+    public ManageApplicationClientsListPage assertOnList() {
+        PlaywrightAssertions.assertThat(
+            page.getByRole(AriaRole.HEADING, new Page.GetByRoleOptions().setName("Clients"))
+        ).isVisible();
+        return this;
+    }
+
+    public ManageApplicationClientsNewPage clickNewClient() {
+        page.getByTestId("clients-new").click();
+        page.waitForURL(baseUrl + "/manage/t/" + slug + "/applications/*/clients/new");
+        return new ManageApplicationClientsNewPage(page, baseUrl, slug);
+    }
+
+    public ManageApplicationClientsListPage assertClientVisible(String displayName) {
+        PlaywrightAssertions.assertThat(
+            page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName(displayName))
+        ).isVisible();
+        return this;
+    }
+}

--- a/src/test/java/com/stucray/limen/ui/pages/manage/applications/clients/ManageApplicationClientsNewPage.java
+++ b/src/test/java/com/stucray/limen/ui/pages/manage/applications/clients/ManageApplicationClientsNewPage.java
@@ -1,0 +1,41 @@
+package com.stucray.limen.ui.pages.manage.applications.clients;
+
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.assertions.PlaywrightAssertions;
+import com.microsoft.playwright.options.AriaRole;
+
+public final class ManageApplicationClientsNewPage {
+
+    private final Page page;
+    private final String baseUrl;
+    private final String slug;
+
+    public ManageApplicationClientsNewPage(Page page, String baseUrl, String slug) {
+        this.page = page;
+        this.baseUrl = baseUrl;
+        this.slug = slug;
+    }
+
+    public ManageApplicationClientsNewPage assertOnForm() {
+        PlaywrightAssertions.assertThat(
+            page.getByRole(AriaRole.HEADING, new Page.GetByRoleOptions().setName("New client"))
+        ).isVisible();
+        return this;
+    }
+
+    public ManageApplicationClientsNewPage fillName(String displayName) {
+        page.getByLabel("Name").fill(displayName);
+        return this;
+    }
+
+    public ManageApplicationClientsNewPage checkClientCredentialsGrant() {
+        page.getByLabel("Client credentials").check();
+        return this;
+    }
+
+    public ManageApplicationClientsListPage submit() {
+        page.getByTestId("clients-create-submit").click();
+        page.waitForURL(baseUrl + "/manage/t/" + slug + "/applications/*/clients");
+        return new ManageApplicationClientsListPage(page, baseUrl, slug);
+    }
+}

--- a/src/test/java/com/stucray/limen/ui/support/TestTenantFactory.java
+++ b/src/test/java/com/stucray/limen/ui/support/TestTenantFactory.java
@@ -1,5 +1,7 @@
 package com.stucray.limen.ui.support;
 
+import com.stucray.limen.management.applications.Application;
+import com.stucray.limen.management.applications.ApplicationService;
 import com.stucray.limen.tenant.Tenant;
 import com.stucray.limen.tenant.TenantProvisioningService;
 import com.stucray.limen.tenant.TenantRepository;
@@ -32,17 +34,28 @@ public class TestTenantFactory {
     private final TenantRepository tenantRepository;
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final ApplicationService applicationService;
 
     public TestTenantFactory(
         TenantProvisioningService tenantProvisioningService,
         TenantRepository tenantRepository,
         UserRepository userRepository,
-        PasswordEncoder passwordEncoder
+        PasswordEncoder passwordEncoder,
+        ApplicationService applicationService
     ) {
         this.tenantProvisioningService = tenantProvisioningService;
         this.tenantRepository = tenantRepository;
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
+        this.applicationService = applicationService;
+    }
+
+    @Transactional
+    public SeededApplication seedApplication(SeededTenant tenant) {
+        String suffix = uniqueSuffix();
+        String name = "App " + suffix;
+        Application app = applicationService.createApplication(tenant.tenantId(), name, "Seeded for UI test");
+        return new SeededApplication(app.id(), name);
     }
 
     @Transactional
@@ -93,4 +106,6 @@ public class TestTenantFactory {
     ) {}
 
     public record SeededSystemAdmin(String username, String password) {}
+
+    public record SeededApplication(Long appId, String name) {}
 }


### PR DESCRIPTION
## Summary
- New \`ManageClientsCreateJourneyUiIT\`: tenant admin signs in, navigates from home → Applications → seeded app's Clients → New, fills name + checks the \`client_credentials\` grant, submits, and the new client appears in the per-app clients list.
- Two new page objects under \`ui/pages/manage/applications/clients/\`: \`ManageApplicationClientsListPage\` and \`ManageApplicationClientsNewPage\`.
- \`ManageApplicationsListPage\` extended with \`clickClientsForApplication(appName)\` — scopes the click to the matching row via \`Locator.filter().setHasText(appName)\` so the helper stays robust if a future test seeds multiple apps.
- \`TestTenantFactory.seedApplication(tenant)\` added (goes through \`ApplicationService\` — same code path the controller uses), returning a \`SeededApplication(appId, name)\` record.
- \`data-test-action\` attributes added only on the consuming templates: \`clients-new\` (per-app list \"New client\" link), \`clients-create-submit\` (new-form \"Create client\" button).

Closes #104.

## Test plan
- [x] \`./mvnw verify -Dit.test=ManageClientsCreateJourneyUiIT\` green locally.
- [x] Full Surefire (292) + Failsafe suites green locally.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)