### PR TITLE
UI testing slice 1.10: forced password change (#106)

### DIFF
--- a/src/main/resources/templates/change-password.html
+++ b/src/main/resources/templates/change-password.html
@@ -19,7 +19,7 @@
                 Confirm password
                 <input type="password" name="confirmPassword" required/>
             </label>
-            <button type="submit" class="btn--block">Change password</button>
+            <button type="submit" class="btn--block" data-test-action="change-password-submit">Change password</button>
         </form>
     </article>
 </main>

--- a/src/test/java/com/stucray/limen/ui/journey/ForcedPasswordChangeJourneyUiIT.java
+++ b/src/test/java/com/stucray/limen/ui/journey/ForcedPasswordChangeJourneyUiIT.java
@@ -1,0 +1,32 @@
+package com.stucray.limen.ui.journey;
+
+import com.microsoft.playwright.Page;
+import com.stucray.limen.ui.pages.enduser.EndUserChangePasswordPage;
+import com.stucray.limen.ui.support.BaseUiIT;
+import com.stucray.limen.ui.support.LoginPageObject;
+import com.stucray.limen.ui.support.TestTenantFactory.SeededForcedChangeUser;
+import com.stucray.limen.ui.support.TestTenantFactory.SeededTenant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("An end user with mustChangePassword set is forced through the change-password page before reaching their tenant home")
+class ForcedPasswordChangeJourneyUiIT extends BaseUiIT {
+
+    @Test
+    @DisplayName("happy path: signs in with the temporary password, lands on /t/{slug}/change-password, sets a new password, and is redirected to the tenant home with their identity visible")
+    void happyPath(Page page) {
+        SeededTenant tenant = tenants.createTenant();
+        SeededForcedChangeUser user = tenants.seedEndUserForcedPasswordChange(tenant);
+
+        new LoginPageObject(page, baseUrl())
+            .loginAsEndUserWithCredentials(tenant.slug(), user.username(), user.temporaryPassword());
+
+        new EndUserChangePasswordPage(page, baseUrl(), tenant.slug())
+            .assertOnChangePasswordPage()
+            .fillNewPassword("new-password-123")
+            .fillConfirmPassword("new-password-123")
+            .submit()
+            .assertOnHomeForTenant(tenant.displayName())
+            .assertSignedInAs(user.username());
+    }
+}

--- a/src/test/java/com/stucray/limen/ui/pages/enduser/EndUserChangePasswordPage.java
+++ b/src/test/java/com/stucray/limen/ui/pages/enduser/EndUserChangePasswordPage.java
@@ -1,0 +1,41 @@
+package com.stucray.limen.ui.pages.enduser;
+
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.assertions.PlaywrightAssertions;
+import com.microsoft.playwright.options.AriaRole;
+
+public final class EndUserChangePasswordPage {
+
+    private final Page page;
+    private final String baseUrl;
+    private final String slug;
+
+    public EndUserChangePasswordPage(Page page, String baseUrl, String slug) {
+        this.page = page;
+        this.baseUrl = baseUrl;
+        this.slug = slug;
+    }
+
+    public EndUserChangePasswordPage assertOnChangePasswordPage() {
+        PlaywrightAssertions.assertThat(
+            page.getByRole(AriaRole.HEADING, new Page.GetByRoleOptions().setName("Change your password"))
+        ).isVisible();
+        return this;
+    }
+
+    public EndUserChangePasswordPage fillNewPassword(String newPassword) {
+        page.getByLabel("New password").fill(newPassword);
+        return this;
+    }
+
+    public EndUserChangePasswordPage fillConfirmPassword(String confirmPassword) {
+        page.getByLabel("Confirm password").fill(confirmPassword);
+        return this;
+    }
+
+    public EndUserHomePage submit() {
+        page.getByTestId("change-password-submit").click();
+        page.waitForURL(baseUrl + "/t/" + slug + "/");
+        return new EndUserHomePage(page, baseUrl, slug);
+    }
+}

--- a/src/test/java/com/stucray/limen/ui/support/LoginPageObject.java
+++ b/src/test/java/com/stucray/limen/ui/support/LoginPageObject.java
@@ -35,11 +35,15 @@ public final class LoginPageObject {
     }
 
     public void loginAsEndUser(SeededTenant tenant) {
-        page.navigate(baseUrl + "/t/" + tenant.slug() + "/login");
-        page.getByLabel("Username").fill(tenant.endUserUsername());
-        page.getByLabel("Password").fill(tenant.endUserPassword());
+        loginAsEndUserWithCredentials(tenant.slug(), tenant.endUserUsername(), tenant.endUserPassword());
+    }
+
+    public void loginAsEndUserWithCredentials(String slug, String username, String password) {
+        page.navigate(baseUrl + "/t/" + slug + "/login");
+        page.getByLabel("Username").fill(username);
+        page.getByLabel("Password").fill(password);
         page.getByTestId("login-submit").click();
-        page.waitForURL(baseUrl + "/t/" + tenant.slug() + "/**");
+        page.waitForURL(baseUrl + "/t/" + slug + "/**");
     }
 
     public void loginAsSystemAdmin(String username, String password) {

--- a/src/test/java/com/stucray/limen/ui/support/TestTenantFactory.java
+++ b/src/test/java/com/stucray/limen/ui/support/TestTenantFactory.java
@@ -59,6 +59,16 @@ public class TestTenantFactory {
     }
 
     @Transactional
+    public SeededForcedChangeUser seedEndUserForcedPasswordChange(SeededTenant tenant) {
+        String suffix = uniqueSuffix();
+        String username = "forcechange-" + suffix;
+        String hash = passwordEncoder.encode(SHARED_TEST_PASSWORD);
+        userRepository.save(new User(
+            null, tenant.tenantId(), username, hash, true, true, false, LocalDateTime.now()));
+        return new SeededForcedChangeUser(username, SHARED_TEST_PASSWORD);
+    }
+
+    @Transactional
     public SeededTenant createTenant() {
         String suffix = uniqueSuffix();
         String slug = "t-" + suffix;
@@ -108,4 +118,6 @@ public class TestTenantFactory {
     public record SeededSystemAdmin(String username, String password) {}
 
     public record SeededApplication(Long appId, String name) {}
+
+    public record SeededForcedChangeUser(String username, String temporaryPassword) {}
 }


### PR DESCRIPTION
## Summary
- New \`ForcedPasswordChangeJourneyUiIT\`: end user with \`mustChangePassword=true\` signs in, gets intercepted by the passwordChangeRequired post-login intent, lands on \`/t/{slug}/change-password\`, sets a new password, and is redirected to the tenant home with their identity visible.
- New \`EndUserChangePasswordPage\` page object under \`ui/pages/enduser/\`.
- \`TestTenantFactory.seedEndUserForcedPasswordChange(tenant)\` added, returning a \`SeededForcedChangeUser(username, temporaryPassword)\` record. Saves via \`UserRepository\` with \`mustChangePassword=true\`, mirroring how \`createTenant\` seeds users.
- \`LoginPageObject.loginAsEndUser\` refactored to delegate to a new \`loginAsEndUserWithCredentials(slug, username, password)\` helper, used here for the temp-password login.
- \`data-test-action=\"change-password-submit\"\` added to the consuming template (\`templates/change-password.html\`).

Closes #106.

## Test plan
- [x] \`./mvnw verify -Dit.test=ForcedPasswordChangeJourneyUiIT\` green locally.
- [x] Full Surefire (292) + Failsafe suites green locally.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)