### PR TITLE
UI testing slice 1.11: OAuth2 authorize flow (#107)

### DIFF
--- a/src/test/java/com/stucray/limen/ui/journey/OAuth2AuthorizeJourneyUiIT.java
+++ b/src/test/java/com/stucray/limen/ui/journey/OAuth2AuthorizeJourneyUiIT.java
@@ -1,0 +1,56 @@
+package com.stucray.limen.ui.journey;
+
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Request;
+import com.microsoft.playwright.Route;
+import com.stucray.limen.ui.support.BaseUiIT;
+import com.stucray.limen.ui.support.OAuth2AuthorizeFlow;
+import com.stucray.limen.ui.support.OAuth2AuthorizeFlow.Pkce;
+import com.stucray.limen.ui.support.TestTenantFactory.SeededApplication;
+import com.stucray.limen.ui.support.TestTenantFactory.SeededOAuth2Client;
+import com.stucray.limen.ui.support.TestTenantFactory.SeededTenant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("An end user can complete an OAuth2 authorization-code-with-PKCE flow and land back at the relying-party callback with a code")
+class OAuth2AuthorizeJourneyUiIT extends BaseUiIT {
+
+    private static final String REDIRECT_URI = "http://localhost/callback";
+    private static final String STATE = "ui-test-state";
+
+    @Test
+    @DisplayName("happy path: authorize → bounced to /t/{slug}/login → end-user signs in → saved request resumes → 302 to RP callback URL with ?code=… present")
+    void happyPath(Page page) {
+        SeededTenant tenant = tenants.createTenant();
+        SeededApplication app = tenants.seedApplication(tenant);
+        SeededOAuth2Client client = tenants.seedOAuth2ClientForEndUser(tenant, app, REDIRECT_URI);
+        Pkce pkce = OAuth2AuthorizeFlow.newPkce();
+        String authorizeUrl = OAuth2AuthorizeFlow.authorizeUrl(
+            baseUrl(), tenant.slug(), client.clientId(), client.redirectUri(),
+            pkce.challenge(), STATE);
+
+        // The redirect URI host:port (port 80, no listener) wouldn't actually
+        // resolve, so intercept client-side and abort — we only care that the
+        // browser was sent there with the right query string. Pattern must be
+        // host-anchored, NOT `**/callback*`, because the authorize URL itself
+        // contains `/callback` inside the redirect_uri query parameter and a
+        // trailing-glob match would intercept the wrong request.
+        page.route(REDIRECT_URI + "*", Route::abort);
+
+        page.navigate(authorizeUrl);
+        page.waitForURL("**/t/" + tenant.slug() + "/login");
+
+        page.getByLabel("Username").fill(tenant.endUserUsername());
+        page.getByLabel("Password").fill(tenant.endUserPassword());
+        // The terminal hop is a 302 to http://localhost/callback?code=…&state=… —
+        // capture it via waitForRequest so the assertion doesn't depend on the
+        // (intentionally aborted) navigation completing a load event.
+        Request callback = page.waitForRequest(REDIRECT_URI + "*", () ->
+            page.getByTestId("login-submit").click());
+
+        assertThat(callback.url()).contains("code=");
+        assertThat(callback.url()).contains("state=" + STATE);
+    }
+}

--- a/src/test/java/com/stucray/limen/ui/support/OAuth2AuthorizeFlow.java
+++ b/src/test/java/com/stucray/limen/ui/support/OAuth2AuthorizeFlow.java
@@ -1,0 +1,54 @@
+package com.stucray.limen.ui.support;
+
+import org.springframework.security.oauth2.core.oidc.OidcScopes;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+/**
+ * Flow plumbing (not a Page object) for the OAuth2 authorization-code-with-PKCE
+ * journey. Generates the PKCE pair and assembles the SAS-tenant authorize URL.
+ *
+ * <p>The verifier is captured for symmetry with the production flow, but the
+ * UI journey ends at the relying-party redirect (a code in the URL), never
+ * POSTing to {@code /oauth2/token} — so the verifier is unused by the test.
+ */
+public final class OAuth2AuthorizeFlow {
+
+    private OAuth2AuthorizeFlow() {}
+
+    public record Pkce(String verifier, String challenge) {}
+
+    public static Pkce newPkce() {
+        try {
+            byte[] verifierBytes = new byte[32];
+            new SecureRandom().nextBytes(verifierBytes);
+            String verifier = Base64.getUrlEncoder().withoutPadding().encodeToString(verifierBytes);
+            byte[] hash = MessageDigest.getInstance("SHA-256")
+                .digest(verifier.getBytes(StandardCharsets.US_ASCII));
+            String challenge = Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+            return new Pkce(verifier, challenge);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+    }
+
+    public static String authorizeUrl(
+        String baseUrl, String slug, String clientId, String redirectUri,
+        String codeChallenge, String state
+    ) {
+        return UriComponentsBuilder.fromUriString(baseUrl + "/t/" + slug + "/oauth2/authorize")
+            .queryParam("response_type", "code")
+            .queryParam("client_id", clientId)
+            .queryParam("redirect_uri", redirectUri)
+            .queryParam("scope", OidcScopes.OPENID)
+            .queryParam("state", state)
+            .queryParam("code_challenge", codeChallenge)
+            .queryParam("code_challenge_method", "S256")
+            .build().toUriString();
+    }
+}

--- a/src/test/java/com/stucray/limen/ui/support/TestTenantFactory.java
+++ b/src/test/java/com/stucray/limen/ui/support/TestTenantFactory.java
@@ -2,16 +2,28 @@ package com.stucray.limen.ui.support;
 
 import com.stucray.limen.management.applications.Application;
 import com.stucray.limen.management.applications.ApplicationService;
+import com.stucray.limen.management.clients.TenantClient;
+import com.stucray.limen.management.clients.TenantClientRepository;
+import com.stucray.limen.management.memberships.ApplicationMembershipService;
+import com.stucray.limen.management.memberships.ClientMembershipService;
+import com.stucray.limen.management.memberships.ClientMembershipTestFixture;
 import com.stucray.limen.tenant.Tenant;
 import com.stucray.limen.tenant.TenantProvisioningService;
 import com.stucray.limen.tenant.TenantRepository;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.oidc.OidcScopes;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -35,19 +47,31 @@ public class TestTenantFactory {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final ApplicationService applicationService;
+    private final RegisteredClientRepository registeredClientRepository;
+    private final TenantClientRepository tenantClientRepository;
+    private final ApplicationMembershipService applicationMembershipService;
+    private final ClientMembershipService clientMembershipService;
 
     public TestTenantFactory(
         TenantProvisioningService tenantProvisioningService,
         TenantRepository tenantRepository,
         UserRepository userRepository,
         PasswordEncoder passwordEncoder,
-        ApplicationService applicationService
+        ApplicationService applicationService,
+        RegisteredClientRepository registeredClientRepository,
+        TenantClientRepository tenantClientRepository,
+        ApplicationMembershipService applicationMembershipService,
+        ClientMembershipService clientMembershipService
     ) {
         this.tenantProvisioningService = tenantProvisioningService;
         this.tenantRepository = tenantRepository;
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
         this.applicationService = applicationService;
+        this.registeredClientRepository = registeredClientRepository;
+        this.tenantClientRepository = tenantClientRepository;
+        this.applicationMembershipService = applicationMembershipService;
+        this.clientMembershipService = clientMembershipService;
     }
 
     @Transactional
@@ -56,6 +80,53 @@ public class TestTenantFactory {
         String name = "App " + suffix;
         Application app = applicationService.createApplication(tenant.tenantId(), name, "Seeded for UI test");
         return new SeededApplication(app.id(), name);
+    }
+
+    /**
+     * Seeds a public PKCE OAuth2 client under the given application and grants the
+     * tenant's seeded end-user the App Membership + Client Membership needed to
+     * pass the {@code MembershipGateFilter}.
+     *
+     * <p>Drops down to {@link RegisteredClientRepository} + {@link TenantClientRepository}
+     * directly rather than going through {@code ClientManagementService.createClient},
+     * because that production helper hardcodes {@code requireAuthorizationConsent(true)}
+     * and this slice's journey deliberately bypasses the consent step (Limen has no
+     * custom consent template — the SAS default is intentionally out of scope).
+     */
+    @SuppressWarnings("NullAway") // Spring Data convention: null id on insert; populated on save
+    @Transactional
+    public SeededOAuth2Client seedOAuth2ClientForEndUser(
+        SeededTenant tenant, SeededApplication app, String redirectUri
+    ) {
+        User endUser = userRepository.findByUsernameAndTenantId(tenant.endUserUsername(), tenant.tenantId())
+            .orElseThrow(() -> new IllegalStateException("seeded end user missing"));
+        User admin = userRepository.findByUsernameAndTenantId(tenant.adminUsername(), tenant.tenantId())
+            .orElseThrow(() -> new IllegalStateException("seeded admin missing"));
+
+        String registeredClientId = UUID.randomUUID().toString();
+        String oauthClientId = UUID.randomUUID().toString();
+        RegisteredClient rc = RegisteredClient.withId(registeredClientId)
+            .clientId(oauthClientId)
+            .clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .redirectUri(redirectUri)
+            .scope(OidcScopes.OPENID)
+            .clientSettings(ClientSettings.builder()
+                .requireProofKey(true)
+                .requireAuthorizationConsent(false)
+                .build())
+            .build();
+        registeredClientRepository.save(rc);
+        tenantClientRepository.save(new TenantClient(
+            null, registeredClientId, app.appId(), tenant.tenantId(), "UI Test Client", false));
+
+        ClientMembershipTestFixture.grant(
+            applicationMembershipService, clientMembershipService,
+            app.appId(), tenant.tenantId(), endUser.id(), admin.id(),
+            registeredClientId, Set.of()
+        );
+
+        return new SeededOAuth2Client(oauthClientId, redirectUri);
     }
 
     @Transactional
@@ -120,4 +191,6 @@ public class TestTenantFactory {
     public record SeededApplication(Long appId, String name) {}
 
     public record SeededForcedChangeUser(String username, String temporaryPassword) {}
+
+    public record SeededOAuth2Client(String clientId, String redirectUri) {}
 }


### PR DESCRIPTION
Closes #107. Completes UI-testing PRD #96 — all 11 slices now shipped.

## Summary

- Drives a real OAuth2 authorization-code-with-PKCE flow as an end user: authorize URL → 302 to `/t/{slug}/login` → submit credentials → saved request resumes → 302 to RP callback URL bearing `?code=…&state=…`.
- New `TestTenantFactory.seedOAuth2ClientForEndUser(...)` seeds a public PKCE RegisteredClient + TenantClient row + grants the seeded end user the App Membership + Client Membership needed to pass `MembershipGateFilter` (uses the existing `ClientMembershipTestFixture.grant(...)` helper).
- New `OAuth2AuthorizeFlow` support helper (NOT a Page object — flow plumbing) generates the PKCE pair and assembles the SAS-tenant authorize URL.
- New `OAuth2AuthorizeJourneyUiIT` is the journey test.

## Deviation from issue acceptance criteria

The issue text and acceptance criteria assume Limen has a custom OAuth2 consent template with `data-test-action` attributes. **It doesn't** — Limen relies on the Spring Authorization Server default consent page (no Thymeleaf template, no Limen control over the markup). The seeded RegisteredClient sets `requireAuthorizationConsent=false` to skip the SAS-rendered consent page, matching what `OAuth2ForcedPasswordChangeIntegrationTest` already does.

The slice is about the authorize *mechanics* (login → saved-request resume → code-bearing redirect), not the consent UX. If a custom Limen consent template is added later, that's a separate follow-up.

## Worth knowing for review

- **Why drop down to `RegisteredClientRepository` instead of `ClientManagementService.createClient`?** The production helper hardcodes `requireAuthorizationConsent(true)` (`ClientManagementService.java:81`) and we need it false. Documented inline.
- **Why `Route::abort` + `page.waitForRequest(...)` instead of `Route::fulfill` + `waitForURL`?** The redirect URI host (`http://localhost`, port 80) doesn't actually serve content. The first attempt used `route.fulfill` + `waitForURL` for the load event — the load event never arrived (status -1 in the trace). Capturing the request URL via `waitForRequest` doesn't depend on a successful navigation, so we abort the request and assert against the captured URL.
- **Why a host-anchored route pattern (`http://localhost/callback*`) instead of `**/callback*`?** First attempt used the trailing-glob form and Playwright matched the *authorize URL* (which contains `/callback` inside the `redirect_uri` query parameter) — intercepting the wrong request and serving the stub body for the authorize call. Host-anchoring fixes that.
- No template changes. No production code changes. No new `data-test-action` attributes — re-uses `login-submit` from slice 1.2.

## Test plan

- [x] `./mvnw verify -Dit.test=OAuth2AuthorizeJourneyUiIT` green.
- [x] `./mvnw verify -Dit.test='*UiIT'` green (all 11 UI journey tests pass).
- [x] `./mvnw verify` green (full Surefire + Failsafe + NullAway + PMD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)