### PR TITLE
UI testing slice 1.7: create role (#105)

### DIFF
--- a/src/main/resources/templates/manage/applications/roles/list.html
+++ b/src/main/resources/templates/manage/applications/roles/list.html
@@ -15,7 +15,7 @@
             <h1>Roles</h1>
             <p>Application roles for <strong th:text="${app.name()}">app</strong>.</p>
         </hgroup>
-        <a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/roles/new'}" class="btn">New role</a>
+        <a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/roles/new'}" class="btn" data-test-action="roles-new">New role</a>
     </div>
 
     <p class="form-error" th:if="${errorMessage}" th:text="${errorMessage}"></p>

--- a/src/main/resources/templates/manage/applications/roles/new.html
+++ b/src/main/resources/templates/manage/applications/roles/new.html
@@ -29,7 +29,7 @@
             <textarea name="description" th:text="${description}"></textarea>
         </label>
         <div class="form-actions">
-            <button type="submit">Create</button>
+            <button type="submit" data-test-action="roles-create-submit">Create</button>
             <a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/roles'}" class="btn btn--secondary">Cancel</a>
         </div>
     </form>

--- a/src/test/java/com/stucray/limen/ui/journey/ManageRolesCreateJourneyUiIT.java
+++ b/src/test/java/com/stucray/limen/ui/journey/ManageRolesCreateJourneyUiIT.java
@@ -1,0 +1,40 @@
+package com.stucray.limen.ui.journey;
+
+import com.microsoft.playwright.Page;
+import com.stucray.limen.ui.pages.manage.ManageHomePage;
+import com.stucray.limen.ui.support.BaseUiIT;
+import com.stucray.limen.ui.support.LoginPageObject;
+import com.stucray.limen.ui.support.TestTenantFactory.SeededApplication;
+import com.stucray.limen.ui.support.TestTenantFactory.SeededTenant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+@DisplayName("A tenant administrator can create a role under an application via the manage console")
+class ManageRolesCreateJourneyUiIT extends BaseUiIT {
+
+    @Test
+    @DisplayName("happy path: from the manage home, navigates to Applications, opens the seeded app's Roles list, fills the new-role form, submits, and the new role appears in the list")
+    void happyPath(Page page) {
+        SeededTenant tenant = tenants.createTenant();
+        SeededApplication app = tenants.seedApplication(tenant);
+        String roleName = "role-" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+
+        new LoginPageObject(page, baseUrl()).loginAsTenantAdmin(tenant);
+
+        new ManageHomePage(page, baseUrl(), tenant.slug())
+            .clickApplications()
+            .assertOnList()
+            .assertApplicationVisible(app.name())
+            .clickRolesForApplication(app.name())
+            .assertOnList()
+            .clickNewRole()
+            .assertOnForm()
+            .fillName(roleName)
+            .fillDescription("Created from a Playwright test.")
+            .submit()
+            .assertOnList()
+            .assertRoleVisible(roleName);
+    }
+}

--- a/src/test/java/com/stucray/limen/ui/pages/manage/applications/ManageApplicationsListPage.java
+++ b/src/test/java/com/stucray/limen/ui/pages/manage/applications/ManageApplicationsListPage.java
@@ -5,6 +5,7 @@ import com.microsoft.playwright.Page;
 import com.microsoft.playwright.assertions.PlaywrightAssertions;
 import com.microsoft.playwright.options.AriaRole;
 import com.stucray.limen.ui.pages.manage.applications.clients.ManageApplicationClientsListPage;
+import com.stucray.limen.ui.pages.manage.applications.roles.ManageApplicationRolesListPage;
 
 public final class ManageApplicationsListPage {
 
@@ -45,5 +46,14 @@ public final class ManageApplicationsListPage {
             .click();
         page.waitForURL(baseUrl + "/manage/t/" + slug + "/applications/*/clients");
         return new ManageApplicationClientsListPage(page, baseUrl, slug);
+    }
+
+    public ManageApplicationRolesListPage clickRolesForApplication(String applicationName) {
+        page.locator("tr")
+            .filter(new Locator.FilterOptions().setHasText(applicationName))
+            .getByRole(AriaRole.LINK, new Locator.GetByRoleOptions().setName("Roles"))
+            .click();
+        page.waitForURL(baseUrl + "/manage/t/" + slug + "/applications/*/roles");
+        return new ManageApplicationRolesListPage(page, baseUrl, slug);
     }
 }

--- a/src/test/java/com/stucray/limen/ui/pages/manage/applications/roles/ManageApplicationRolesListPage.java
+++ b/src/test/java/com/stucray/limen/ui/pages/manage/applications/roles/ManageApplicationRolesListPage.java
@@ -1,0 +1,38 @@
+package com.stucray.limen.ui.pages.manage.applications.roles;
+
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.assertions.PlaywrightAssertions;
+import com.microsoft.playwright.options.AriaRole;
+
+public final class ManageApplicationRolesListPage {
+
+    private final Page page;
+    private final String baseUrl;
+    private final String slug;
+
+    public ManageApplicationRolesListPage(Page page, String baseUrl, String slug) {
+        this.page = page;
+        this.baseUrl = baseUrl;
+        this.slug = slug;
+    }
+
+    public ManageApplicationRolesListPage assertOnList() {
+        PlaywrightAssertions.assertThat(
+            page.getByRole(AriaRole.HEADING, new Page.GetByRoleOptions().setName("Roles"))
+        ).isVisible();
+        return this;
+    }
+
+    public ManageApplicationRolesNewPage clickNewRole() {
+        page.getByTestId("roles-new").click();
+        page.waitForURL(baseUrl + "/manage/t/" + slug + "/applications/*/roles/new");
+        return new ManageApplicationRolesNewPage(page, baseUrl, slug);
+    }
+
+    public ManageApplicationRolesListPage assertRoleVisible(String roleName) {
+        PlaywrightAssertions.assertThat(
+            page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName(roleName))
+        ).isVisible();
+        return this;
+    }
+}

--- a/src/test/java/com/stucray/limen/ui/pages/manage/applications/roles/ManageApplicationRolesNewPage.java
+++ b/src/test/java/com/stucray/limen/ui/pages/manage/applications/roles/ManageApplicationRolesNewPage.java
@@ -1,0 +1,41 @@
+package com.stucray.limen.ui.pages.manage.applications.roles;
+
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.assertions.PlaywrightAssertions;
+import com.microsoft.playwright.options.AriaRole;
+
+public final class ManageApplicationRolesNewPage {
+
+    private final Page page;
+    private final String baseUrl;
+    private final String slug;
+
+    public ManageApplicationRolesNewPage(Page page, String baseUrl, String slug) {
+        this.page = page;
+        this.baseUrl = baseUrl;
+        this.slug = slug;
+    }
+
+    public ManageApplicationRolesNewPage assertOnForm() {
+        PlaywrightAssertions.assertThat(
+            page.getByRole(AriaRole.HEADING, new Page.GetByRoleOptions().setName("New role"))
+        ).isVisible();
+        return this;
+    }
+
+    public ManageApplicationRolesNewPage fillName(String name) {
+        page.getByLabel("Name").fill(name);
+        return this;
+    }
+
+    public ManageApplicationRolesNewPage fillDescription(String description) {
+        page.getByLabel("Description").fill(description);
+        return this;
+    }
+
+    public ManageApplicationRolesListPage submit() {
+        page.getByTestId("roles-create-submit").click();
+        page.waitForURL(baseUrl + "/manage/t/" + slug + "/applications/*/roles");
+        return new ManageApplicationRolesListPage(page, baseUrl, slug);
+    }
+}


### PR DESCRIPTION
## Summary
- New \`ManageRolesCreateJourneyUiIT\`: tenant admin signs in, navigates from home → Applications → seeded app's Roles → New, fills name + description, submits, and the new role appears in the per-app roles list.
- Two new page objects under \`ui/pages/manage/applications/roles/\`: \`ManageApplicationRolesListPage\` and \`ManageApplicationRolesNewPage\`.
- \`ManageApplicationsListPage\` extended with \`clickRolesForApplication(appName)\` — same row-scoping pattern (\`Locator.filter().setHasText(appName)\`) introduced in slice 1.6 for clients.
- Reuses \`TestTenantFactory.seedApplication\` added in slice 1.6.
- \`data-test-action\` attributes added only on the consuming templates: \`roles-new\` (per-app list \"New role\" link), \`roles-create-submit\` (new-form \"Create\" button).

Closes #105. Completes the manage-CRUD sweep (#102/#103/#104/#105 all merged).

## Test plan
- [x] \`./mvnw verify -Dit.test=ManageRolesCreateJourneyUiIT\` green locally.
- [x] Full Surefire (292) + Failsafe suites green locally.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)