### PR TITLE
Slice 1: email-as-identity migration (#122)

### DIFF
--- a/src/main/java/com/stucray/limen/auth/TenantAuthProvider.java
+++ b/src/main/java/com/stucray/limen/auth/TenantAuthProvider.java
@@ -34,9 +34,9 @@ public class TenantAuthProvider implements AuthenticationProvider {
     public Authentication authenticate(Authentication authentication) throws AuthenticationException {
         TenantAuthToken token = (TenantAuthToken) authentication;
         String slug = token.getTenantSlug();
-        String username = (String) token.getPrincipal();
+        String email = (String) token.getPrincipal();
         String rawPassword = (String) token.getCredentials();
-        if (username == null) {
+        if (email == null) {
             throw new BadCredentialsException("Invalid credentials");
         }
 
@@ -47,7 +47,7 @@ public class TenantAuthProvider implements AuthenticationProvider {
             throw new DisabledException("Tenant is suspended");
         }
 
-        User user = userRepository.findByUsernameAndTenantId(username, tenant.id())
+        User user = userRepository.findByEmailAndTenantId(email, tenant.id())
             .orElseThrow(() -> new BadCredentialsException("Invalid credentials"));
 
         if (!user.enabled()) {

--- a/src/main/java/com/stucray/limen/auth/TenantAuthToken.java
+++ b/src/main/java/com/stucray/limen/auth/TenantAuthToken.java
@@ -10,8 +10,8 @@ public final class TenantAuthToken extends UsernamePasswordAuthenticationToken {
     private final String tenantSlug;
 
     /** Unauthenticated — used when submitting credentials. */
-    public TenantAuthToken(String tenantSlug, String username, String password) {
-        super(username, password);
+    public TenantAuthToken(String tenantSlug, String email, String password) {
+        super(email, password);
         this.tenantSlug = tenantSlug;
     }
 

--- a/src/main/java/com/stucray/limen/auth/TenantPersistentTokenBasedRememberMeServices.java
+++ b/src/main/java/com/stucray/limen/auth/TenantPersistentTokenBasedRememberMeServices.java
@@ -64,7 +64,7 @@ public final class TenantPersistentTokenBasedRememberMeServices extends Abstract
         HttpServletRequest request, HttpServletResponse response, Authentication auth
     ) {
         TenantUserDetails principal = (TenantUserDetails) Objects.requireNonNull(auth.getPrincipal());
-        String username = principal.displayUsername();
+        String email = principal.displayEmail();
         String slug = principal.tenantSlug();
         Long tenantId = principal.tenantId();
         String series = encodeBase64(seriesLength());
@@ -72,7 +72,7 @@ public final class TenantPersistentTokenBasedRememberMeServices extends Abstract
         Date now = new Date();
         try {
             tokenRepository.createNewToken(
-                new PersistentRememberMeToken(username, series, tokenValue, now), tenantId);
+                new PersistentRememberMeToken(email, series, tokenValue, now), tenantId);
         } catch (Exception ex) {
             this.logger.error("Failed to save persistent token", ex);
             return;
@@ -128,14 +128,14 @@ public final class TenantPersistentTokenBasedRememberMeServices extends Abstract
             throw new RememberMeAuthenticationException("Autologin failed due to data access problem");
         }
 
-        return tenantUserDetailsService.loadByUsernameAndSlug(token.getUsername(), cookieSlug);
+        return tenantUserDetailsService.loadByEmailAndSlug(token.getUsername(), cookieSlug);
     }
 
     @Override
     public void logout(HttpServletRequest request, HttpServletResponse response, @Nullable Authentication auth) {
         super.logout(request, response, auth);
         if (auth != null && auth.getPrincipal() instanceof TenantUserDetails details) {
-            tokenRepository.removeUserTokens(details.displayUsername(), details.tenantId());
+            tokenRepository.removeUserTokens(details.displayEmail(), details.tenantId());
         }
     }
 

--- a/src/main/java/com/stucray/limen/auth/TenantPersistentTokenRepository.java
+++ b/src/main/java/com/stucray/limen/auth/TenantPersistentTokenRepository.java
@@ -21,7 +21,7 @@ import java.util.Date;
 public class TenantPersistentTokenRepository {
 
     private static final String INSERT_SQL =
-        "INSERT INTO persistent_logins (tenant_id, username, series, token, last_used) "
+        "INSERT INTO persistent_logins (tenant_id, email, series, token, last_used) "
         + "VALUES (?, ?, ?, ?, ?)";
 
     private static final String UPDATE_SQL =
@@ -29,11 +29,11 @@ public class TenantPersistentTokenRepository {
         + "WHERE tenant_id = ? AND series = ?";
 
     private static final String SELECT_SQL =
-        "SELECT username, series, token, last_used, tenant_id FROM persistent_logins "
+        "SELECT email, series, token, last_used, tenant_id FROM persistent_logins "
         + "WHERE tenant_id = ? AND series = ?";
 
     private static final String DELETE_USER_SQL =
-        "DELETE FROM persistent_logins WHERE tenant_id = ? AND username = ?";
+        "DELETE FROM persistent_logins WHERE tenant_id = ? AND email = ?";
 
     private final JdbcTemplate jdbcTemplate;
 
@@ -55,7 +55,7 @@ public class TenantPersistentTokenRepository {
         try {
             return jdbcTemplate.queryForObject(SELECT_SQL, (rs, rowNum) ->
                 new TenantPersistentRememberMeToken(
-                    rs.getString("username"),
+                    rs.getString("email"),
                     rs.getString("series"),
                     rs.getString("token"),
                     rs.getTimestamp("last_used"),
@@ -68,7 +68,7 @@ public class TenantPersistentTokenRepository {
         }
     }
 
-    public void removeUserTokens(String username, Long tenantId) {
-        jdbcTemplate.update(DELETE_USER_SQL, tenantId, username);
+    public void removeUserTokens(String email, Long tenantId) {
+        jdbcTemplate.update(DELETE_USER_SQL, tenantId, email);
     }
 }

--- a/src/main/java/com/stucray/limen/auth/TenantUserDetails.java
+++ b/src/main/java/com/stucray/limen/auth/TenantUserDetails.java
@@ -34,7 +34,7 @@ public final class TenantUserDetails implements UserDetails {
 
     @Override
     public String getUsername() {
-        return user.username();
+        return user.email();
     }
 
     @Override
@@ -45,7 +45,7 @@ public final class TenantUserDetails implements UserDetails {
     public String tenantSlug() { return tenant.slug(); }
     public Long tenantId()     { return tenant.id(); }
     public Long userId()       { return user.id(); }
-    public String displayUsername() { return user.username(); }
+    public String displayEmail() { return user.email(); }
     public boolean mustChangePassword() { return user.mustChangePassword(); }
     public Tenant tenant() { return tenant; }
     public User user()     { return user; }

--- a/src/main/java/com/stucray/limen/auth/TenantUserDetailsService.java
+++ b/src/main/java/com/stucray/limen/auth/TenantUserDetailsService.java
@@ -29,17 +29,17 @@ public class TenantUserDetailsService implements UserDetailsService {
         this.userRepository = userRepository;
     }
 
-    public UserDetails loadByUsernameAndSlug(String username, String slug) {
+    public UserDetails loadByEmailAndSlug(String email, String slug) {
         Tenant tenant = tenantRepository.findBySlug(slug)
             .orElseThrow(() -> new UsernameNotFoundException("Unknown tenant: " + slug));
-        User user = userRepository.findByUsernameAndTenantId(username, tenant.id())
-            .orElseThrow(() -> new UsernameNotFoundException(username));
+        User user = userRepository.findByEmailAndTenantId(email, tenant.id())
+            .orElseThrow(() -> new UsernameNotFoundException(email));
         return new TenantUserDetails(user, tenant);
     }
 
     @Override
     public UserDetails loadUserByUsername(String username) {
         throw new UnsupportedOperationException(
-            "Plain username lookup is not supported — use loadByUsernameAndSlug(username, slug)");
+            "Plain email lookup is not supported — use loadByEmailAndSlug(email, slug)");
     }
 }

--- a/src/main/java/com/stucray/limen/auth/login/TenantLogin.java
+++ b/src/main/java/com/stucray/limen/auth/login/TenantLogin.java
@@ -149,9 +149,9 @@ public final class TenantLogin {
             // slug is non-null here because attemptAuthentication only fires on a request
             // that already matched scheme.loginMatcher().
             String slug = Objects.requireNonNull(scheme.slugFrom(request));
-            String username = request.getParameter("username");
+            String email = request.getParameter("email");
             String password = request.getParameter("password");
-            return getAuthenticationManager().authenticate(new TenantAuthToken(slug, username, password));
+            return getAuthenticationManager().authenticate(new TenantAuthToken(slug, email, password));
         }
     }
 

--- a/src/main/java/com/stucray/limen/enduser/web/EndUserHomeController.java
+++ b/src/main/java/com/stucray/limen/enduser/web/EndUserHomeController.java
@@ -18,7 +18,7 @@ public class EndUserHomeController {
     ) {
         model.addAttribute("slug", slug);
         model.addAttribute("tenantName", principal.tenant().displayName());
-        model.addAttribute("username", principal.displayUsername());
+        model.addAttribute("email", principal.displayEmail());
         return "t/home";
     }
 }

--- a/src/main/java/com/stucray/limen/identity/BootstrapAdminProperties.java
+++ b/src/main/java/com/stucray/limen/identity/BootstrapAdminProperties.java
@@ -6,17 +6,17 @@ import org.springframework.validation.annotation.Validated;
 
 @ConfigurationProperties("limen.bootstrap.admin")
 @Validated
-public record BootstrapAdminProperties(String username, String password) {
+public record BootstrapAdminProperties(String email, String password) {
 
-    @AssertTrue(message = "limen.bootstrap.admin.username and password must both be set or both be unset")
+    @AssertTrue(message = "limen.bootstrap.admin.email and password must both be set or both be unset")
     public boolean isPairConsistent() {
-        boolean userSet = username != null && !username.isBlank();
+        boolean emailSet = email != null && !email.isBlank();
         boolean passSet = password != null && !password.isBlank();
-        return userSet == passSet;
+        return emailSet == passSet;
     }
 
     public boolean isConfigured() {
-        return username != null && !username.isBlank()
+        return email != null && !email.isBlank()
             && password != null && !password.isBlank();
     }
 }

--- a/src/main/java/com/stucray/limen/identity/UserBootstrap.java
+++ b/src/main/java/com/stucray/limen/identity/UserBootstrap.java
@@ -49,11 +49,11 @@ public class UserBootstrap implements CommandLineRunner {
         if (!adminProperties.isConfigured()) return;
 
         String hash = Objects.requireNonNull(passwordEncoder.encode(adminProperties.password()));
-        userRepository.findByUsernameAndTenantId(adminProperties.username(), systemTenant.id())
+        userRepository.findByEmailAndTenantId(adminProperties.email(), systemTenant.id())
             .ifPresentOrElse(
                 existing -> userRepository.save(existing.withPasswordHash(hash).withMustChangePassword(false)),
                 () -> userRepository.save(
-                    new User(null, systemTenant.id(), adminProperties.username(), hash, true, false, false, LocalDateTime.now())
+                    new User(null, systemTenant.id(), adminProperties.email(), hash, true, false, false, LocalDateTime.now())
                 )
             );
     }

--- a/src/main/java/com/stucray/limen/management/memberships/ClientMembersController.java
+++ b/src/main/java/com/stucray/limen/management/memberships/ClientMembersController.java
@@ -65,7 +65,7 @@ public class ClientMembersController {
         model.addAttribute("app", app);
         model.addAttribute("client", client);
         model.addAttribute("memberships", memberships);
-        model.addAttribute("usernamesById", usernamesByIdFor(memberships));
+        model.addAttribute("emailsById", emailsByIdFor(memberships));
         model.addAttribute("roleNamesById", roleNamesByIdFor(allRoles));
         return "manage/clients/members/list";
     }
@@ -132,7 +132,7 @@ public class ClientMembersController {
         model.addAttribute("app", app);
         model.addAttribute("client", client);
         model.addAttribute("membership", membership);
-        model.addAttribute("memberUsername", member.username());
+        model.addAttribute("memberEmail", member.email());
         model.addAttribute("allRoles", allRoles);
         model.addAttribute("assignedRoleIds", membership.roleIds());
         return "manage/clients/members/edit";
@@ -163,7 +163,7 @@ public class ClientMembersController {
             model.addAttribute("app", app);
             model.addAttribute("client", client);
             model.addAttribute("membership", membership);
-            model.addAttribute("memberUsername", member.username());
+            model.addAttribute("memberEmail", member.email());
             model.addAttribute("allRoles", allRoles);
             model.addAttribute("assignedRoleIds", roleIds == null ? Set.of() : new LinkedHashSet<>(roleIds));
             model.addAttribute("errorMessage", e.getMessage());
@@ -183,10 +183,10 @@ public class ClientMembersController {
         return "redirect:/manage/t/" + slug + "/applications/" + appId + "/clients/" + registeredClientId + "/members";
     }
 
-    private Map<Long, String> usernamesByIdFor(List<ClientMembership> memberships) {
+    private Map<Long, String> emailsByIdFor(List<ClientMembership> memberships) {
         Map<Long, String> map = new LinkedHashMap<>();
         for (ClientMembership m : memberships) {
-            userRepository.findById(m.userId()).ifPresent(u -> map.put(u.id(), u.username()));
+            userRepository.findById(m.userId()).ifPresent(u -> map.put(u.id(), u.email()));
         }
         return map;
     }

--- a/src/main/java/com/stucray/limen/management/memberships/MembersController.java
+++ b/src/main/java/com/stucray/limen/management/memberships/MembersController.java
@@ -56,7 +56,7 @@ public class MembersController {
         model.addAttribute("slug", slug);
         model.addAttribute("app", app);
         model.addAttribute("memberships", memberships);
-        model.addAttribute("usernamesById", usernamesByIdFor(memberships));
+        model.addAttribute("emailsById", emailsByIdFor(memberships));
         model.addAttribute("roleNamesById", roleNamesByIdFor(allRoles));
         return "manage/applications/members/list";
     }
@@ -112,7 +112,7 @@ public class MembersController {
         model.addAttribute("slug", slug);
         model.addAttribute("app", app);
         model.addAttribute("membership", membership);
-        model.addAttribute("memberUsername", member.username());
+        model.addAttribute("memberEmail", member.email());
         model.addAttribute("allRoles", allRoles);
         model.addAttribute("assignedRoleIds", membership.roleIds());
         return "manage/applications/members/edit";
@@ -140,7 +140,7 @@ public class MembersController {
             model.addAttribute("slug", slug);
             model.addAttribute("app", app);
             model.addAttribute("membership", membership);
-            model.addAttribute("memberUsername", member.username());
+            model.addAttribute("memberEmail", member.email());
             model.addAttribute("allRoles", allRoles);
             model.addAttribute("assignedRoleIds", roleIds == null ? Set.of() : new java.util.LinkedHashSet<>(roleIds));
             model.addAttribute("errorMessage", e.getMessage());
@@ -159,10 +159,10 @@ public class MembersController {
         return "redirect:/manage/t/" + slug + "/applications/" + appId + "/members";
     }
 
-    private Map<Long, String> usernamesByIdFor(List<ApplicationMembership> memberships) {
+    private Map<Long, String> emailsByIdFor(List<ApplicationMembership> memberships) {
         Map<Long, String> map = new LinkedHashMap<>();
         for (ApplicationMembership m : memberships) {
-            userRepository.findById(m.userId()).ifPresent(u -> map.put(u.id(), u.username()));
+            userRepository.findById(m.userId()).ifPresent(u -> map.put(u.id(), u.email()));
         }
         return map;
     }

--- a/src/main/java/com/stucray/limen/management/signup/SignupController.java
+++ b/src/main/java/com/stucray/limen/management/signup/SignupController.java
@@ -25,11 +25,11 @@ public class SignupController {
     public String signup(
         @RequestParam String organizationName,
         @RequestParam String slug,
-        @RequestParam String username,
+        @RequestParam String email,
         @RequestParam String password,
         Model model
     ) {
-        SignupForm form = new SignupForm(organizationName, slug, username, password);
+        SignupForm form = new SignupForm(organizationName, slug, email, password);
         SignupService.SignupResult result = signupService.signup(form);
 
         if (result instanceof SignupService.SignupResult.Success success) {

--- a/src/main/java/com/stucray/limen/management/signup/SignupForm.java
+++ b/src/main/java/com/stucray/limen/management/signup/SignupForm.java
@@ -3,6 +3,6 @@ package com.stucray.limen.management.signup;
 public record SignupForm(
     String organizationName,
     String slug,
-    String username,
+    String email,
     String password
 ) {}

--- a/src/main/java/com/stucray/limen/management/signup/SignupService.java
+++ b/src/main/java/com/stucray/limen/management/signup/SignupService.java
@@ -18,6 +18,7 @@ import java.util.regex.Pattern;
 public class SignupService {
 
     private static final Pattern SLUG_FORMAT = Pattern.compile("^[a-z0-9][a-z0-9-]{1,46}[a-z0-9]$");
+    private static final Pattern EMAIL_FORMAT = Pattern.compile("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$");
     private static final Set<String> RESERVED_SLUGS = Set.of(
         "system", "admin", "manage", "api", "www", "static", "health", "limen"
     );
@@ -67,12 +68,15 @@ public class SignupService {
             return new SignupResult.Error("organizationName", "Organization name is required");
         }
 
-        String username = form.username() == null ? "" : form.username().trim();
-        if (username.isBlank()) {
-            return new SignupResult.Error("username", "Username is required");
+        String email = form.email() == null ? "" : form.email().trim();
+        if (email.isBlank()) {
+            return new SignupResult.Error("email", "Email is required");
         }
-        if (username.length() > 100) {
-            return new SignupResult.Error("username", "Username must be 100 characters or fewer");
+        if (email.length() > 255) {
+            return new SignupResult.Error("email", "Email must be 255 characters or fewer");
+        }
+        if (!EMAIL_FORMAT.matcher(email).matches()) {
+            return new SignupResult.Error("email", "Email must be a valid email address");
         }
 
         if (form.password() == null || form.password().isBlank()) {
@@ -81,7 +85,7 @@ public class SignupService {
 
         Tenant tenant = tenantProvisioningService.createTenant(slug, orgName);
         userRepository.save(new User(
-            null, tenant.id(), username,
+            null, tenant.id(), email,
             Objects.requireNonNull(passwordEncoder.encode(form.password())),
             true, false, true, LocalDateTime.now()
         ));

--- a/src/main/java/com/stucray/limen/management/users/UserManagementController.java
+++ b/src/main/java/com/stucray/limen/management/users/UserManagementController.java
@@ -43,17 +43,17 @@ public class UserManagementController {
     public String createUser(
         @PathVariable String slug,
         @AuthenticationPrincipal TenantUserDetails principal,
-        @RequestParam String username,
+        @RequestParam String email,
         @RequestParam String temporaryPassword,
         Model model
     ) {
         try {
-            userManagementService.createUser(principal.tenantId(), username, temporaryPassword);
+            userManagementService.createUser(principal.tenantId(), email, temporaryPassword);
             return "redirect:/manage/t/" + slug + "/users";
         } catch (IllegalArgumentException e) {
             model.addAttribute("slug", slug);
             model.addAttribute("errorMessage", e.getMessage());
-            model.addAttribute("username", username);
+            model.addAttribute("email", email);
             return "manage/users/new";
         }
     }

--- a/src/main/java/com/stucray/limen/management/users/UserManagementService.java
+++ b/src/main/java/com/stucray/limen/management/users/UserManagementService.java
@@ -25,12 +25,12 @@ public class UserManagementService {
     }
 
     @SuppressWarnings("NullAway") // Spring Data convention: null id on insert; populated on save
-    public void createUser(Long tenantId, String username, String temporaryPassword) {
-        if (userRepository.existsByUsernameAndTenantId(username, tenantId)) {
-            throw new IllegalArgumentException("Username already exists in this tenant");
+    public void createUser(Long tenantId, String email, String temporaryPassword) {
+        if (userRepository.existsByEmailAndTenantId(email, tenantId)) {
+            throw new IllegalArgumentException("Email already exists in this tenant");
         }
         userRepository.save(new User(
-            null, tenantId, username,
+            null, tenantId, email,
             Objects.requireNonNull(passwordEncoder.encode(temporaryPassword)),
             true, true, false, LocalDateTime.now()
         ));

--- a/src/main/java/com/stucray/limen/management/web/ManagementHomeController.java
+++ b/src/main/java/com/stucray/limen/management/web/ManagementHomeController.java
@@ -18,7 +18,7 @@ public class ManagementHomeController {
     ) {
         model.addAttribute("slug", slug);
         model.addAttribute("tenantName", principal.tenant().displayName());
-        model.addAttribute("username", principal.displayUsername());
+        model.addAttribute("email", principal.displayEmail());
         model.addAttribute("isSystemAdmin", principal.tenant().isSystem());
         return "manage/home";
     }

--- a/src/main/java/com/stucray/limen/management/web/ManagementModelAdvice.java
+++ b/src/main/java/com/stucray/limen/management/web/ManagementModelAdvice.java
@@ -9,8 +9,8 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 @ControllerAdvice(basePackages = "com.stucray.limen.management")
 public class ManagementModelAdvice {
 
-    @ModelAttribute("currentUsername")
-    public @Nullable String currentUsername(@AuthenticationPrincipal @Nullable TenantUserDetails principal) {
-        return principal == null ? null : principal.displayUsername();
+    @ModelAttribute("currentEmail")
+    public @Nullable String currentEmail(@AuthenticationPrincipal @Nullable TenantUserDetails principal) {
+        return principal == null ? null : principal.displayEmail();
     }
 }

--- a/src/main/java/com/stucray/limen/user/User.java
+++ b/src/main/java/com/stucray/limen/user/User.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 public record User(
     @Id Long id,
     Long tenantId,
-    String username,
+    String email,
     String passwordHash,
     boolean enabled,
     boolean mustChangePassword,
@@ -17,18 +17,18 @@ public record User(
     LocalDateTime createdAt
 ) {
     public User withPasswordHash(String newHash) {
-        return new User(id, tenantId, username, newHash, enabled, true, tenantOwner, createdAt);
+        return new User(id, tenantId, email, newHash, enabled, true, tenantOwner, createdAt);
     }
 
     public User withEnabled(boolean newEnabled) {
-        return new User(id, tenantId, username, passwordHash, newEnabled, mustChangePassword, tenantOwner, createdAt);
+        return new User(id, tenantId, email, passwordHash, newEnabled, mustChangePassword, tenantOwner, createdAt);
     }
 
     public User withMustChangePassword(boolean value) {
-        return new User(id, tenantId, username, passwordHash, enabled, value, tenantOwner, createdAt);
+        return new User(id, tenantId, email, passwordHash, enabled, value, tenantOwner, createdAt);
     }
 
     public User withTenantOwner(boolean value) {
-        return new User(id, tenantId, username, passwordHash, enabled, mustChangePassword, value, createdAt);
+        return new User(id, tenantId, email, passwordHash, enabled, mustChangePassword, value, createdAt);
     }
 }

--- a/src/main/java/com/stucray/limen/user/UserRepository.java
+++ b/src/main/java/com/stucray/limen/user/UserRepository.java
@@ -6,8 +6,8 @@ import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends CrudRepository<User, Long> {
-    Optional<User> findByUsernameAndTenantId(String username, Long tenantId);
+    Optional<User> findByEmailAndTenantId(String email, Long tenantId);
     Optional<User> findByIdAndTenantId(Long id, Long tenantId);
     List<User> findAllByTenantId(Long tenantId);
-    boolean existsByUsernameAndTenantId(String username, Long tenantId);
+    boolean existsByEmailAndTenantId(String email, Long tenantId);
 }

--- a/src/main/resources/db/migration/V6__email_as_identity.sql
+++ b/src/main/resources/db/migration/V6__email_as_identity.sql
@@ -1,0 +1,27 @@
+-- Switch the user identifier from `username` to `email`. The PRD scopes Limen
+-- to per-tenant user pools (Auth0 / Cognito shape), so the uniqueness constraint
+-- is `(tenant_id, email)` — the same email may identify two distinct Users in
+-- two different Tenants.
+--
+-- Existing dev data is dropped (no real customers yet); the alternative — a
+-- nullable email column with a forced-fill flow — leaves permanent technical
+-- debt for the sake of throwaway seeded rows. See PRD #120 §Implementation
+-- Decisions → Slice 0 prerequisite.
+--
+-- `persistent_logins` mirrors the rename so the remember-me token row is
+-- consistent with the new identifier; the table is TRUNCATEd because the prior
+-- cookies referenced usernames that no longer exist.
+
+TRUNCATE persistent_logins;
+TRUNCATE users CASCADE;
+
+ALTER TABLE users DROP CONSTRAINT users_tenant_username_unique;
+ALTER TABLE users DROP COLUMN username;
+ALTER TABLE users ADD COLUMN email varchar(255) NOT NULL;
+ALTER TABLE users ADD CONSTRAINT users_tenant_email_unique UNIQUE (tenant_id, email);
+
+DROP INDEX persistent_logins_tenant_username_idx;
+ALTER TABLE persistent_logins RENAME COLUMN username TO email;
+ALTER TABLE persistent_logins ALTER COLUMN email TYPE varchar(255);
+CREATE INDEX persistent_logins_tenant_email_idx
+    ON persistent_logins (tenant_id, email);

--- a/src/main/resources/templates/fragments/layout-authed.html
+++ b/src/main/resources/templates/fragments/layout-authed.html
@@ -9,7 +9,7 @@
             Limen
         </span>
         <div class="app-header__user">
-            <span class="app-header__user-name" th:if="${currentUsername}" th:text="${currentUsername}">user</span>
+            <span class="app-header__user-name" th:if="${currentEmail}" th:text="${currentEmail}">user</span>
             <form method="post" th:action="@{/manage/logout}">
                 <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                 <button type="submit" class="btn--ghost">Sign out</button>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -11,8 +11,8 @@
         <form method="post" th:action="@{/t/{slug}/login(slug=${tenantSlug})}" class="stack">
             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
             <label>
-                Username
-                <input type="text" name="username" autofocus required/>
+                Email
+                <input type="email" name="email" autofocus required/>
             </label>
             <label>
                 Password

--- a/src/main/resources/templates/manage/applications/members/edit.html
+++ b/src/main/resources/templates/manage/applications/members/edit.html
@@ -8,12 +8,12 @@
         <li><a th:href="@{'/manage/t/' + ${slug} + '/applications'}">Applications</a></li>
         <li th:text="${app.name()}">App</li>
         <li><a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/members'}">Members</a></li>
-        <li th:text="${memberUsername}">user</li>
+        <li th:text="${memberEmail}">user</li>
     </ol>
 
     <hgroup>
         <h1>Member roles</h1>
-        <p><strong th:text="${memberUsername}">user</strong> on <strong th:text="${app.name()}">app</strong></p>
+        <p><strong th:text="${memberEmail}">user</strong> on <strong th:text="${app.name()}">app</strong></p>
     </hgroup>
 
     <p class="form-error" th:if="${errorMessage}" th:text="${errorMessage}"></p>

--- a/src/main/resources/templates/manage/applications/members/list.html
+++ b/src/main/resources/templates/manage/applications/members/list.html
@@ -31,7 +31,7 @@
         </thead>
         <tbody>
             <tr th:each="m : ${memberships}">
-                <td th:text="${usernamesById.get(m.userId())}"></td>
+                <td th:text="${emailsById.get(m.userId())}"></td>
                 <td>
                     <span th:if="${#lists.isEmpty(m.roleIds())}" class="muted">—</span>
                     <span th:unless="${#lists.isEmpty(m.roleIds())}">

--- a/src/main/resources/templates/manage/applications/members/new.html
+++ b/src/main/resources/templates/manage/applications/members/new.html
@@ -25,7 +25,7 @@
         <label>
             User
             <select name="userId" required>
-                <option th:each="u : ${grantableUsers}" th:value="${u.id()}" th:text="${u.username()}"></option>
+                <option th:each="u : ${grantableUsers}" th:value="${u.id()}" th:text="${u.email()}"></option>
             </select>
         </label>
         <div class="form-actions">

--- a/src/main/resources/templates/manage/clients/members/edit.html
+++ b/src/main/resources/templates/manage/clients/members/edit.html
@@ -10,12 +10,12 @@
         <li><a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/clients'}">Clients</a></li>
         <li th:text="${client.displayName()}">Client</li>
         <li><a th:href="@{'/manage/t/' + ${slug} + '/applications/' + ${app.id()} + '/clients/' + ${client.registeredClientId()} + '/members'}">Members</a></li>
-        <li th:text="${memberUsername}">user</li>
+        <li th:text="${memberEmail}">user</li>
     </ol>
 
     <hgroup>
         <h1>Client member roles</h1>
-        <p><strong th:text="${memberUsername}">user</strong> on <strong th:text="${client.displayName()}">client</strong></p>
+        <p><strong th:text="${memberEmail}">user</strong> on <strong th:text="${client.displayName()}">client</strong></p>
     </hgroup>
 
     <p class="form-error" th:if="${errorMessage}" th:text="${errorMessage}"></p>

--- a/src/main/resources/templates/manage/clients/members/list.html
+++ b/src/main/resources/templates/manage/clients/members/list.html
@@ -33,7 +33,7 @@
         </thead>
         <tbody>
             <tr th:each="m : ${memberships}">
-                <td th:text="${usernamesById.get(m.userId())}"></td>
+                <td th:text="${emailsById.get(m.userId())}"></td>
                 <td>
                     <span th:if="${#lists.isEmpty(m.roleIds())}" class="muted">—</span>
                     <span th:unless="${#lists.isEmpty(m.roleIds())}">

--- a/src/main/resources/templates/manage/clients/members/new.html
+++ b/src/main/resources/templates/manage/clients/members/new.html
@@ -27,7 +27,7 @@
         <label>
             User
             <select name="userId" required>
-                <option th:each="u : ${grantableUsers}" th:value="${u.id()}" th:text="${u.username()}"></option>
+                <option th:each="u : ${grantableUsers}" th:value="${u.id()}" th:text="${u.email()}"></option>
             </select>
         </label>
         <div class="form-actions">

--- a/src/main/resources/templates/manage/home.html
+++ b/src/main/resources/templates/manage/home.html
@@ -7,7 +7,7 @@
 <main class="container">
     <hgroup>
         <h1 th:text="${tenantName}">Tenant</h1>
-        <p>Welcome, <span th:text="${username}">user</span>.</p>
+        <p>Welcome, <span th:text="${email}">user</span>.</p>
     </hgroup>
 
     <nav class="nav-tiles">

--- a/src/main/resources/templates/manage/login.html
+++ b/src/main/resources/templates/manage/login.html
@@ -10,13 +10,13 @@
             <h1>Sign in</h1>
             <p th:text="${tenantName}">Tenant</p>
         </hgroup>
-        <p class="form-error" th:if="${param.error}">Invalid username or password.</p>
+        <p class="form-error" th:if="${param.error}">Invalid email or password.</p>
         <p class="form-info" th:if="${param.registered}">Account created — please sign in.</p>
         <form method="post" th:action="@{'/manage/t/' + ${slug} + '/login'}" class="stack">
             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
             <label>
-                Username
-                <input type="text" name="username" autofocus required/>
+                Email
+                <input type="email" name="email" autofocus required/>
             </label>
             <label>
                 Password

--- a/src/main/resources/templates/manage/users/detail.html
+++ b/src/main/resources/templates/manage/users/detail.html
@@ -1,16 +1,16 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" th:replace="~{fragments/layout-authed :: layout(~{::title}, ~{::main})}">
-<head><title th:text="'User · ' + ${user.username()}">User</title></head>
+<head><title th:text="'User · ' + ${user.email()}">User</title></head>
 <body>
 <main class="container">
     <ol class="breadcrumb" aria-label="breadcrumb">
         <li><a th:href="@{'/manage/t/' + ${slug} + '/'}">Home</a></li>
         <li><a th:href="@{'/manage/t/' + ${slug} + '/users'}">Users</a></li>
-        <li th:text="${user.username()}">user</li>
+        <li th:text="${user.email()}">user</li>
     </ol>
 
     <hgroup>
-        <h1 th:text="${user.username()}">username</h1>
+        <h1 th:text="${user.email()}">email</h1>
         <p>User account details.</p>
     </hgroup>
 

--- a/src/main/resources/templates/manage/users/list.html
+++ b/src/main/resources/templates/manage/users/list.html
@@ -19,7 +19,7 @@
     <table>
         <thead>
             <tr>
-                <th scope="col">Username</th>
+                <th scope="col">Email</th>
                 <th scope="col">Status</th>
                 <th scope="col">Tenant Owner</th>
                 <th scope="col">Actions</th>
@@ -27,7 +27,7 @@
         </thead>
         <tbody>
             <tr th:each="user : ${users}">
-                <td><a th:href="@{'/manage/t/' + ${slug} + '/users/' + ${user.id()}}" th:text="${user.username()}"></a></td>
+                <td><a th:href="@{'/manage/t/' + ${slug} + '/users/' + ${user.id()}}" th:text="${user.email()}"></a></td>
                 <td>
                     <span th:if="${user.enabled()}" class="badge badge--success">Active</span>
                     <span th:unless="${user.enabled()}" class="badge badge--muted">Disabled</span>

--- a/src/main/resources/templates/manage/users/new.html
+++ b/src/main/resources/templates/manage/users/new.html
@@ -19,8 +19,8 @@
     <form method="post" th:action="@{'/manage/t/' + ${slug} + '/users'}" class="stack section">
         <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
         <label>
-            Username
-            <input type="text" name="username" th:value="${username}" autofocus required/>
+            Email
+            <input type="email" name="email" th:value="${email}" autofocus required/>
         </label>
         <label>
             Temporary password

--- a/src/main/resources/templates/manage/users/reset-password.html
+++ b/src/main/resources/templates/manage/users/reset-password.html
@@ -6,13 +6,13 @@
     <ol class="breadcrumb" aria-label="breadcrumb">
         <li><a th:href="@{'/manage/t/' + ${slug} + '/'}">Home</a></li>
         <li><a th:href="@{'/manage/t/' + ${slug} + '/users'}">Users</a></li>
-        <li><a th:href="@{'/manage/t/' + ${slug} + '/users/' + ${user.id()}}" th:text="${user.username()}">user</a></li>
+        <li><a th:href="@{'/manage/t/' + ${slug} + '/users/' + ${user.id()}}" th:text="${user.email()}">user</a></li>
         <li>Reset password</li>
     </ol>
 
     <hgroup>
         <h1>Reset password</h1>
-        <p>Resetting password for <strong th:text="${user.username()}">user</strong>.</p>
+        <p>Resetting password for <strong th:text="${user.email()}">user</strong>.</p>
     </hgroup>
 
     <form method="post" th:action="@{'/manage/t/' + ${slug} + '/users/' + ${user.id()} + '/reset-password'}" class="stack section">

--- a/src/main/resources/templates/signup.html
+++ b/src/main/resources/templates/signup.html
@@ -26,9 +26,9 @@
             </label>
 
             <label>
-                Username
-                <input type="text" name="username" th:value="${form.username()}" required/>
-                <span class="form-error" th:if="${errorField == 'username'}" th:text="${errorMessage}"></span>
+                Email
+                <input type="email" name="email" th:value="${form.email()}" required/>
+                <span class="form-error" th:if="${errorField == 'email'}" th:text="${errorMessage}"></span>
             </label>
 
             <label>

--- a/src/main/resources/templates/t/home.html
+++ b/src/main/resources/templates/t/home.html
@@ -5,7 +5,7 @@
 <main class="container">
     <hgroup>
         <h1 th:text="${tenantName}">Tenant</h1>
-        <p>Signed in as <span th:text="${username}">user</span>.</p>
+        <p>Signed in as <span th:text="${email}">user</span>.</p>
     </hgroup>
     <form method="post" th:action="@{/t/{slug}/logout(slug=${slug})}">
         <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>

--- a/src/test/java/com/stucray/limen/IssuerContractTest.java
+++ b/src/test/java/com/stucray/limen/IssuerContractTest.java
@@ -45,8 +45,8 @@ class IssuerContractTest {
     @BeforeEach
     void setUp() {
         Long systemTenantId = tenantRepository.findBySlug("system").orElseThrow().id();
-        if (!userRepository.existsByUsernameAndTenantId("testuser", systemTenantId)) {
-            userRepository.save(new User(null, systemTenantId, "testuser", passwordEncoder.encode("password"), true, false, false, LocalDateTime.now()));
+        if (!userRepository.existsByEmailAndTenantId("testuser@example.test", systemTenantId)) {
+            userRepository.save(new User(null, systemTenantId, "testuser@example.test", passwordEncoder.encode("password"), true, false, false, LocalDateTime.now()));
         }
 
         RegisteredClient existing = registeredClientRepository.findByClientId(CLIENT_ID);

--- a/src/test/java/com/stucray/limen/LoginIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/LoginIntegrationTest.java
@@ -51,7 +51,7 @@ class LoginIntegrationTest {
         jdbcTemplate.execute("DELETE FROM users WHERE tenant_id = (SELECT id FROM tenants WHERE slug = 'system')");
 
         systemTenantId = tenantRepository.findBySlug("system").orElseThrow().id();
-        userRepository.save(new User(null, systemTenantId, "testuser", passwordEncoder.encode("password"), true, false, false, LocalDateTime.now()));
+        userRepository.save(new User(null, systemTenantId, "testuser@example.test", passwordEncoder.encode("password"), true, false, false, LocalDateTime.now()));
     }
 
     @Test
@@ -83,7 +83,7 @@ class LoginIntegrationTest {
     @DisplayName("System admin signs in at /manage/t/system/login and lands on /manage/t/system/")
     void systemAdminLoginAtSystemTenantSucceeds() throws Exception {
         mockMvc.perform(post("/manage/t/system/login")
-                .param("username", "testuser")
+                .param("email", "testuser@example.test")
                 .param("password", "password")
                 .with(csrf()))
             .andExpect(status().is3xxRedirection())

--- a/src/test/java/com/stucray/limen/auth/CrossTenantLoginIsolationIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/auth/CrossTenantLoginIsolationIntegrationTest.java
@@ -53,12 +53,12 @@ class CrossTenantLoginIsolationIntegrationTest {
         beta = tenantRepository.save(new Tenant(null, "beta", "Beta", TenantStatus.ACTIVE, LocalDateTime.now()));
 
         userRepository.save(new User(
-            null, alpha.id(), "alice",
+            null, alpha.id(), "alice@example.test",
             passwordEncoder.encode("alpha-pwd"),
             true, false, false, LocalDateTime.now()
         ));
         userRepository.save(new User(
-            null, beta.id(), "alice",
+            null, beta.id(), "alice@example.test",
             passwordEncoder.encode("beta-pwd"),
             true, false, false, LocalDateTime.now()
         ));
@@ -68,7 +68,7 @@ class CrossTenantLoginIsolationIntegrationTest {
     @DisplayName("OAuth2 surface: alice@alpha cannot sign in with beta's password")
     void oauth2LoginRejectsOtherTenantsPassword() throws Exception {
         mockMvc.perform(post("/t/alpha/login")
-                .param("username", "alice")
+                .param("email", "alice@example.test")
                 .param("password", "beta-pwd")
                 .with(csrf()))
             .andExpect(status().is3xxRedirection())
@@ -79,7 +79,7 @@ class CrossTenantLoginIsolationIntegrationTest {
     @DisplayName("Management surface: alice@alpha cannot sign in with beta's password")
     void managementLoginRejectsOtherTenantsPassword() throws Exception {
         mockMvc.perform(post("/manage/t/alpha/login")
-                .param("username", "alice")
+                .param("email", "alice@example.test")
                 .param("password", "beta-pwd")
                 .with(csrf()))
             .andExpect(status().is3xxRedirection())
@@ -90,7 +90,7 @@ class CrossTenantLoginIsolationIntegrationTest {
     @DisplayName("OAuth2 surface: alice@alpha signs in successfully with alpha's password")
     void oauth2LoginAcceptsOwnTenantsPassword() throws Exception {
         mockMvc.perform(post("/t/alpha/login")
-                .param("username", "alice")
+                .param("email", "alice@example.test")
                 .param("password", "alpha-pwd")
                 .with(csrf()))
             .andExpect(status().is3xxRedirection())

--- a/src/test/java/com/stucray/limen/auth/TenantPersistentTokenBasedRememberMeServicesIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/auth/TenantPersistentTokenBasedRememberMeServicesIntegrationTest.java
@@ -61,9 +61,9 @@ class TenantPersistentTokenBasedRememberMeServicesIntegrationTest {
         alpha = tenantRepository.save(new Tenant(null, "alpha-rm", "Alpha", TenantStatus.ACTIVE, LocalDateTime.now()));
         beta = tenantRepository.save(new Tenant(null, "beta-rm", "Beta", TenantStatus.ACTIVE, LocalDateTime.now()));
 
-        userRepository.save(new User(null, alpha.id(), "alice",
+        userRepository.save(new User(null, alpha.id(), "alice@example.test",
             passwordEncoder.encode("alpha-pwd"), true, false, false, LocalDateTime.now()));
-        userRepository.save(new User(null, beta.id(), "alice",
+        userRepository.save(new User(null, beta.id(), "alice@example.test",
             passwordEncoder.encode("beta-pwd"), true, false, false, LocalDateTime.now()));
     }
 
@@ -71,15 +71,15 @@ class TenantPersistentTokenBasedRememberMeServicesIntegrationTest {
     @DisplayName("OAuth2 login: persisted persistent_logins row carries the user's tenant_id")
     void rememberMeRowOnOAuth2LoginCarriesTenantId() throws Exception {
         mockMvc.perform(post("/t/alpha-rm/login")
-                .param("username", "alice")
+                .param("email", "alice@example.test")
                 .param("password", "alpha-pwd")
                 .param("remember-me", "on")
                 .with(csrf()))
             .andExpect(cookie().exists("remember-me"));
 
         Long persistedTenantId = jdbcTemplate.queryForObject(
-            "SELECT tenant_id FROM persistent_logins WHERE username = ?",
-            Long.class, "alice"
+            "SELECT tenant_id FROM persistent_logins WHERE email = ?",
+            Long.class, "alice@example.test"
         );
         assertThat(persistedTenantId).isEqualTo(alpha.id());
 
@@ -94,15 +94,15 @@ class TenantPersistentTokenBasedRememberMeServicesIntegrationTest {
     @DisplayName("Management login: persisted persistent_logins row carries the user's tenant_id")
     void rememberMeOnManagementLoginCarriesTenantId() throws Exception {
         mockMvc.perform(post("/manage/t/alpha-rm/login")
-                .param("username", "alice")
+                .param("email", "alice@example.test")
                 .param("password", "alpha-pwd")
                 .param("remember-me", "on")
                 .with(csrf()))
             .andExpect(cookie().exists("remember-me"));
 
         Long persistedTenantId = jdbcTemplate.queryForObject(
-            "SELECT tenant_id FROM persistent_logins WHERE username = ?",
-            Long.class, "alice"
+            "SELECT tenant_id FROM persistent_logins WHERE email = ?",
+            Long.class, "alice@example.test"
         );
         assertThat(persistedTenantId).isEqualTo(alpha.id());
     }
@@ -111,7 +111,7 @@ class TenantPersistentTokenBasedRememberMeServicesIntegrationTest {
     @DisplayName("Issued cookie value (base64-decoded) is series:token:slug")
     void cookieValueIncludesSlugAsThirdSegment() throws Exception {
         MvcResult result = mockMvc.perform(post("/t/alpha-rm/login")
-                .param("username", "alice")
+                .param("email", "alice@example.test")
                 .param("password", "alpha-pwd")
                 .param("remember-me", "on")
                 .with(csrf()))
@@ -134,8 +134,8 @@ class TenantPersistentTokenBasedRememberMeServicesIntegrationTest {
         Cookie rememberMeCookie = loginAndGetRememberMeCookie("/manage/t/alpha-rm/login", "alpha-pwd");
         assertThat(rememberMeCookie).isNotNull();
         // Server-side token is replaced — the presented cookie's token will mismatch.
-        jdbcTemplate.update("UPDATE persistent_logins SET token = ? WHERE username = ?",
-            "tampered-server-token-value", "alice");
+        jdbcTemplate.update("UPDATE persistent_logins SET token = ? WHERE email = ?",
+            "tampered-server-token-value", "alice@example.test");
 
         // Auto-login on a protected URL with no session triggers processAutoLoginCookie,
         // which calls removeUserTokens before throwing CookieTheftException (which propagates
@@ -145,8 +145,8 @@ class TenantPersistentTokenBasedRememberMeServicesIntegrationTest {
             .isInstanceOf(org.springframework.security.web.authentication.rememberme.CookieTheftException.class);
 
         Integer rowCount = jdbcTemplate.queryForObject(
-            "SELECT COUNT(*) FROM persistent_logins WHERE username = ?",
-            Integer.class, "alice"
+            "SELECT COUNT(*) FROM persistent_logins WHERE email = ?",
+            Integer.class, "alice@example.test"
         );
         assertThat(rowCount).isEqualTo(0);
     }
@@ -157,16 +157,16 @@ class TenantPersistentTokenBasedRememberMeServicesIntegrationTest {
         Cookie rememberMeCookie = loginAndGetRememberMeCookie("/manage/t/alpha-rm/login", "alpha-pwd");
         assertThat(rememberMeCookie).isNotNull();
         // Backdate the persisted token well beyond the validity window (default 14 days).
-        jdbcTemplate.update("UPDATE persistent_logins SET last_used = ? WHERE username = ?",
-            Timestamp.valueOf(LocalDateTime.now().minusDays(100)), "alice");
+        jdbcTemplate.update("UPDATE persistent_logins SET last_used = ? WHERE email = ?",
+            Timestamp.valueOf(LocalDateTime.now().minusDays(100)), "alice@example.test");
 
         mockMvc.perform(get("/manage/t/alpha-rm/applications").cookie(rememberMeCookie))
             .andExpect(status().is3xxRedirection());
 
         // Expired tokens are not removed (only theft removes them); the row remains.
         Integer rowCount = jdbcTemplate.queryForObject(
-            "SELECT COUNT(*) FROM persistent_logins WHERE username = ?",
-            Integer.class, "alice"
+            "SELECT COUNT(*) FROM persistent_logins WHERE email = ?",
+            Integer.class, "alice@example.test"
         );
         assertThat(rowCount).isEqualTo(1);
     }
@@ -175,7 +175,7 @@ class TenantPersistentTokenBasedRememberMeServicesIntegrationTest {
     @DisplayName("Logout deletes the persistent_logins row and redirects back to the tenant's login page")
     void logoutRemovesPersistentTokenAndRedirectsToTenantLogin() throws Exception {
         MvcResult login = mockMvc.perform(post("/manage/t/alpha-rm/login")
-                .param("username", "alice")
+                .param("email", "alice@example.test")
                 .param("password", "alpha-pwd")
                 .param("remember-me", "on")
                 .with(csrf()))
@@ -185,7 +185,7 @@ class TenantPersistentTokenBasedRememberMeServicesIntegrationTest {
         Cookie rememberMeCookie = login.getResponse().getCookie("remember-me");
         assertThat(rememberMeCookie).isNotNull();
         assertThat(jdbcTemplate.queryForObject(
-            "SELECT COUNT(*) FROM persistent_logins WHERE username = ?", Integer.class, "alice"))
+            "SELECT COUNT(*) FROM persistent_logins WHERE email = ?", Integer.class, "alice@example.test"))
             .isEqualTo(1);
 
         mockMvc.perform(post("/manage/logout")
@@ -197,13 +197,13 @@ class TenantPersistentTokenBasedRememberMeServicesIntegrationTest {
             .andExpect(redirectedUrl("/manage/t/alpha-rm/login"));
 
         assertThat(jdbcTemplate.queryForObject(
-            "SELECT COUNT(*) FROM persistent_logins WHERE username = ?", Integer.class, "alice"))
+            "SELECT COUNT(*) FROM persistent_logins WHERE email = ?", Integer.class, "alice@example.test"))
             .isEqualTo(0);
     }
 
     private Cookie loginAndGetRememberMeCookie(String loginPath, String password) throws Exception {
         return mockMvc.perform(post(loginPath)
-                .param("username", "alice")
+                .param("email", "alice@example.test")
                 .param("password", password)
                 .param("remember-me", "on")
                 .with(csrf()))

--- a/src/test/java/com/stucray/limen/auth/TenantPersistentTokenBasedRememberMeServicesUnitTest.java
+++ b/src/test/java/com/stucray/limen/auth/TenantPersistentTokenBasedRememberMeServicesUnitTest.java
@@ -58,7 +58,7 @@ class TenantPersistentTokenBasedRememberMeServicesUnitTest {
         services.setTokenValiditySeconds(3600);
 
         alpha = new Tenant(1L, "alpha", "Alpha", TenantStatus.ACTIVE, LocalDateTime.now());
-        alice = new User(10L, 1L, "alice", "hash", true, false, false, LocalDateTime.now());
+        alice = new User(10L, 1L, "alice@example.test", "hash", true, false, false, LocalDateTime.now());
     }
 
     @Test

--- a/src/test/java/com/stucray/limen/auth/TenantPersistentTokenRepositoryIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/auth/TenantPersistentTokenRepositoryIntegrationTest.java
@@ -41,12 +41,13 @@ class TenantPersistentTokenRepositoryIntegrationTest {
     @Test
     @DisplayName("getTokenForSeries returns the row only when called with the matching tenant_id")
     void createAndGetIsTenantScoped() {
-        repo.createNewToken(new PersistentRememberMeToken("alice", "series-1", "tok-1", new Date()), alpha.id());
-        repo.createNewToken(new PersistentRememberMeToken("alice", "series-2", "tok-2", new Date()), beta.id());
+        repo.createNewToken(new PersistentRememberMeToken("alice@example.test", "series-1", "tok-1", new Date()), alpha.id());
+        repo.createNewToken(new PersistentRememberMeToken("alice@example.test", "series-2", "tok-2", new Date()), beta.id());
 
         TenantPersistentRememberMeToken alphaRow = repo.getTokenForSeries("series-1", alpha.id());
         assertThat(alphaRow).isNotNull();
-        assertThat(alphaRow.getUsername()).isEqualTo("alice");
+        // Spring's PersistentRememberMeToken.getUsername() returns the email value in this codebase
+        assertThat(alphaRow.getUsername()).isEqualTo("alice@example.test");
         assertThat(alphaRow.getTenantId()).isEqualTo(alpha.id());
 
         // Same series under wrong tenant returns null
@@ -56,7 +57,7 @@ class TenantPersistentTokenRepositoryIntegrationTest {
     @Test
     @DisplayName("updateToken under the wrong tenant_id is a no-op; under the right one it replaces the token")
     void updateIsTenantScoped() {
-        repo.createNewToken(new PersistentRememberMeToken("alice", "series-3", "old-tok", new Date()), alpha.id());
+        repo.createNewToken(new PersistentRememberMeToken("alice@example.test", "series-3", "old-tok", new Date()), alpha.id());
 
         // Update under wrong tenant — no-op
         repo.updateToken("series-3", beta.id(), "wrong-tok", new Date());
@@ -70,10 +71,10 @@ class TenantPersistentTokenRepositoryIntegrationTest {
     @Test
     @DisplayName("removeUserTokens deletes only the rows belonging to the named tenant")
     void removeUserTokensIsTenantScoped() {
-        repo.createNewToken(new PersistentRememberMeToken("alice", "series-4", "tok-a", new Date()), alpha.id());
-        repo.createNewToken(new PersistentRememberMeToken("alice", "series-5", "tok-b", new Date()), beta.id());
+        repo.createNewToken(new PersistentRememberMeToken("alice@example.test", "series-4", "tok-a", new Date()), alpha.id());
+        repo.createNewToken(new PersistentRememberMeToken("alice@example.test", "series-5", "tok-b", new Date()), beta.id());
 
-        repo.removeUserTokens("alice", alpha.id());
+        repo.removeUserTokens("alice@example.test", alpha.id());
 
         assertThat(repo.getTokenForSeries("series-4", alpha.id())).isNull();
         // Beta's row survives
@@ -84,8 +85,8 @@ class TenantPersistentTokenRepositoryIntegrationTest {
     @DisplayName("Two tenants can store rows for the same series — (tenant_id, series) is the composite PK")
     void sameSeriesAcrossTenantsCoexist() {
         // (tenant_id, series) is the PK so both rows can persist with the same series.
-        repo.createNewToken(new PersistentRememberMeToken("alice", "shared", "tok-a", new Date()), alpha.id());
-        repo.createNewToken(new PersistentRememberMeToken("alice", "shared", "tok-b", new Date()), beta.id());
+        repo.createNewToken(new PersistentRememberMeToken("alice@example.test", "shared", "tok-a", new Date()), alpha.id());
+        repo.createNewToken(new PersistentRememberMeToken("alice@example.test", "shared", "tok-b", new Date()), beta.id());
 
         assertThat(repo.getTokenForSeries("shared", alpha.id()).getTokenValue()).isEqualTo("tok-a");
         assertThat(repo.getTokenForSeries("shared", beta.id()).getTokenValue()).isEqualTo("tok-b");

--- a/src/test/java/com/stucray/limen/auth/TenantUserDetailsServiceUnitTest.java
+++ b/src/test/java/com/stucray/limen/auth/TenantUserDetailsServiceUnitTest.java
@@ -37,50 +37,51 @@ class TenantUserDetailsServiceUnitTest {
     void setUp() {
         service = new TenantUserDetailsService(tenantRepository, userRepository);
         alpha = new Tenant(1L, "alpha", "Alpha", TenantStatus.ACTIVE, LocalDateTime.now());
-        alice = new User(10L, 1L, "alice", "hash", true, false, false, LocalDateTime.now());
+        alice = new User(10L, 1L, "alice@example.test", "hash", true, false, false, LocalDateTime.now());
     }
 
     @Test
-    @DisplayName("Returns TenantUserDetails carrying both username and tenant slug for a known user")
-    void loadByUsernameAndSlugReturnsTenantUserDetailsForKnownUser() {
+    @DisplayName("Returns TenantUserDetails carrying both email and tenant slug for a known user")
+    void loadByEmailAndSlugReturnsTenantUserDetailsForKnownUser() {
         given(tenantRepository.findBySlug("alpha")).willReturn(Optional.of(alpha));
-        given(userRepository.findByUsernameAndTenantId("alice", 1L)).willReturn(Optional.of(alice));
+        given(userRepository.findByEmailAndTenantId("alice@example.test", 1L)).willReturn(Optional.of(alice));
 
-        UserDetails details = service.loadByUsernameAndSlug("alice", "alpha");
+        UserDetails details = service.loadByEmailAndSlug("alice@example.test", "alpha");
 
         assertThat(details).isInstanceOf(TenantUserDetails.class);
         TenantUserDetails tenantDetails = (TenantUserDetails) details;
-        assertThat(tenantDetails.getUsername()).isEqualTo("alice");
+        // Spring's UserDetails.getUsername() returns the email value in this codebase
+        assertThat(tenantDetails.getUsername()).isEqualTo("alice@example.test");
         assertThat(tenantDetails.tenantSlug()).isEqualTo("alpha");
         assertThat(tenantDetails.userId()).isEqualTo(10L);
     }
 
     @Test
     @DisplayName("Throws UsernameNotFoundException when the slug does not resolve to a tenant")
-    void loadByUsernameAndSlugThrowsWhenTenantSlugUnknown() {
+    void loadByEmailAndSlugThrowsWhenTenantSlugUnknown() {
         given(tenantRepository.findBySlug("ghost")).willReturn(Optional.empty());
 
-        assertThatThrownBy(() -> service.loadByUsernameAndSlug("alice", "ghost"))
+        assertThatThrownBy(() -> service.loadByEmailAndSlug("alice@example.test", "ghost"))
             .isInstanceOf(UsernameNotFoundException.class)
             .hasMessageContaining("Unknown tenant: ghost");
     }
 
     @Test
     @DisplayName("Throws UsernameNotFoundException when the user is unknown within the resolved tenant")
-    void loadByUsernameAndSlugThrowsWhenUserUnknownInTenant() {
+    void loadByEmailAndSlugThrowsWhenUserUnknownInTenant() {
         given(tenantRepository.findBySlug("alpha")).willReturn(Optional.of(alpha));
-        given(userRepository.findByUsernameAndTenantId("nobody", 1L)).willReturn(Optional.empty());
+        given(userRepository.findByEmailAndTenantId("nobody@example.test", 1L)).willReturn(Optional.empty());
 
-        assertThatThrownBy(() -> service.loadByUsernameAndSlug("nobody", "alpha"))
+        assertThatThrownBy(() -> service.loadByEmailAndSlug("nobody@example.test", "alpha"))
             .isInstanceOf(UsernameNotFoundException.class)
-            .hasMessage("nobody");
+            .hasMessage("nobody@example.test");
     }
 
     @Test
     @DisplayName("loadUserByUsername (the slugless API) always throws — slug is required")
     void loadUserByUsernameAlwaysThrowsBecauseSlugIsRequired() {
-        assertThatThrownBy(() -> service.loadUserByUsername("alice"))
+        assertThatThrownBy(() -> service.loadUserByUsername("alice@example.test"))
             .isInstanceOf(UnsupportedOperationException.class)
-            .hasMessageContaining("loadByUsernameAndSlug");
+            .hasMessageContaining("loadByEmailAndSlug");
     }
 }

--- a/src/test/java/com/stucray/limen/auth/login/SyntheticSchemeIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/auth/login/SyntheticSchemeIntegrationTest.java
@@ -70,7 +70,7 @@ class SyntheticSchemeIntegrationTest {
         tenantRepository.save(new Tenant(
             null, "beta", "Beta", TenantStatus.ACTIVE, LocalDateTime.now()));
         userRepository.save(new User(
-            null, alpha.id(), "owner",
+            null, alpha.id(), "owner@example.test",
             passwordEncoder.encode("alpha-pwd"),
             true, false, false, LocalDateTime.now()));
     }
@@ -86,7 +86,7 @@ class SyntheticSchemeIntegrationTest {
     @DisplayName("Alpha session hitting /api/t/beta/... is force-logged-out and redirected to /api/t/beta/login")
     void crossTenantAccessOnSyntheticSurfaceForcesLogoutAndRedirects() throws Exception {
         MvcResult loginResult = mockMvc.perform(post("/manage/t/alpha/login")
-                .param("username", "owner")
+                .param("email", "owner@example.test")
                 .param("password", "alpha-pwd")
                 .with(csrf()))
             .andExpect(status().is3xxRedirection())

--- a/src/test/java/com/stucray/limen/enduser/EndUserHomeIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/enduser/EndUserHomeIntegrationTest.java
@@ -58,7 +58,7 @@ class EndUserHomeIntegrationTest {
             null, "alpha-corp", "Alpha Corp", TenantStatus.ACTIVE, LocalDateTime.now()
         ));
         userRepository.save(new User(
-            null, testTenant.id(), "alice",
+            null, testTenant.id(), "alice@example.test",
             passwordEncoder.encode("password"),
             true, false, false, LocalDateTime.now()
         ));
@@ -68,7 +68,7 @@ class EndUserHomeIntegrationTest {
     @DisplayName("Successful end-user login redirects to /t/{slug}/")
     void successfulLoginRedirectsToHome() throws Exception {
         mockMvc.perform(post("/t/alpha-corp/login")
-                .param("username", "alice")
+                .param("email", "alice@example.test")
                 .param("password", "password")
                 .with(csrf()))
             .andExpect(status().is3xxRedirection())
@@ -84,10 +84,10 @@ class EndUserHomeIntegrationTest {
     }
 
     @Test
-    @DisplayName("Authenticated end user can GET /t/{slug}/ and sees the tenant display name plus their username")
+    @DisplayName("Authenticated end user can GET /t/{slug}/ and sees the tenant display name plus their email")
     void authenticatedUserCanAccessHome() throws Exception {
         MvcResult loginResult = mockMvc.perform(post("/t/alpha-corp/login")
-                .param("username", "alice")
+                .param("email", "alice@example.test")
                 .param("password", "password")
                 .with(csrf()))
             .andReturn();
@@ -97,14 +97,14 @@ class EndUserHomeIntegrationTest {
         mockMvc.perform(get("/t/alpha-corp/").session(session))
             .andExpect(status().isOk())
             .andExpect(content().string(org.hamcrest.Matchers.containsString("Alpha Corp")))
-            .andExpect(content().string(org.hamcrest.Matchers.containsString("alice")));
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("alice@example.test")));
     }
 
     @Test
     @DisplayName("Cross-tenant access: TenantAccessFilter force-logs out and redirects to the URL slug's login page")
     void crossTenantAccessIsBlocked() throws Exception {
         MvcResult loginResult = mockMvc.perform(post("/t/alpha-corp/login")
-                .param("username", "alice")
+                .param("email", "alice@example.test")
                 .param("password", "password")
                 .with(csrf()))
             .andReturn();
@@ -124,7 +124,7 @@ class EndUserHomeIntegrationTest {
     @DisplayName("POST /t/{slug}/logout invalidates the session and redirects to that tenant's login page")
     void logoutInvalidatesSessionAndRedirects() throws Exception {
         MvcResult loginResult = mockMvc.perform(post("/t/alpha-corp/login")
-                .param("username", "alice")
+                .param("email", "alice@example.test")
                 .param("password", "password")
                 .with(csrf()))
             .andReturn();

--- a/src/test/java/com/stucray/limen/identity/UserBootstrapTest.java
+++ b/src/test/java/com/stucray/limen/identity/UserBootstrapTest.java
@@ -38,7 +38,7 @@ class UserBootstrapTest {
     }
 
     private static final BootstrapAdminProperties NO_ADMIN = new BootstrapAdminProperties(null, null);
-    private static final BootstrapAdminProperties ADMIN = new BootstrapAdminProperties("admin", "pass");
+    private static final BootstrapAdminProperties ADMIN = new BootstrapAdminProperties("admin@example.test", "pass");
 
     @Test
     @DisplayName("Always looks up the system tenant on startup, even with no admin credentials configured")
@@ -69,13 +69,13 @@ class UserBootstrapTest {
     @Test
     @DisplayName("Creates the configured admin user in the system tenant with an encoded password")
     void createsAdminUserInSystemTenantWhenAbsent() throws Exception {
-        given(userRepository.findByUsernameAndTenantId("admin", 1L)).willReturn(Optional.empty());
+        given(userRepository.findByEmailAndTenantId("admin@example.test", 1L)).willReturn(Optional.empty());
         given(passwordEncoder.encode("pass")).willReturn("hashed");
 
         new UserBootstrap(ADMIN, tenantRepository, tenantProvisioningService, userRepository, passwordEncoder).run();
 
         verify(userRepository).save(argThat(u ->
-            u.username().equals("admin") && u.passwordHash().equals("hashed")
+            u.email().equals("admin@example.test") && u.passwordHash().equals("hashed")
             && u.tenantId().equals(1L) && u.enabled() && !u.mustChangePassword()
         ));
     }
@@ -83,11 +83,11 @@ class UserBootstrapTest {
     @Test
     @DisplayName("Re-hashes and saves the admin password when the admin user already exists")
     void updatesPasswordHashWhenAdminUserExists() throws Exception {
-        var existing = new User(10L, 1L, "admin", "oldhash", true, false, false, LocalDateTime.now());
-        given(userRepository.findByUsernameAndTenantId("admin", 1L)).willReturn(Optional.of(existing));
+        var existing = new User(10L, 1L, "admin@example.test", "oldhash", true, false, false, LocalDateTime.now());
+        given(userRepository.findByEmailAndTenantId("admin@example.test", 1L)).willReturn(Optional.of(existing));
         given(passwordEncoder.encode("newpass")).willReturn("newhash");
 
-        new UserBootstrap(new BootstrapAdminProperties("admin", "newpass"),
+        new UserBootstrap(new BootstrapAdminProperties("admin@example.test", "newpass"),
             tenantRepository, tenantProvisioningService, userRepository, passwordEncoder).run();
 
         verify(userRepository).save(argThat(u -> u.id().equals(10L) && u.passwordHash().equals("newhash")));

--- a/src/test/java/com/stucray/limen/management/ManagementForcedPasswordChangeIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/ManagementForcedPasswordChangeIntegrationTest.java
@@ -107,12 +107,12 @@ class ManagementForcedPasswordChangeIntegrationTest {
     @DisplayName("Login with must_change_password=true redirects to /manage/t/{slug}/change-password")
     void managementLoginRedirectsToChangePasswordWhenMustChangeFlagSet() throws Exception {
         userRepository.save(new User(
-            null, tenant.id(), "alice",
+            null, tenant.id(), "alice@example.test",
             passwordEncoder.encode("temp"),
             true, true, false, LocalDateTime.now()));
 
         MvcResult loginResult = mockMvc.perform(post("/manage/t/alpha-corp/login")
-                .param("username", "alice").param("password", "temp")
+                .param("email", "alice@example.test").param("password", "temp")
                 .with(csrf()))
             .andExpect(status().is3xxRedirection())
             .andReturn();
@@ -125,14 +125,14 @@ class ManagementForcedPasswordChangeIntegrationTest {
     @DisplayName("Login with a saved /oauth2/authorize redirects to the tenant-prefixed authorize URL, not the management home")
     void managementLoginResumesSavedOAuth2AuthorizeRequest() throws Exception {
         userRepository.save(new User(
-            null, tenant.id(), "owner",
+            null, tenant.id(), "owner@example.test",
             passwordEncoder.encode("password"),
             true, false, false, LocalDateTime.now()));
 
         MockHttpSession session = startAuthorize(newPkce().challenge());
 
         MvcResult loginResult = mockMvc.perform(post("/manage/t/alpha-corp/login")
-                .param("username", "owner").param("password", "password")
+                .param("email", "owner@example.test").param("password", "password")
                 .session(session).with(csrf()))
             .andExpect(status().is3xxRedirection())
             .andReturn();
@@ -147,14 +147,14 @@ class ManagementForcedPasswordChangeIntegrationTest {
     @DisplayName("Successful password change resumes the saved /oauth2/authorize flow and clears must_change_password")
     void changePasswordResumesOAuth2FlowAndClearsFlag() throws Exception {
         User original = userRepository.save(new User(
-            null, tenant.id(), "alice",
+            null, tenant.id(), "alice@example.test",
             passwordEncoder.encode("temp"),
             true, true, false, LocalDateTime.now()));
 
         MockHttpSession session = startAuthorize(newPkce().challenge());
 
         mockMvc.perform(post("/manage/t/alpha-corp/login")
-                .param("username", "alice").param("password", "temp")
+                .param("email", "alice@example.test").param("password", "temp")
                 .session(session).with(csrf()))
             .andExpect(status().is3xxRedirection());
 
@@ -174,13 +174,13 @@ class ManagementForcedPasswordChangeIntegrationTest {
     @DisplayName("Mismatched newPassword/confirmPassword re-renders the form; flag stays set")
     void mismatchedPasswordsRerendersFormAndDoesNotClearFlag() throws Exception {
         User original = userRepository.save(new User(
-            null, tenant.id(), "alice",
+            null, tenant.id(), "alice@example.test",
             passwordEncoder.encode("temp"),
             true, true, false, LocalDateTime.now()));
 
         MockHttpSession session = new MockHttpSession();
         mockMvc.perform(post("/manage/t/alpha-corp/login")
-                .param("username", "alice").param("password", "temp")
+                .param("email", "alice@example.test").param("password", "temp")
                 .session(session).with(csrf()))
             .andExpect(status().is3xxRedirection());
 
@@ -197,13 +197,13 @@ class ManagementForcedPasswordChangeIntegrationTest {
     @DisplayName("Blank/whitespace newPassword re-renders the form; flag stays set")
     void blankNewPasswordRerendersFormAndDoesNotClearFlag() throws Exception {
         User original = userRepository.save(new User(
-            null, tenant.id(), "alice",
+            null, tenant.id(), "alice@example.test",
             passwordEncoder.encode("temp"),
             true, true, false, LocalDateTime.now()));
 
         MockHttpSession session = new MockHttpSession();
         mockMvc.perform(post("/manage/t/alpha-corp/login")
-                .param("username", "alice").param("password", "temp")
+                .param("email", "alice@example.test").param("password", "temp")
                 .session(session).with(csrf()))
             .andExpect(status().is3xxRedirection());
 
@@ -219,13 +219,13 @@ class ManagementForcedPasswordChangeIntegrationTest {
     @DisplayName("Successful password change with no saved request redirects to /manage/t/{slug}/")
     void changePasswordWithoutSavedRequestRedirectsToManagementHome() throws Exception {
         User original = userRepository.save(new User(
-            null, tenant.id(), "alice",
+            null, tenant.id(), "alice@example.test",
             passwordEncoder.encode("temp"),
             true, true, false, LocalDateTime.now()));
 
         MockHttpSession session = new MockHttpSession();
         mockMvc.perform(post("/manage/t/alpha-corp/login")
-                .param("username", "alice").param("password", "temp")
+                .param("email", "alice@example.test").param("password", "temp")
                 .session(session).with(csrf()))
             .andExpect(status().is3xxRedirection());
 
@@ -244,13 +244,13 @@ class ManagementForcedPasswordChangeIntegrationTest {
     @DisplayName("GET /manage/t/{slug}/change-password renders the change-password form")
     void changePasswordFormGetRendersChangePasswordView() throws Exception {
         userRepository.save(new User(
-            null, tenant.id(), "alice",
+            null, tenant.id(), "alice@example.test",
             passwordEncoder.encode("temp"),
             true, true, false, LocalDateTime.now()));
 
         MockHttpSession session = new MockHttpSession();
         mockMvc.perform(post("/manage/t/alpha-corp/login")
-                .param("username", "alice").param("password", "temp")
+                .param("email", "alice@example.test").param("password", "temp")
                 .session(session).with(csrf()))
             .andExpect(status().is3xxRedirection());
 

--- a/src/test/java/com/stucray/limen/management/ManagementLoginIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/ManagementLoginIntegrationTest.java
@@ -56,7 +56,7 @@ class ManagementLoginIntegrationTest {
             null, "test-corp", "Test Corp", TenantStatus.ACTIVE, LocalDateTime.now()
         ));
         userRepository.save(new User(
-            null, testTenant.id(), "owner",
+            null, testTenant.id(), "owner@example.test",
             passwordEncoder.encode("password"),
             true, false, false, LocalDateTime.now()
         ));
@@ -75,7 +75,7 @@ class ManagementLoginIntegrationTest {
     @DisplayName("Successful login redirects to /manage/t/{slug}/")
     void successfulLoginRedirectsToHome() throws Exception {
         mockMvc.perform(post("/manage/t/test-corp/login")
-                .param("username", "owner")
+                .param("email", "owner@example.test")
                 .param("password", "password")
                 .with(csrf()))
             .andExpect(status().is3xxRedirection())
@@ -86,7 +86,7 @@ class ManagementLoginIntegrationTest {
     @DisplayName("Bad password redirects back to /manage/t/{slug}/login?error")
     void failedLoginShowsError() throws Exception {
         mockMvc.perform(post("/manage/t/test-corp/login")
-                .param("username", "owner")
+                .param("email", "owner@example.test")
                 .param("password", "wrong")
                 .with(csrf()))
             .andExpect(status().is3xxRedirection())
@@ -105,7 +105,7 @@ class ManagementLoginIntegrationTest {
     @DisplayName("Authenticated user can GET /manage/t/{slug}/ and sees their tenant's display name")
     void authenticatedUserCanAccessManagementHome() throws Exception {
         MvcResult loginResult = mockMvc.perform(post("/manage/t/test-corp/login")
-                .param("username", "owner")
+                .param("email", "owner@example.test")
                 .param("password", "password")
                 .with(csrf()))
             .andReturn();
@@ -122,13 +122,13 @@ class ManagementLoginIntegrationTest {
     void systemAdminCanLoginAtSystemSlug() throws Exception {
         Tenant systemTenant = tenantRepository.findBySlug("system").orElseThrow();
         userRepository.save(new User(
-            null, systemTenant.id(), "sysadmin",
+            null, systemTenant.id(), "sysadmin@example.test",
             passwordEncoder.encode("syspassword"),
             true, false, false, LocalDateTime.now()
         ));
 
         mockMvc.perform(post("/manage/t/system/login")
-                .param("username", "sysadmin")
+                .param("email", "sysadmin@example.test")
                 .param("password", "syspassword")
                 .with(csrf()))
             .andExpect(status().is3xxRedirection())
@@ -139,7 +139,7 @@ class ManagementLoginIntegrationTest {
     @DisplayName("Cross-tenant access: TenantAccessFilter force-logs out and redirects to the URL slug's login page")
     void userCannotAccessAnotherTenantManagementPages() throws Exception {
         MvcResult loginResult = mockMvc.perform(post("/manage/t/test-corp/login")
-                .param("username", "owner")
+                .param("email", "owner@example.test")
                 .param("password", "password")
                 .with(csrf()))
             .andReturn();

--- a/src/test/java/com/stucray/limen/management/SignupIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/SignupIntegrationTest.java
@@ -52,7 +52,7 @@ class SignupIntegrationTest {
         mockMvc.perform(post("/signup")
                 .param("organizationName", "Acme Corp")
                 .param("slug", "acme-corp")
-                .param("username", "alice")
+                .param("email", "alice@example.test")
                 .param("password", "secret123")
                 .with(csrf()))
             .andExpect(status().is3xxRedirection())
@@ -74,7 +74,7 @@ class SignupIntegrationTest {
         mockMvc.perform(post("/signup")
                 .param("organizationName", "Another Corp")
                 .param("slug", "taken-slug")
-                .param("username", "bob")
+                .param("email", "bob@example.test")
                 .param("password", "secret123")
                 .with(csrf()))
             .andExpect(status().isOk())
@@ -88,7 +88,7 @@ class SignupIntegrationTest {
             mockMvc.perform(post("/signup")
                     .param("organizationName", "Test")
                     .param("slug", reserved)
-                    .param("username", "user")
+                    .param("email", "user@example.test")
                     .param("password", "secret123")
                     .with(csrf()))
                 .andExpect(status().isOk())
@@ -102,7 +102,7 @@ class SignupIntegrationTest {
         mockMvc.perform(post("/signup")
                 .param("organizationName", "Test")
                 .param("slug", "UPPERCASE")
-                .param("username", "user")
+                .param("email", "user@example.test")
                 .param("password", "secret123")
                 .with(csrf()))
             .andExpect(status().isOk())
@@ -113,12 +113,12 @@ class SignupIntegrationTest {
     @MethodSource("invalidFormCases")
     @DisplayName("Invalid field re-renders form with field-level error")
     void invalidFormFieldRendersFieldError(
-        String label, String slug, String orgName, String username, String password, String expectedFragment
+        String label, String slug, String orgName, String email, String password, String expectedFragment
     ) throws Exception {
         mockMvc.perform(post("/signup")
                 .param("slug", slug)
                 .param("organizationName", orgName)
-                .param("username", username)
+                .param("email", email)
                 .param("password", password)
                 .with(csrf()))
             .andExpect(status().isOk())
@@ -127,14 +127,15 @@ class SignupIntegrationTest {
 
     static java.util.stream.Stream<Arguments> invalidFormCases() {
         String fortyNineChars  = "a".repeat(49);
-        String hundredOneChars = "u".repeat(101);
+        String twoFiftySixLocal = "u".repeat(256);
         return java.util.stream.Stream.of(
-            Arguments.of("slug too short",          "ab",            "Acme", "alice", "secret123", "between 3 and 48"),
-            Arguments.of("slug too long",           fortyNineChars,  "Acme", "alice", "secret123", "between 3 and 48"),
-            Arguments.of("blank organization name", "acme-corp",     "",     "alice", "secret123", "Organization name is required"),
-            Arguments.of("blank username",          "acme-corp",     "Acme", "",      "secret123", "Username is required"),
-            Arguments.of("username too long",       "acme-corp",     "Acme", hundredOneChars, "secret123", "100 characters or fewer"),
-            Arguments.of("blank password",          "acme-corp",     "Acme", "alice", "",          "Password is required")
+            Arguments.of("slug too short",          "ab",            "Acme", "alice@example.test", "secret123", "between 3 and 48"),
+            Arguments.of("slug too long",           fortyNineChars,  "Acme", "alice@example.test", "secret123", "between 3 and 48"),
+            Arguments.of("blank organization name", "acme-corp",     "",     "alice@example.test", "secret123", "Organization name is required"),
+            Arguments.of("blank email",             "acme-corp",     "Acme", "",                   "secret123", "Email is required"),
+            Arguments.of("email too long",          "acme-corp",     "Acme", twoFiftySixLocal + "@example.test", "secret123", "255 characters or fewer"),
+            Arguments.of("email malformed (no @)",  "acme-corp",     "Acme", "not-an-email",       "secret123", "valid email address"),
+            Arguments.of("blank password",          "acme-corp",     "Acme", "alice@example.test", "",          "Password is required")
         );
     }
 }

--- a/src/test/java/com/stucray/limen/management/applications/ApplicationManagementIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/applications/ApplicationManagementIntegrationTest.java
@@ -56,10 +56,10 @@ class ApplicationManagementIntegrationTest {
 
         tenantA = tenantRepository.save(new Tenant(null, "corp-a", "Corp A", TenantStatus.ACTIVE, LocalDateTime.now()));
         tenantB = tenantRepository.save(new Tenant(null, "corp-b", "Corp B", TenantStatus.ACTIVE, LocalDateTime.now()));
-        userRepository.save(new User(null, tenantA.id(), "owner", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        userRepository.save(new User(null, tenantA.id(), "owner@example.test", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
 
         MvcResult login = mockMvc.perform(post("/manage/t/corp-a/login")
-                .param("username", "owner").param("password", "pass").with(csrf()))
+                .param("email", "owner@example.test").param("password", "pass").with(csrf()))
             .andReturn();
         sessionA = (MockHttpSession) login.getRequest().getSession(false);
     }
@@ -167,9 +167,9 @@ class ApplicationManagementIntegrationTest {
     @DisplayName("Tenant A's applications are not visible to a tenant B session — TenantAccessFilter forces logout")
     void tenantAApplicationsNotVisibleToTenantBSession() throws Exception {
         Application appA = applicationRepository.save(new Application(null, tenantA.id(), "App A", null, LocalDateTime.now()));
-        userRepository.save(new User(null, tenantB.id(), "ownerB", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        userRepository.save(new User(null, tenantB.id(), "ownerB@example.test", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
         MvcResult loginB = mockMvc.perform(post("/manage/t/corp-b/login")
-                .param("username", "ownerB").param("password", "pass").with(csrf()))
+                .param("email", "ownerB@example.test").param("password", "pass").with(csrf()))
             .andReturn();
         MockHttpSession sessionB = (MockHttpSession) loginB.getRequest().getSession(false);
 

--- a/src/test/java/com/stucray/limen/management/clients/ClientManagementIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/clients/ClientManagementIntegrationTest.java
@@ -72,10 +72,10 @@ class ClientManagementIntegrationTest {
         tenantA = tenantRepository.save(new Tenant(null, "corp-a", "Corp A", TenantStatus.ACTIVE, LocalDateTime.now()));
         tenantB = tenantRepository.save(new Tenant(null, "corp-b", "Corp B", TenantStatus.ACTIVE, LocalDateTime.now()));
         appA = applicationRepository.save(new Application(null, tenantA.id(), "App A", null, LocalDateTime.now()));
-        userRepository.save(new User(null, tenantA.id(), "owner", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        userRepository.save(new User(null, tenantA.id(), "owner@example.test", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
 
         MvcResult login = mockMvc.perform(post("/manage/t/corp-a/login")
-                .param("username", "owner").param("password", "pass").with(csrf()))
+                .param("email", "owner@example.test").param("password", "pass").with(csrf()))
             .andReturn();
         sessionA = (MockHttpSession) login.getRequest().getSession(false);
     }
@@ -216,9 +216,9 @@ class ClientManagementIntegrationTest {
     @DisplayName("Tenant A's clients list is not visible to a tenant B session — TenantAccessFilter forces logout")
     void tenantAClientsNotVisibleToTenantBSession() throws Exception {
         createConfidentialClient("Tenant A Client");
-        userRepository.save(new User(null, tenantB.id(), "ownerB", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        userRepository.save(new User(null, tenantB.id(), "ownerB@example.test", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
         MvcResult loginB = mockMvc.perform(post("/manage/t/corp-b/login")
-                .param("username", "ownerB").param("password", "pass").with(csrf()))
+                .param("email", "ownerB@example.test").param("password", "pass").with(csrf()))
             .andReturn();
         MockHttpSession sessionB = (MockHttpSession) loginB.getRequest().getSession(false);
 

--- a/src/test/java/com/stucray/limen/management/clients/ClientTokenSettingsIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/clients/ClientTokenSettingsIntegrationTest.java
@@ -85,7 +85,7 @@ class ClientTokenSettingsIntegrationTest {
 
         tenant = tenantProvisioningService.createTenant("token-test", "Token Test");
         app = applicationRepository.save(new Application(null, tenant.id(), "Test App", null, LocalDateTime.now()));
-        alice = userRepository.save(new User(null, tenant.id(), "alice", passwordEncoder.encode("password"), true, false, false, LocalDateTime.now()));
+        alice = userRepository.save(new User(null, tenant.id(), "alice@example.test", passwordEncoder.encode("password"), true, false, false, LocalDateTime.now()));
     }
 
     private void grantMembership(String registeredClientId) {
@@ -165,7 +165,7 @@ class ClientTokenSettingsIntegrationTest {
             .andExpect(status().is3xxRedirection());
 
         mockMvc.perform(post("/t/token-test/login")
-                .param("username", "alice").param("password", "password")
+                .param("email", "alice@example.test").param("password", "password")
                 .session(session).with(csrf()))
             .andExpect(status().is3xxRedirection());
 
@@ -323,7 +323,7 @@ class ClientTokenSettingsIntegrationTest {
 
         // Login
         mockMvc.perform(post("/t/token-test/login")
-                .param("username", "alice").param("password", "password")
+                .param("email", "alice@example.test").param("password", "password")
                 .session(session).with(csrf()))
             .andExpect(status().is3xxRedirection());
 

--- a/src/test/java/com/stucray/limen/management/memberships/ApplicationMembershipServiceIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/memberships/ApplicationMembershipServiceIntegrationTest.java
@@ -64,10 +64,10 @@ class ApplicationMembershipServiceIntegrationTest {
         tenantB = tenantRepository.save(new Tenant(null, "mem-b", "Mem B", TenantStatus.ACTIVE, LocalDateTime.now()));
         appA = applicationRepository.save(new Application(null, tenantA.id(), "App A", null, LocalDateTime.now()));
         appB = applicationRepository.save(new Application(null, tenantB.id(), "App B", null, LocalDateTime.now()));
-        aliceA = userRepository.save(new User(null, tenantA.id(), "alice", "x", true, false, false, LocalDateTime.now()));
-        bobA = userRepository.save(new User(null, tenantA.id(), "bob",   "x", true, false, false, LocalDateTime.now()));
-        adminA = userRepository.save(new User(null, tenantA.id(), "admin", "x", true, false, true,  LocalDateTime.now()));
-        carolB = userRepository.save(new User(null, tenantB.id(), "carol", "x", true, false, false, LocalDateTime.now()));
+        aliceA = userRepository.save(new User(null, tenantA.id(), "alice@example.test", "x", true, false, false, LocalDateTime.now()));
+        bobA = userRepository.save(new User(null, tenantA.id(), "bob@example.test",   "x", true, false, false, LocalDateTime.now()));
+        adminA = userRepository.save(new User(null, tenantA.id(), "admin@example.test", "x", true, false, true,  LocalDateTime.now()));
+        carolB = userRepository.save(new User(null, tenantB.id(), "carol@example.test", "x", true, false, false, LocalDateTime.now()));
     }
 
     @Test
@@ -279,6 +279,6 @@ class ApplicationMembershipServiceIntegrationTest {
 
         var grantable = membershipService.listGrantableUsers(appA.id(), tenantA.id());
 
-        assertThat(grantable).extracting(User::username).containsExactlyInAnyOrder("bob", "admin");
+        assertThat(grantable).extracting(User::email).containsExactlyInAnyOrder("bob@example.test", "admin@example.test");
     }
 }

--- a/src/test/java/com/stucray/limen/management/memberships/ClientMembersControllerIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/memberships/ClientMembersControllerIntegrationTest.java
@@ -75,8 +75,8 @@ class ClientMembersControllerIntegrationTest {
 
         tenantA = tenantRepository.save(new Tenant(null, "client-mem-a", "Client Mem A", TenantStatus.ACTIVE, LocalDateTime.now()));
         tenantB = tenantRepository.save(new Tenant(null, "client-mem-b", "Client Mem B", TenantStatus.ACTIVE, LocalDateTime.now()));
-        ownerA = userRepository.save(new User(null, tenantA.id(), "owner", passwordEncoder.encode("pass"), true, false, true,  LocalDateTime.now()));
-        aliceA = userRepository.save(new User(null, tenantA.id(), "alice", passwordEncoder.encode("pass"), true, false, false, LocalDateTime.now()));
+        ownerA = userRepository.save(new User(null, tenantA.id(), "owner@example.test", passwordEncoder.encode("pass"), true, false, true,  LocalDateTime.now()));
+        aliceA = userRepository.save(new User(null, tenantA.id(), "alice@example.test", passwordEncoder.encode("pass"), true, false, false, LocalDateTime.now()));
         appA = applicationRepository.save(new Application(null, tenantA.id(), "App A", "desc", LocalDateTime.now()));
         clientA = clientManagementService.createClient(
             appA.id(), tenantA.id(), "client-a",
@@ -86,7 +86,7 @@ class ClientMembersControllerIntegrationTest {
         ).client();
 
         MvcResult login = mockMvc.perform(post("/manage/t/client-mem-a/login")
-                .param("username", "owner").param("password", "pass").with(csrf()))
+                .param("email", "owner@example.test").param("password", "pass").with(csrf()))
             .andReturn();
         sessionA = (MockHttpSession) login.getRequest().getSession(false);
     }
@@ -107,7 +107,7 @@ class ClientMembersControllerIntegrationTest {
 
         mockMvc.perform(get(url("/members")).session(sessionA))
             .andExpect(status().isOk())
-            .andExpect(content().string(org.hamcrest.Matchers.containsString("alice")));
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("alice@example.test")));
     }
 
     @Test
@@ -209,7 +209,7 @@ class ClientMembersControllerIntegrationTest {
 
         mockMvc.perform(get(url("/members/new")).session(sessionA))
             .andExpect(status().isOk())
-            .andExpect(content().string(org.hamcrest.Matchers.containsString("alice")));
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("alice@example.test")));
     }
 
     @Test
@@ -251,9 +251,9 @@ class ClientMembersControllerIntegrationTest {
     @Test
     @DisplayName("Tenant B session is force-redirected to tenant A's login when reaching tenant A's client members")
     void tenantBSessionCannotReachTenantAClientMembers() throws Exception {
-        userRepository.save(new User(null, tenantB.id(), "ownerB", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        userRepository.save(new User(null, tenantB.id(), "ownerB@example.test", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
         MvcResult loginB = mockMvc.perform(post("/manage/t/client-mem-b/login")
-                .param("username", "ownerB").param("password", "pass").with(csrf()))
+                .param("email", "ownerB@example.test").param("password", "pass").with(csrf()))
             .andReturn();
         MockHttpSession sessionB = (MockHttpSession) loginB.getRequest().getSession(false);
 

--- a/src/test/java/com/stucray/limen/management/memberships/ClientMembershipServiceIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/memberships/ClientMembershipServiceIntegrationTest.java
@@ -75,10 +75,10 @@ class ClientMembershipServiceIntegrationTest {
         appA  = applicationRepository.save(new Application(null, tenantA.id(), "App A",  null, LocalDateTime.now()));
         appA2 = applicationRepository.save(new Application(null, tenantA.id(), "App A2", null, LocalDateTime.now()));
         appB  = applicationRepository.save(new Application(null, tenantB.id(), "App B",  null, LocalDateTime.now()));
-        aliceA = userRepository.save(new User(null, tenantA.id(), "alice", "x", true, false, false, LocalDateTime.now()));
-        bobA   = userRepository.save(new User(null, tenantA.id(), "bob",   "x", true, false, false, LocalDateTime.now()));
-        adminA = userRepository.save(new User(null, tenantA.id(), "admin", "x", true, false, true,  LocalDateTime.now()));
-        carolB = userRepository.save(new User(null, tenantB.id(), "carol", "x", true, false, false, LocalDateTime.now()));
+        aliceA = userRepository.save(new User(null, tenantA.id(), "alice@example.test", "x", true, false, false, LocalDateTime.now()));
+        bobA   = userRepository.save(new User(null, tenantA.id(), "bob@example.test",   "x", true, false, false, LocalDateTime.now()));
+        adminA = userRepository.save(new User(null, tenantA.id(), "admin@example.test", "x", true, false, true,  LocalDateTime.now()));
+        carolB = userRepository.save(new User(null, tenantB.id(), "carol@example.test", "x", true, false, false, LocalDateTime.now()));
 
         clientA  = createClient(appA.id(),  tenantA.id(), "client-a");
         clientA2 = createClient(appA2.id(), tenantA.id(), "client-a2");
@@ -334,6 +334,6 @@ class ClientMembershipServiceIntegrationTest {
         var grantable = clientMembershipService.listGrantableUsers(clientA.registeredClientId(), appA.id(), tenantA.id());
 
         // admin has no App Membership → not eligible. alice has Client Membership → not eligible.
-        assertThat(grantable).extracting(User::username).containsExactly("bob");
+        assertThat(grantable).extracting(User::email).containsExactly("bob@example.test");
     }
 }

--- a/src/test/java/com/stucray/limen/management/memberships/MembersControllerIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/memberships/MembersControllerIntegrationTest.java
@@ -71,12 +71,12 @@ class MembersControllerIntegrationTest {
 
         tenantA = tenantRepository.save(new Tenant(null, "members-corp-a", "Members Corp A", TenantStatus.ACTIVE, LocalDateTime.now()));
         tenantB = tenantRepository.save(new Tenant(null, "members-corp-b", "Members Corp B", TenantStatus.ACTIVE, LocalDateTime.now()));
-        ownerA = userRepository.save(new User(null, tenantA.id(), "owner", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
-        aliceA = userRepository.save(new User(null, tenantA.id(), "alice", passwordEncoder.encode("pass"), true, false, false, LocalDateTime.now()));
+        ownerA = userRepository.save(new User(null, tenantA.id(), "owner@example.test", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        aliceA = userRepository.save(new User(null, tenantA.id(), "alice@example.test", passwordEncoder.encode("pass"), true, false, false, LocalDateTime.now()));
         appA = applicationRepository.save(new Application(null, tenantA.id(), "App A", "desc", LocalDateTime.now()));
 
         MvcResult login = mockMvc.perform(post("/manage/t/members-corp-a/login")
-                .param("username", "owner").param("password", "pass").with(csrf()))
+                .param("email", "owner@example.test").param("password", "pass").with(csrf()))
             .andReturn();
         sessionA = (MockHttpSession) login.getRequest().getSession(false);
     }
@@ -90,7 +90,7 @@ class MembersControllerIntegrationTest {
 
         mockMvc.perform(get("/manage/t/members-corp-a/applications/" + appA.id() + "/members").session(sessionA))
             .andExpect(status().isOk())
-            .andExpect(content().string(org.hamcrest.Matchers.containsString("alice")));
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("alice@example.test")));
     }
 
     @Test
@@ -172,7 +172,7 @@ class MembersControllerIntegrationTest {
         mockMvc.perform(get("/manage/t/members-corp-a/applications/" + appA.id() + "/members/" + m.id() + "/edit")
                 .session(sessionA))
             .andExpect(status().isOk())
-            .andExpect(content().string(org.hamcrest.Matchers.containsString("alice")))
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("alice@example.test")))
             .andExpect(content().string(org.hamcrest.Matchers.containsString("viewer")));
     }
 
@@ -183,7 +183,7 @@ class MembersControllerIntegrationTest {
         mockMvc.perform(get("/manage/t/members-corp-a/applications/" + appA.id() + "/members/new")
                 .session(sessionA))
             .andExpect(status().isOk())
-            .andExpect(content().string(org.hamcrest.Matchers.containsString("alice")));
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("alice@example.test")));
     }
 
     @Test
@@ -219,9 +219,9 @@ class MembersControllerIntegrationTest {
     @Test
     @DisplayName("Tenant B session is force-redirected to tenant A's login when reaching tenant A's members")
     void tenantBSessionCannotReachTenantAMembers() throws Exception {
-        userRepository.save(new User(null, tenantB.id(), "ownerB", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        userRepository.save(new User(null, tenantB.id(), "ownerB@example.test", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
         MvcResult loginB = mockMvc.perform(post("/manage/t/members-corp-b/login")
-                .param("username", "ownerB").param("password", "pass").with(csrf()))
+                .param("email", "ownerB@example.test").param("password", "pass").with(csrf()))
             .andReturn();
         MockHttpSession sessionB = (MockHttpSession) loginB.getRequest().getSession(false);
 

--- a/src/test/java/com/stucray/limen/management/roles/RolesControllerIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/roles/RolesControllerIntegrationTest.java
@@ -62,11 +62,11 @@ class RolesControllerIntegrationTest {
 
         tenantA = tenantRepository.save(new Tenant(null, "roles-corp-a", "Roles Corp A", TenantStatus.ACTIVE, LocalDateTime.now()));
         tenantB = tenantRepository.save(new Tenant(null, "roles-corp-b", "Roles Corp B", TenantStatus.ACTIVE, LocalDateTime.now()));
-        userRepository.save(new User(null, tenantA.id(), "owner", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        userRepository.save(new User(null, tenantA.id(), "owner@example.test", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
         appA = applicationRepository.save(new Application(null, tenantA.id(), "App A", "desc", LocalDateTime.now()));
 
         MvcResult login = mockMvc.perform(post("/manage/t/roles-corp-a/login")
-                .param("username", "owner").param("password", "pass").with(csrf()))
+                .param("email", "owner@example.test").param("password", "pass").with(csrf()))
             .andReturn();
         sessionA = (MockHttpSession) login.getRequest().getSession(false);
     }
@@ -162,7 +162,7 @@ class RolesControllerIntegrationTest {
         // row so the FK ON DELETE RESTRICT fires when the role is deleted. Using
         // raw SQL keeps the test independent of the ApplicationMembershipService.
         Role role = roleRepository.save(new Role(null, appA.id(), "viewer", null, LocalDateTime.now()));
-        Long ownerId = userRepository.findByUsernameAndTenantId("owner", tenantA.id()).orElseThrow().id();
+        Long ownerId = userRepository.findByEmailAndTenantId("owner@example.test", tenantA.id()).orElseThrow().id();
         Long membershipId = jdbcTemplate.queryForObject(
             "INSERT INTO application_membership (user_id, application_id, granted_at, granted_by) VALUES (?,?,NOW(),?) RETURNING id",
             Long.class, ownerId, appA.id(), ownerId
@@ -195,9 +195,9 @@ class RolesControllerIntegrationTest {
     @Test
     @DisplayName("Tenant B session is force-redirected to tenant A's login when reaching tenant A's roles")
     void tenantBSessionCannotReachTenantARoles() throws Exception {
-        userRepository.save(new User(null, tenantB.id(), "ownerB", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        userRepository.save(new User(null, tenantB.id(), "ownerB@example.test", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
         MvcResult loginB = mockMvc.perform(post("/manage/t/roles-corp-b/login")
-                .param("username", "ownerB").param("password", "pass").with(csrf()))
+                .param("email", "ownerB@example.test").param("password", "pass").with(csrf()))
             .andReturn();
         MockHttpSession sessionB = (MockHttpSession) loginB.getRequest().getSession(false);
 

--- a/src/test/java/com/stucray/limen/management/system/SystemAdminCrossTenantIsolationIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/system/SystemAdminCrossTenantIsolationIntegrationTest.java
@@ -57,7 +57,7 @@ class SystemAdminCrossTenantIsolationIntegrationTest {
 
         Tenant systemTenant = tenantRepository.findBySlug("system").orElseThrow();
         userRepository.save(new User(
-            null, systemTenant.id(), "sysadmin",
+            null, systemTenant.id(), "sysadmin@example.test",
             passwordEncoder.encode("syspass"),
             true, false, false, LocalDateTime.now()
         ));
@@ -67,7 +67,7 @@ class SystemAdminCrossTenantIsolationIntegrationTest {
         ));
 
         MvcResult login = mockMvc.perform(post("/manage/t/system/login")
-                .param("username", "sysadmin")
+                .param("email", "sysadmin@example.test")
                 .param("password", "syspass")
                 .with(csrf()))
             .andExpect(status().is3xxRedirection())

--- a/src/test/java/com/stucray/limen/management/system/SystemAdminIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/system/SystemAdminIntegrationTest.java
@@ -53,10 +53,10 @@ class SystemAdminIntegrationTest {
         jdbcTemplate.execute("DELETE FROM users WHERE tenant_id = (SELECT id FROM tenants WHERE slug = 'system')");
 
         Tenant systemTenant = tenantRepository.findBySlug("system").orElseThrow();
-        userRepository.save(new User(null, systemTenant.id(), "sysadmin", passwordEncoder.encode("syspass"), true, false, false, LocalDateTime.now()));
+        userRepository.save(new User(null, systemTenant.id(), "sysadmin@example.test", passwordEncoder.encode("syspass"), true, false, false, LocalDateTime.now()));
 
         MvcResult login = mockMvc.perform(post("/manage/t/system/login")
-                .param("username", "sysadmin").param("password", "syspass").with(csrf()))
+                .param("email", "sysadmin@example.test").param("password", "syspass").with(csrf()))
             .andReturn();
         adminSession = (MockHttpSession) login.getRequest().getSession(false);
 
@@ -84,11 +84,11 @@ class SystemAdminIntegrationTest {
     @Test
     @DisplayName("Login at a suspended tenant fails (redirects to ?error)")
     void suspendedTenantLoginIsBlocked() throws Exception {
-        userRepository.save(new User(null, customerTenant.id(), "owner", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        userRepository.save(new User(null, customerTenant.id(), "owner@example.test", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
         tenantRepository.save(customerTenant.withStatus(TenantStatus.SUSPENDED));
 
         mockMvc.perform(post("/manage/t/customer/login")
-                .param("username", "owner").param("password", "pass").with(csrf()))
+                .param("email", "owner@example.test").param("password", "pass").with(csrf()))
             .andExpect(status().is3xxRedirection())
             .andExpect(redirectedUrl("/manage/t/customer/login?error"));
     }
@@ -141,9 +141,9 @@ class SystemAdminIntegrationTest {
     @DisplayName("A tenant owner can view their tenant settings and update its display name")
     void tenantOwnerCanViewAndUpdateTenantDetails() throws Exception {
         Tenant corp = tenantRepository.save(new Tenant(null, "my-corp", "My Corp", TenantStatus.ACTIVE, LocalDateTime.now()));
-        userRepository.save(new User(null, corp.id(), "owner", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        userRepository.save(new User(null, corp.id(), "owner@example.test", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
         MvcResult login = mockMvc.perform(post("/manage/t/my-corp/login")
-                .param("username", "owner").param("password", "pass").with(csrf()))
+                .param("email", "owner@example.test").param("password", "pass").with(csrf()))
             .andReturn();
         MockHttpSession ownerSession = (MockHttpSession) login.getRequest().getSession(false);
 

--- a/src/test/java/com/stucray/limen/management/users/UserDetailControllerIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/users/UserDetailControllerIntegrationTest.java
@@ -82,8 +82,8 @@ class UserDetailControllerIntegrationTest {
 
         tenantA = tenantRepository.save(new Tenant(null, "user-detail-a", "User Detail A", TenantStatus.ACTIVE, LocalDateTime.now()));
         tenantB = tenantRepository.save(new Tenant(null, "user-detail-b", "User Detail B", TenantStatus.ACTIVE, LocalDateTime.now()));
-        ownerA = userRepository.save(new User(null, tenantA.id(), "owner", passwordEncoder.encode("pass"), true, false, true,  LocalDateTime.now()));
-        aliceA = userRepository.save(new User(null, tenantA.id(), "alice", passwordEncoder.encode("pass"), true, false, false, LocalDateTime.now()));
+        ownerA = userRepository.save(new User(null, tenantA.id(), "owner@example.test", passwordEncoder.encode("pass"), true, false, true,  LocalDateTime.now()));
+        aliceA = userRepository.save(new User(null, tenantA.id(), "alice@example.test", passwordEncoder.encode("pass"), true, false, false, LocalDateTime.now()));
         appA = applicationRepository.save(new Application(null, tenantA.id(), "Acme Web", "desc", LocalDateTime.now()));
         clientA = clientManagementService.createClient(
             appA.id(), tenantA.id(), "acme-spa",
@@ -93,7 +93,7 @@ class UserDetailControllerIntegrationTest {
         ).client();
 
         MvcResult login = mockMvc.perform(post("/manage/t/user-detail-a/login")
-                .param("username", "owner").param("password", "pass").with(csrf()))
+                .param("email", "owner@example.test").param("password", "pass").with(csrf()))
             .andReturn();
         sessionA = (MockHttpSession) login.getRequest().getSession(false);
     }
@@ -162,9 +162,9 @@ class UserDetailControllerIntegrationTest {
     @Test
     @DisplayName("A session for tenant B cannot view a user-detail page in tenant A — redirects to tenant A's login")
     void crossTenantSessionCannotReachUserDetail() throws Exception {
-        userRepository.save(new User(null, tenantB.id(), "ownerB", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        userRepository.save(new User(null, tenantB.id(), "ownerB@example.test", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
         MvcResult loginB = mockMvc.perform(post("/manage/t/user-detail-b/login")
-                .param("username", "ownerB").param("password", "pass").with(csrf()))
+                .param("email", "ownerB@example.test").param("password", "pass").with(csrf()))
             .andReturn();
         MockHttpSession sessionB = (MockHttpSession) loginB.getRequest().getSession(false);
 
@@ -174,8 +174,8 @@ class UserDetailControllerIntegrationTest {
     }
 
     @Test
-    @DisplayName("On the users list page, each username links to that user's detail page")
-    void usernameOnListPageLinksToDetail() throws Exception {
+    @DisplayName("On the users list page, each email links to that user's detail page")
+    void emailOnListPageLinksToDetail() throws Exception {
         mockMvc.perform(get("/manage/t/user-detail-a/users").session(sessionA))
             .andExpect(status().isOk())
             .andExpect(content().string(containsString(
@@ -187,7 +187,7 @@ class UserDetailControllerIntegrationTest {
     @DisplayName("Empty-state still shows when other users in the same tenant have memberships but the target user does not")
     void detailPageRendersWhenMembershipsExistInOtherAppsButNotForThisUser() throws Exception {
         // Other user has memberships, target user does not — empty state still shows.
-        User bob = userRepository.save(new User(null, tenantA.id(), "bob", passwordEncoder.encode("pass"), true, false, false, LocalDateTime.now()));
+        User bob = userRepository.save(new User(null, tenantA.id(), "bob@example.test", passwordEncoder.encode("pass"), true, false, false, LocalDateTime.now()));
         appMembershipRepository.save(new ApplicationMembership(
             null, bob.id(), appA.id(), LocalDateTime.now(), ownerA.id(), Set.of()
         ));

--- a/src/test/java/com/stucray/limen/management/users/UserManagementIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/users/UserManagementIntegrationTest.java
@@ -48,10 +48,10 @@ class UserManagementIntegrationTest {
         jdbcTemplate.execute("DELETE FROM tenants WHERE slug != 'system'");
 
         tenant = tenantRepository.save(new Tenant(null, "corp", "Corp", TenantStatus.ACTIVE, LocalDateTime.now()));
-        userRepository.save(new User(null, tenant.id(), "owner", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        userRepository.save(new User(null, tenant.id(), "owner@example.test", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
 
         MvcResult login = mockMvc.perform(post("/manage/t/corp/login")
-                .param("username", "owner").param("password", "pass").with(csrf()))
+                .param("email", "owner@example.test").param("password", "pass").with(csrf()))
             .andReturn();
         ownerSession = (MockHttpSession) login.getRequest().getSession(false);
     }
@@ -61,24 +61,24 @@ class UserManagementIntegrationTest {
     void ownerCanListUsers() throws Exception {
         mockMvc.perform(get("/manage/t/corp/users").session(ownerSession))
             .andExpect(status().isOk())
-            .andExpect(content().string(org.hamcrest.Matchers.containsString("owner")));
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("owner@example.test")));
     }
 
     @Test
     @DisplayName("Creating a user persists them with mustChangePassword=true so they're forced to set a real password on first login")
     void ownerCanCreateUser() throws Exception {
         mockMvc.perform(post("/manage/t/corp/users").session(ownerSession).with(csrf())
-                .param("username", "alice").param("temporaryPassword", "temppass1"))
+                .param("email", "alice@example.test").param("temporaryPassword", "temppass1"))
             .andExpect(status().is3xxRedirection());
 
-        assertThat(userRepository.findByUsernameAndTenantId("alice", tenant.id())).isPresent();
-        assertThat(userRepository.findByUsernameAndTenantId("alice", tenant.id()).orElseThrow().mustChangePassword()).isTrue();
+        assertThat(userRepository.findByEmailAndTenantId("alice@example.test", tenant.id())).isPresent();
+        assertThat(userRepository.findByEmailAndTenantId("alice@example.test", tenant.id()).orElseThrow().mustChangePassword()).isTrue();
     }
 
     @Test
     @DisplayName("Tenant owner can disable a user and re-enable them, flipping the enabled flag in both directions")
     void ownerCanDisableAndEnableUser() throws Exception {
-        User alice = userRepository.save(new User(null, tenant.id(), "alice", passwordEncoder.encode("pass"), true, false, false, LocalDateTime.now()));
+        User alice = userRepository.save(new User(null, tenant.id(), "alice@example.test", passwordEncoder.encode("pass"), true, false, false, LocalDateTime.now()));
 
         mockMvc.perform(post("/manage/t/corp/users/" + alice.id() + "/disable").session(ownerSession).with(csrf()))
             .andExpect(status().is3xxRedirection());
@@ -92,7 +92,7 @@ class UserManagementIntegrationTest {
     @Test
     @DisplayName("Tenant owner can delete a user — the row is removed from the users table")
     void ownerCanDeleteUser() throws Exception {
-        User alice = userRepository.save(new User(null, tenant.id(), "alice", passwordEncoder.encode("pass"), true, false, false, LocalDateTime.now()));
+        User alice = userRepository.save(new User(null, tenant.id(), "alice@example.test", passwordEncoder.encode("pass"), true, false, false, LocalDateTime.now()));
 
         mockMvc.perform(post("/manage/t/corp/users/" + alice.id() + "/delete").session(ownerSession).with(csrf()))
             .andExpect(status().is3xxRedirection());
@@ -102,7 +102,7 @@ class UserManagementIntegrationTest {
     @Test
     @DisplayName("Reset-password sets a temporary password and flips mustChangePassword=true so the user must change it on next login")
     void ownerCanResetPassword() throws Exception {
-        User alice = userRepository.save(new User(null, tenant.id(), "alice", passwordEncoder.encode("oldpass"), true, false, false, LocalDateTime.now()));
+        User alice = userRepository.save(new User(null, tenant.id(), "alice@example.test", passwordEncoder.encode("oldpass"), true, false, false, LocalDateTime.now()));
 
         mockMvc.perform(post("/manage/t/corp/users/" + alice.id() + "/reset-password").session(ownerSession).with(csrf())
                 .param("temporaryPassword", "newpass123"))
@@ -115,7 +115,7 @@ class UserManagementIntegrationTest {
     @Test
     @DisplayName("Tenant owner can grant the tenant-owner role to another user and revoke it again")
     void ownerCanGrantAndRevokeTenantOwnerRole() throws Exception {
-        User alice = userRepository.save(new User(null, tenant.id(), "alice", passwordEncoder.encode("pass"), true, false, false, LocalDateTime.now()));
+        User alice = userRepository.save(new User(null, tenant.id(), "alice@example.test", passwordEncoder.encode("pass"), true, false, false, LocalDateTime.now()));
 
         mockMvc.perform(post("/manage/t/corp/users/" + alice.id() + "/grant-owner").session(ownerSession).with(csrf()))
             .andExpect(status().is3xxRedirection());
@@ -129,10 +129,10 @@ class UserManagementIntegrationTest {
     @Test
     @DisplayName("A user with mustChangePassword=true is redirected to the change-password page on every authenticated request")
     void userWithMustChangePasswordIsInterceptedToChangePasswordPage() throws Exception {
-        userRepository.save(new User(null, tenant.id(), "newuser", passwordEncoder.encode("temp"), true, true, false, LocalDateTime.now()));
+        userRepository.save(new User(null, tenant.id(), "newuser@example.test", passwordEncoder.encode("temp"), true, true, false, LocalDateTime.now()));
 
         MvcResult login = mockMvc.perform(post("/manage/t/corp/login")
-                .param("username", "newuser").param("password", "temp").with(csrf()))
+                .param("email", "newuser@example.test").param("password", "temp").with(csrf()))
             .andReturn();
         MockHttpSession newUserSession = (MockHttpSession) login.getRequest().getSession(false);
 
@@ -144,10 +144,10 @@ class UserManagementIntegrationTest {
     @Test
     @DisplayName("After successfully changing the password, mustChangePassword is cleared so the user can use the app normally")
     void mustChangePasswordClearedAfterChange() throws Exception {
-        User newUser = userRepository.save(new User(null, tenant.id(), "newuser", passwordEncoder.encode("temp"), true, true, false, LocalDateTime.now()));
+        User newUser = userRepository.save(new User(null, tenant.id(), "newuser@example.test", passwordEncoder.encode("temp"), true, true, false, LocalDateTime.now()));
 
         MvcResult login = mockMvc.perform(post("/manage/t/corp/login")
-                .param("username", "newuser").param("password", "temp").with(csrf()))
+                .param("email", "newuser@example.test").param("password", "temp").with(csrf()))
             .andReturn();
         MockHttpSession newUserSession = (MockHttpSession) login.getRequest().getSession(false);
 
@@ -161,10 +161,10 @@ class UserManagementIntegrationTest {
     @Test
     @DisplayName("Mismatched new/confirm passwords re-render the form with an error and leave mustChangePassword=true")
     void changePasswordRedisplaysFormWhenNewAndConfirmDoNotMatch() throws Exception {
-        User newUser = userRepository.save(new User(null, tenant.id(), "newuser", passwordEncoder.encode("temp"), true, true, false, LocalDateTime.now()));
+        User newUser = userRepository.save(new User(null, tenant.id(), "newuser@example.test", passwordEncoder.encode("temp"), true, true, false, LocalDateTime.now()));
 
         MvcResult login = mockMvc.perform(post("/manage/t/corp/login")
-                .param("username", "newuser").param("password", "temp").with(csrf()))
+                .param("email", "newuser@example.test").param("password", "temp").with(csrf()))
             .andReturn();
         MockHttpSession newUserSession = (MockHttpSession) login.getRequest().getSession(false);
 
@@ -180,10 +180,10 @@ class UserManagementIntegrationTest {
     @Test
     @DisplayName("Blank/whitespace new password re-renders the form with 'Password is required' and leaves mustChangePassword=true")
     void changePasswordRedisplaysFormWhenNewPasswordIsBlank() throws Exception {
-        User newUser = userRepository.save(new User(null, tenant.id(), "newuser", passwordEncoder.encode("temp"), true, true, false, LocalDateTime.now()));
+        User newUser = userRepository.save(new User(null, tenant.id(), "newuser@example.test", passwordEncoder.encode("temp"), true, true, false, LocalDateTime.now()));
 
         MvcResult login = mockMvc.perform(post("/manage/t/corp/login")
-                .param("username", "newuser").param("password", "temp").with(csrf()))
+                .param("email", "newuser@example.test").param("password", "temp").with(csrf()))
             .andReturn();
         MockHttpSession newUserSession = (MockHttpSession) login.getRequest().getSession(false);
 

--- a/src/test/java/com/stucray/limen/oauth2/OAuth2AuthorizeMembershipGateIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/OAuth2AuthorizeMembershipGateIntegrationTest.java
@@ -111,22 +111,22 @@ class OAuth2AuthorizeMembershipGateIntegrationTest {
             null, betaTenant.id(), "Beta App", null, LocalDateTime.now()
         ));
         aliceAlpha = userRepository.save(new User(
-            null, alphaTenant.id(), "alice",
+            null, alphaTenant.id(), "alice@example.test",
             passwordEncoder.encode("password"),
             true, false, false, LocalDateTime.now()
         ));
         adminAlpha = userRepository.save(new User(
-            null, alphaTenant.id(), "alpha-admin",
+            null, alphaTenant.id(), "alpha-admin@example.test",
             passwordEncoder.encode("password"),
             true, false, true, LocalDateTime.now()
         ));
         bobBeta = userRepository.save(new User(
-            null, betaTenant.id(), "bob",
+            null, betaTenant.id(), "bob@example.test",
             passwordEncoder.encode("password"),
             true, false, false, LocalDateTime.now()
         ));
         adminBeta = userRepository.save(new User(
-            null, betaTenant.id(), "beta-admin",
+            null, betaTenant.id(), "beta-admin@example.test",
             passwordEncoder.encode("password"),
             true, false, true, LocalDateTime.now()
         ));
@@ -139,7 +139,7 @@ class OAuth2AuthorizeMembershipGateIntegrationTest {
 
         // alice authenticates successfully; the gate rejects the authorization
         // request with access_denied (302 to redirect_uri).
-        String location = runFlowToAuthorizeRedirect(alphaTenant.slug(), client, "alice", "password");
+        String location = runFlowToAuthorizeRedirect(alphaTenant.slug(), client, "alice@example.test", "password");
 
         Map<String, String> params = queryParams(location);
         assertThat(params.get("error")).isEqualTo("access_denied");
@@ -158,7 +158,7 @@ class OAuth2AuthorizeMembershipGateIntegrationTest {
         );
 
         Map<String, Object> claims = runFlowAndExtractJwtClaims(
-            alphaTenant.slug(), client, "alice", "password"
+            alphaTenant.slug(), client, "alice@example.test", "password"
         );
 
         assertThat(claims.get("tenant")).isEqualTo("gate-alpha");
@@ -178,7 +178,7 @@ class OAuth2AuthorizeMembershipGateIntegrationTest {
         );
 
         Map<String, Object> claims = runFlowAndExtractJwtClaims(
-            alphaTenant.slug(), client, "alice", "password"
+            alphaTenant.slug(), client, "alice@example.test", "password"
         );
 
         assertThat(claims.get("tenant")).isEqualTo("gate-alpha");
@@ -209,7 +209,7 @@ class OAuth2AuthorizeMembershipGateIntegrationTest {
 
         // bob's credentials don't validate against Tenant Alpha's User pool.
         mockMvc.perform(post("/t/" + alphaTenant.slug() + "/login")
-                .param("username", "bob").param("password", "password")
+                .param("email", "bob@example.test").param("password", "password")
                 .session(session).with(csrf()))
             .andExpect(status().is3xxRedirection())
             .andExpect(result ->
@@ -238,7 +238,7 @@ class OAuth2AuthorizeMembershipGateIntegrationTest {
     }
 
     private String runFlowToAuthorizeRedirect(
-        String slug, TenantClient client, String username, String password
+        String slug, TenantClient client, String email, String password
     ) throws Exception {
         Pkce pkce = pkce();
         MockHttpSession session = new MockHttpSession();
@@ -248,7 +248,7 @@ class OAuth2AuthorizeMembershipGateIntegrationTest {
             .andExpect(status().is3xxRedirection());
 
         mockMvc.perform(post("/t/" + slug + "/login")
-                .param("username", username).param("password", password)
+                .param("email", email).param("password", password)
                 .session(session).with(csrf()))
             .andExpect(status().is3xxRedirection());
 
@@ -260,7 +260,7 @@ class OAuth2AuthorizeMembershipGateIntegrationTest {
     }
 
     private Map<String, Object> runFlowAndExtractJwtClaims(
-        String slug, TenantClient client, String username, String password
+        String slug, TenantClient client, String email, String password
     ) throws Exception {
         Pkce pkce = pkce();
         MockHttpSession session = new MockHttpSession();
@@ -269,7 +269,7 @@ class OAuth2AuthorizeMembershipGateIntegrationTest {
         mockMvc.perform(get(authzUri).session(session))
             .andExpect(status().is3xxRedirection());
         mockMvc.perform(post("/t/" + slug + "/login")
-                .param("username", username).param("password", password)
+                .param("email", email).param("password", password)
                 .session(session).with(csrf()))
             .andExpect(status().is3xxRedirection());
         MvcResult codeResult = mockMvc.perform(get(authzUri).session(session))

--- a/src/test/java/com/stucray/limen/oauth2/OAuth2ForcedPasswordChangeIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/OAuth2ForcedPasswordChangeIntegrationTest.java
@@ -107,14 +107,14 @@ class OAuth2ForcedPasswordChangeIntegrationTest {
     @DisplayName("During an /oauth2/authorize flow, a user with mustChangePassword=true is redirected to the tenant change-password page after login")
     void userWithMustChangePasswordRedirectedToChangePasswordPage() throws Exception {
         userRepository.save(new User(
-            null, tenant.id(), "alice",
+            null, tenant.id(), "alice@example.test",
             passwordEncoder.encode("temp"),
             true, true, false, LocalDateTime.now()));
 
         MockHttpSession session = startAuthorize(newPkce().challenge());
 
         MvcResult loginResult = mockMvc.perform(post("/t/alpha-corp/login")
-                .param("username", "alice").param("password", "temp")
+                .param("email", "alice@example.test").param("password", "temp")
                 .session(session).with(csrf()))
             .andExpect(status().is3xxRedirection())
             .andReturn();
@@ -127,7 +127,7 @@ class OAuth2ForcedPasswordChangeIntegrationTest {
     @DisplayName("Successful change-password clears mustChangePassword and resumes the saved /oauth2/authorize request, ultimately yielding an authorization code")
     void changePasswordResumesOAuth2FlowAndClearsFlag() throws Exception {
         User original = userRepository.save(new User(
-            null, tenant.id(), "alice",
+            null, tenant.id(), "alice@example.test",
             passwordEncoder.encode("temp"),
             true, true, false, LocalDateTime.now()));
         ClientMembershipTestFixture.grant(
@@ -139,7 +139,7 @@ class OAuth2ForcedPasswordChangeIntegrationTest {
         MockHttpSession session = startAuthorize(newPkce().challenge());
 
         mockMvc.perform(post("/t/alpha-corp/login")
-                .param("username", "alice").param("password", "temp")
+                .param("email", "alice@example.test").param("password", "temp")
                 .session(session).with(csrf()))
             .andExpect(status().is3xxRedirection());
 
@@ -167,14 +167,14 @@ class OAuth2ForcedPasswordChangeIntegrationTest {
     @DisplayName("Mismatched new/confirm re-renders the form and leaves mustChangePassword=true so the user remains gated")
     void mismatchedPasswordsRerendersFormAndDoesNotClearFlag() throws Exception {
         User original = userRepository.save(new User(
-            null, tenant.id(), "alice",
+            null, tenant.id(), "alice@example.test",
             passwordEncoder.encode("temp"),
             true, true, false, LocalDateTime.now()));
 
         MockHttpSession session = startAuthorize(newPkce().challenge());
 
         mockMvc.perform(post("/t/alpha-corp/login")
-                .param("username", "alice").param("password", "temp")
+                .param("email", "alice@example.test").param("password", "temp")
                 .session(session).with(csrf()))
             .andExpect(status().is3xxRedirection());
 
@@ -191,14 +191,14 @@ class OAuth2ForcedPasswordChangeIntegrationTest {
     @DisplayName("A user without mustChangePassword goes straight from login back to /oauth2/authorize without the change-password detour")
     void userWithoutMustChangePasswordCompletesNormally() throws Exception {
         userRepository.save(new User(
-            null, tenant.id(), "bob",
+            null, tenant.id(), "bob@example.test",
             passwordEncoder.encode("password"),
             true, false, false, LocalDateTime.now()));
 
         MockHttpSession session = startAuthorize(newPkce().challenge());
 
         MvcResult loginResult = mockMvc.perform(post("/t/alpha-corp/login")
-                .param("username", "bob").param("password", "password")
+                .param("email", "bob@example.test").param("password", "password")
                 .session(session).with(csrf()))
             .andExpect(status().is3xxRedirection())
             .andReturn();
@@ -211,14 +211,14 @@ class OAuth2ForcedPasswordChangeIntegrationTest {
     @DisplayName("Blank/whitespace new password re-renders the form and leaves mustChangePassword=true")
     void blankNewPasswordRerendersFormAndDoesNotClearFlag() throws Exception {
         User original = userRepository.save(new User(
-            null, tenant.id(), "alice",
+            null, tenant.id(), "alice@example.test",
             passwordEncoder.encode("temp"),
             true, true, false, LocalDateTime.now()));
 
         MockHttpSession session = startAuthorize(newPkce().challenge());
 
         mockMvc.perform(post("/t/alpha-corp/login")
-                .param("username", "alice").param("password", "temp")
+                .param("email", "alice@example.test").param("password", "temp")
                 .session(session).with(csrf()))
             .andExpect(status().is3xxRedirection());
 
@@ -237,13 +237,13 @@ class OAuth2ForcedPasswordChangeIntegrationTest {
         // SavedRequest in the cache); after success the controller should fall back
         // to redirect:/t/{slug}/.
         User original = userRepository.save(new User(
-            null, tenant.id(), "alice",
+            null, tenant.id(), "alice@example.test",
             passwordEncoder.encode("temp"),
             true, true, false, LocalDateTime.now()));
 
         MockHttpSession session = new MockHttpSession();
         mockMvc.perform(post("/t/alpha-corp/login")
-                .param("username", "alice").param("password", "temp")
+                .param("email", "alice@example.test").param("password", "temp")
                 .session(session).with(csrf()))
             .andExpect(status().is3xxRedirection());
 
@@ -262,13 +262,13 @@ class OAuth2ForcedPasswordChangeIntegrationTest {
     @DisplayName("GET /t/{slug}/change-password renders the change-password view for an authenticated mustChangePassword user")
     void changePasswordFormGetRendersChangePasswordView() throws Exception {
         userRepository.save(new User(
-            null, tenant.id(), "alice",
+            null, tenant.id(), "alice@example.test",
             passwordEncoder.encode("temp"),
             true, true, false, LocalDateTime.now()));
 
         MockHttpSession session = new MockHttpSession();
         mockMvc.perform(post("/t/alpha-corp/login")
-                .param("username", "alice").param("password", "temp")
+                .param("email", "alice@example.test").param("password", "temp")
                 .session(session).with(csrf()))
             .andExpect(status().is3xxRedirection());
 

--- a/src/test/java/com/stucray/limen/oauth2/OAuth2JwtRolesClaimIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/OAuth2JwtRolesClaimIntegrationTest.java
@@ -101,12 +101,12 @@ class OAuth2JwtRolesClaimIntegrationTest {
             null, tenant.id(), "Acme Web", "End-to-end test app", LocalDateTime.now()
         ));
         alice = userRepository.save(new User(
-            null, tenant.id(), "alice",
+            null, tenant.id(), "alice@example.test",
             passwordEncoder.encode("password"),
             true, false, false, LocalDateTime.now()
         ));
         admin = userRepository.save(new User(
-            null, tenant.id(), "admin",
+            null, tenant.id(), "admin@example.test",
             passwordEncoder.encode("password"),
             true, false, true, LocalDateTime.now()
         ));
@@ -128,7 +128,7 @@ class OAuth2JwtRolesClaimIntegrationTest {
         );
 
         // 3. Run the authorization code + PKCE flow as alice.
-        Map<String, Object> claims = runAuthorizationCodeFlow(client, "alice");
+        Map<String, Object> claims = runAuthorizationCodeFlow(client, "alice@example.test");
 
         // 4. Verify JWT claims.
         assertThat(claims.get("tenant")).isEqualTo("acme");
@@ -151,7 +151,7 @@ class OAuth2JwtRolesClaimIntegrationTest {
             client.registeredClientId(), Set.of()
         );
 
-        Map<String, Object> claims = runAuthorizationCodeFlow(client, "alice");
+        Map<String, Object> claims = runAuthorizationCodeFlow(client, "alice@example.test");
 
         assertThat(claims.get("tenant")).isEqualTo("acme");
         assertThat((List<?>) claims.get("roles")).isEmpty();
@@ -177,7 +177,7 @@ class OAuth2JwtRolesClaimIntegrationTest {
         ));
     }
 
-    private Map<String, Object> runAuthorizationCodeFlow(TenantClient client, String username) throws Exception {
+    private Map<String, Object> runAuthorizationCodeFlow(TenantClient client, String email) throws Exception {
         String oauthClientId = jdbcTemplate.queryForObject(
             "SELECT client_id FROM oauth2_registered_client WHERE id = ?",
             String.class, client.registeredClientId()
@@ -206,7 +206,7 @@ class OAuth2JwtRolesClaimIntegrationTest {
         assertThat(authzResult.getResponse().getHeader("Location")).contains("/t/acme/login");
 
         mockMvc.perform(post("/t/acme/login")
-                .param("username", username)
+                .param("email", email)
                 .param("password", "password")
                 .session(session)
                 .with(csrf()))

--- a/src/test/java/com/stucray/limen/oauth2/TenantAccessFilterIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/TenantAccessFilterIntegrationTest.java
@@ -59,7 +59,7 @@ class TenantAccessFilterIntegrationTest {
         beta = tenantRepository.save(new Tenant(null, "beta", "Beta", TenantStatus.ACTIVE, LocalDateTime.now()));
 
         userRepository.save(new User(
-            null, alpha.id(), "owner",
+            null, alpha.id(), "owner@example.test",
             passwordEncoder.encode("alpha-pwd"),
             true, false, false, LocalDateTime.now()
         ));
@@ -69,7 +69,7 @@ class TenantAccessFilterIntegrationTest {
     @DisplayName("Alpha-tenant session presented at /manage/t/beta/ is invalidated, redirected to beta's login, and is no longer authenticated for alpha either")
     void crossTenantManagementAccessForcesLogoutAndRedirect() throws Exception {
         MvcResult loginResult = mockMvc.perform(post("/manage/t/alpha/login")
-                .param("username", "owner")
+                .param("email", "owner@example.test")
                 .param("password", "alpha-pwd")
                 .with(csrf()))
             .andExpect(status().is3xxRedirection())

--- a/src/test/java/com/stucray/limen/oauth2/TenantOAuth2RoutingIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/TenantOAuth2RoutingIntegrationTest.java
@@ -107,7 +107,7 @@ class TenantOAuth2RoutingIntegrationTest {
             null, alphaCorpTenant.id(), "Alpha App", "Test app", LocalDateTime.now()
         ));
         alphaAdmin = userRepository.save(new User(
-            null, alphaCorpTenant.id(), "alpha-admin",
+            null, alphaCorpTenant.id(), "alpha-admin@example.test",
             passwordEncoder.encode("password"),
             true, false, true, LocalDateTime.now()
         ));
@@ -239,7 +239,7 @@ class TenantOAuth2RoutingIntegrationTest {
     @DisplayName("Full authorization-code + PKCE flow under /t/{slug}/ yields a token with tenant + iss claims for the end user")
     void authorizationCodePkceFlowProducesTokenWithTenantClaims() throws Exception {
         User alice = userRepository.save(new User(
-            null, alphaCorpTenant.id(), "alice",
+            null, alphaCorpTenant.id(), "alice@example.test",
             passwordEncoder.encode("password"),
             true, false, false, LocalDateTime.now()
         ));
@@ -296,7 +296,7 @@ class TenantOAuth2RoutingIntegrationTest {
 
         // 2. POST /t/alpha-corp/login → redirect to /t/alpha-corp/oauth2/authorize
         MvcResult loginResult = mockMvc.perform(post("/t/alpha-corp/login")
-                .param("username", "alice")
+                .param("email", "alice@example.test")
                 .param("password", "password")
                 .session(session)
                 .with(csrf()))
@@ -388,7 +388,7 @@ class TenantOAuth2RoutingIntegrationTest {
     @DisplayName("/t/{slug}/userinfo accepts a Bearer token from the same tenant and returns the user's claims")
     void userinfoEndpointReturnsClaimsForTenantUser() throws Exception {
         User bob = userRepository.save(new User(
-            null, alphaCorpTenant.id(), "bob",
+            null, alphaCorpTenant.id(), "bob@example.test",
             passwordEncoder.encode("password"),
             true, false, false, LocalDateTime.now()
         ));
@@ -435,7 +435,7 @@ class TenantOAuth2RoutingIntegrationTest {
             .andExpect(status().is3xxRedirection());
 
         mockMvc.perform(post("/t/alpha-corp/login")
-                .param("username", "bob")
+                .param("email", "bob@example.test")
                 .param("password", "password")
                 .session(session)
                 .with(csrf()))

--- a/src/test/java/com/stucray/limen/ui/journey/EndUserLoginJourneyUiIT.java
+++ b/src/test/java/com/stucray/limen/ui/journey/EndUserLoginJourneyUiIT.java
@@ -20,6 +20,6 @@ class EndUserLoginJourneyUiIT extends BaseUiIT {
 
         new EndUserHomePage(page, baseUrl(), tenant.slug())
             .assertOnHomeForTenant(tenant.displayName())
-            .assertSignedInAs(tenant.endUserUsername());
+            .assertSignedInAs(tenant.endUserEmail());
     }
 }

--- a/src/test/java/com/stucray/limen/ui/journey/ForcedPasswordChangeJourneyUiIT.java
+++ b/src/test/java/com/stucray/limen/ui/journey/ForcedPasswordChangeJourneyUiIT.java
@@ -19,7 +19,7 @@ class ForcedPasswordChangeJourneyUiIT extends BaseUiIT {
         SeededForcedChangeUser user = tenants.seedEndUserForcedPasswordChange(tenant);
 
         new LoginPageObject(page, baseUrl())
-            .loginAsEndUserWithCredentials(tenant.slug(), user.username(), user.temporaryPassword());
+            .loginAsEndUserWithCredentials(tenant.slug(), user.email(), user.temporaryPassword());
 
         new EndUserChangePasswordPage(page, baseUrl(), tenant.slug())
             .assertOnChangePasswordPage()
@@ -27,6 +27,6 @@ class ForcedPasswordChangeJourneyUiIT extends BaseUiIT {
             .fillConfirmPassword("new-password-123")
             .submit()
             .assertOnHomeForTenant(tenant.displayName())
-            .assertSignedInAs(user.username());
+            .assertSignedInAs(user.email());
     }
 }

--- a/src/test/java/com/stucray/limen/ui/journey/ManageUsersCreateJourneyUiIT.java
+++ b/src/test/java/com/stucray/limen/ui/journey/ManageUsersCreateJourneyUiIT.java
@@ -17,7 +17,7 @@ class ManageUsersCreateJourneyUiIT extends BaseUiIT {
     @DisplayName("happy path: from the manage home, navigates to Users, fills the add-user form, submits, and the new user appears in the list")
     void happyPath(Page page) {
         SeededTenant tenant = tenants.createTenant();
-        String username = "newuser-" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+        String email = "newuser-" + UUID.randomUUID().toString().replace("-", "").substring(0, 8) + "@example.test";
 
         new LoginPageObject(page, baseUrl()).loginAsTenantAdmin(tenant);
 
@@ -26,10 +26,10 @@ class ManageUsersCreateJourneyUiIT extends BaseUiIT {
             .assertOnList()
             .clickAddUser()
             .assertOnForm()
-            .fillUsername(username)
+            .fillEmail(email)
             .fillTemporaryPassword("temp-secret-123")
             .submit()
             .assertOnList()
-            .assertUserVisible(username);
+            .assertUserVisible(email);
     }
 }

--- a/src/test/java/com/stucray/limen/ui/journey/OAuth2AuthorizeJourneyUiIT.java
+++ b/src/test/java/com/stucray/limen/ui/journey/OAuth2AuthorizeJourneyUiIT.java
@@ -42,7 +42,7 @@ class OAuth2AuthorizeJourneyUiIT extends BaseUiIT {
         page.navigate(authorizeUrl);
         page.waitForURL("**/t/" + tenant.slug() + "/login");
 
-        page.getByLabel("Username").fill(tenant.endUserUsername());
+        page.getByLabel("Email").fill(tenant.endUserEmail());
         page.getByLabel("Password").fill(tenant.endUserPassword());
         // The terminal hop is a 302 to http://localhost/callback?code=…&state=… —
         // capture it via waitForRequest so the assertion doesn't depend on the

--- a/src/test/java/com/stucray/limen/ui/journey/SignupJourneyUiIT.java
+++ b/src/test/java/com/stucray/limen/ui/journey/SignupJourneyUiIT.java
@@ -17,13 +17,13 @@ class SignupJourneyUiIT extends BaseUiIT {
         String suffix = uniqueSuffix();
         String slug = "t-" + suffix;
         String orgName = "Acme " + suffix;
-        String username = "owner-" + suffix;
+        String email = "owner-" + suffix + "@example.test";
         String password = "secret123";
 
         new LandingPage(page, baseUrl())
             .visit()
             .clickSignUp()
-            .fillForm(orgName, slug, username, password)
+            .fillForm(orgName, slug, email, password)
             .submit(slug)
             .assertOnLoginForTenant(orgName)
             .assertJustRegisteredBannerVisible();

--- a/src/test/java/com/stucray/limen/ui/journey/SystemAdminTenantsJourneyUiIT.java
+++ b/src/test/java/com/stucray/limen/ui/journey/SystemAdminTenantsJourneyUiIT.java
@@ -19,7 +19,7 @@ class SystemAdminTenantsJourneyUiIT extends BaseUiIT {
         SeededSystemAdmin admin = tenants.createSystemAdmin();
 
         new LoginPageObject(page, baseUrl())
-            .loginAsSystemAdmin(admin.username(), admin.password());
+            .loginAsSystemAdmin(admin.email(), admin.password());
 
         new SystemTenantsListPage(page, baseUrl())
             .visit()

--- a/src/test/java/com/stucray/limen/ui/journey/TenantAdminLoginJourneyUiIT.java
+++ b/src/test/java/com/stucray/limen/ui/journey/TenantAdminLoginJourneyUiIT.java
@@ -20,7 +20,7 @@ class TenantAdminLoginJourneyUiIT extends BaseUiIT {
 
         new ManageHomePage(page, baseUrl(), tenant.slug())
             .assertOnHomeForTenant(tenant.displayName())
-            .assertWelcomeForUser(tenant.adminUsername())
+            .assertWelcomeForUser(tenant.adminEmail())
             .assertTenantAdminNavTilesVisible();
     }
 }

--- a/src/test/java/com/stucray/limen/ui/pages/SignupPage.java
+++ b/src/test/java/com/stucray/limen/ui/pages/SignupPage.java
@@ -13,10 +13,10 @@ public final class SignupPage {
         this.baseUrl = baseUrl;
     }
 
-    public SignupPage fillForm(String organizationName, String slug, String username, String password) {
+    public SignupPage fillForm(String organizationName, String slug, String email, String password) {
         page.getByLabel("Organization name").fill(organizationName);
         page.getByLabel("Slug").fill(slug);
-        page.getByLabel("Username").fill(username);
+        page.getByLabel("Email").fill(email);
         page.getByLabel("Password").fill(password);
         return this;
     }

--- a/src/test/java/com/stucray/limen/ui/pages/enduser/EndUserHomePage.java
+++ b/src/test/java/com/stucray/limen/ui/pages/enduser/EndUserHomePage.java
@@ -23,8 +23,8 @@ public final class EndUserHomePage {
         return this;
     }
 
-    public EndUserHomePage assertSignedInAs(String username) {
-        PlaywrightAssertions.assertThat(page.getByText("Signed in as " + username)).isVisible();
+    public EndUserHomePage assertSignedInAs(String email) {
+        PlaywrightAssertions.assertThat(page.getByText("Signed in as " + email)).isVisible();
         return this;
     }
 }

--- a/src/test/java/com/stucray/limen/ui/pages/manage/ManageHomePage.java
+++ b/src/test/java/com/stucray/limen/ui/pages/manage/ManageHomePage.java
@@ -37,8 +37,8 @@ public final class ManageHomePage {
         return this;
     }
 
-    public ManageHomePage assertWelcomeForUser(String username) {
-        PlaywrightAssertions.assertThat(page.getByText("Welcome, " + username)).isVisible();
+    public ManageHomePage assertWelcomeForUser(String email) {
+        PlaywrightAssertions.assertThat(page.getByText("Welcome, " + email)).isVisible();
         return this;
     }
 

--- a/src/test/java/com/stucray/limen/ui/pages/manage/ManageLoginPage.java
+++ b/src/test/java/com/stucray/limen/ui/pages/manage/ManageLoginPage.java
@@ -32,8 +32,8 @@ public final class ManageLoginPage {
         return this;
     }
 
-    public ManageLoginPage fill(String username, String password) {
-        page.getByLabel("Username").fill(username);
+    public ManageLoginPage fill(String email, String password) {
+        page.getByLabel("Email").fill(email);
         page.getByLabel("Password").fill(password);
         return this;
     }

--- a/src/test/java/com/stucray/limen/ui/pages/manage/users/ManageUsersListPage.java
+++ b/src/test/java/com/stucray/limen/ui/pages/manage/users/ManageUsersListPage.java
@@ -29,9 +29,9 @@ public final class ManageUsersListPage {
         return new ManageUsersNewPage(page, baseUrl, slug);
     }
 
-    public ManageUsersListPage assertUserVisible(String username) {
+    public ManageUsersListPage assertUserVisible(String email) {
         PlaywrightAssertions.assertThat(
-            page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName(username))
+            page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName(email))
         ).isVisible();
         return this;
     }

--- a/src/test/java/com/stucray/limen/ui/pages/manage/users/ManageUsersNewPage.java
+++ b/src/test/java/com/stucray/limen/ui/pages/manage/users/ManageUsersNewPage.java
@@ -23,8 +23,8 @@ public final class ManageUsersNewPage {
         return this;
     }
 
-    public ManageUsersNewPage fillUsername(String username) {
-        page.getByLabel("Username").fill(username);
+    public ManageUsersNewPage fillEmail(String email) {
+        page.getByLabel("Email").fill(email);
         return this;
     }
 

--- a/src/test/java/com/stucray/limen/ui/support/LoginPageObject.java
+++ b/src/test/java/com/stucray/limen/ui/support/LoginPageObject.java
@@ -28,27 +28,27 @@ public final class LoginPageObject {
 
     public void loginAsTenantAdmin(SeededTenant tenant) {
         page.navigate(baseUrl + "/manage/t/" + tenant.slug() + "/login");
-        page.getByLabel("Username").fill(tenant.adminUsername());
+        page.getByLabel("Email").fill(tenant.adminEmail());
         page.getByLabel("Password").fill(tenant.adminPassword());
         page.getByTestId("manage-login-submit").click();
         page.waitForURL(baseUrl + "/manage/t/" + tenant.slug() + "/**");
     }
 
     public void loginAsEndUser(SeededTenant tenant) {
-        loginAsEndUserWithCredentials(tenant.slug(), tenant.endUserUsername(), tenant.endUserPassword());
+        loginAsEndUserWithCredentials(tenant.slug(), tenant.endUserEmail(), tenant.endUserPassword());
     }
 
-    public void loginAsEndUserWithCredentials(String slug, String username, String password) {
+    public void loginAsEndUserWithCredentials(String slug, String email, String password) {
         page.navigate(baseUrl + "/t/" + slug + "/login");
-        page.getByLabel("Username").fill(username);
+        page.getByLabel("Email").fill(email);
         page.getByLabel("Password").fill(password);
         page.getByTestId("login-submit").click();
         page.waitForURL(baseUrl + "/t/" + slug + "/**");
     }
 
-    public void loginAsSystemAdmin(String username, String password) {
+    public void loginAsSystemAdmin(String email, String password) {
         page.navigate(baseUrl + "/manage/t/system/login");
-        page.getByLabel("Username").fill(username);
+        page.getByLabel("Email").fill(email);
         page.getByLabel("Password").fill(password);
         page.getByTestId("manage-login-submit").click();
         page.waitForURL(baseUrl + "/manage/t/system/**");

--- a/src/test/java/com/stucray/limen/ui/support/TestTenantFactory.java
+++ b/src/test/java/com/stucray/limen/ui/support/TestTenantFactory.java
@@ -30,7 +30,7 @@ import java.util.UUID;
  * Single source of truth for "give me a fresh tenant" across UI tests.
  *
  * <p>Each call seeds a uniquely-named tenant with one admin (owner) and one end user,
- * so concurrent tests cannot collide on slug/username and no teardown is needed —
+ * so concurrent tests cannot collide on slug/email and no teardown is needed —
  * the Testcontainers Postgres is discarded at JVM exit.
  *
  * <p>Goes through real service-layer code ({@link TenantProvisioningService} +
@@ -98,9 +98,9 @@ public class TestTenantFactory {
     public SeededOAuth2Client seedOAuth2ClientForEndUser(
         SeededTenant tenant, SeededApplication app, String redirectUri
     ) {
-        User endUser = userRepository.findByUsernameAndTenantId(tenant.endUserUsername(), tenant.tenantId())
+        User endUser = userRepository.findByEmailAndTenantId(tenant.endUserEmail(), tenant.tenantId())
             .orElseThrow(() -> new IllegalStateException("seeded end user missing"));
-        User admin = userRepository.findByUsernameAndTenantId(tenant.adminUsername(), tenant.tenantId())
+        User admin = userRepository.findByEmailAndTenantId(tenant.adminEmail(), tenant.tenantId())
             .orElseThrow(() -> new IllegalStateException("seeded admin missing"));
 
         String registeredClientId = UUID.randomUUID().toString();
@@ -132,11 +132,11 @@ public class TestTenantFactory {
     @Transactional
     public SeededForcedChangeUser seedEndUserForcedPasswordChange(SeededTenant tenant) {
         String suffix = uniqueSuffix();
-        String username = "forcechange-" + suffix;
+        String email = "forcechange-" + suffix + "@example.test";
         String hash = passwordEncoder.encode(SHARED_TEST_PASSWORD);
         userRepository.save(new User(
-            null, tenant.tenantId(), username, hash, true, true, false, LocalDateTime.now()));
-        return new SeededForcedChangeUser(username, SHARED_TEST_PASSWORD);
+            null, tenant.tenantId(), email, hash, true, true, false, LocalDateTime.now()));
+        return new SeededForcedChangeUser(email, SHARED_TEST_PASSWORD);
     }
 
     @Transactional
@@ -144,32 +144,32 @@ public class TestTenantFactory {
         String suffix = uniqueSuffix();
         String slug = "t-" + suffix;
         String displayName = "Test Org " + suffix;
-        String adminUsername = "admin-" + suffix;
-        String endUserUsername = "user-" + suffix;
+        String adminEmail = "admin-" + suffix + "@example.test";
+        String endUserEmail = "user-" + suffix + "@example.test";
 
         Tenant tenant = tenantProvisioningService.createTenant(slug, displayName);
         String hash = passwordEncoder.encode(SHARED_TEST_PASSWORD);
         userRepository.save(new User(
-            null, tenant.id(), adminUsername, hash, true, false, true, LocalDateTime.now()));
+            null, tenant.id(), adminEmail, hash, true, false, true, LocalDateTime.now()));
         userRepository.save(new User(
-            null, tenant.id(), endUserUsername, hash, true, false, false, LocalDateTime.now()));
+            null, tenant.id(), endUserEmail, hash, true, false, false, LocalDateTime.now()));
 
         return new SeededTenant(
             tenant.id(), slug, displayName,
-            adminUsername, SHARED_TEST_PASSWORD,
-            endUserUsername, SHARED_TEST_PASSWORD);
+            adminEmail, SHARED_TEST_PASSWORD,
+            endUserEmail, SHARED_TEST_PASSWORD);
     }
 
     @Transactional
     public SeededSystemAdmin createSystemAdmin() {
         String suffix = uniqueSuffix();
-        String username = "sysadmin-" + suffix;
+        String email = "sysadmin-" + suffix + "@example.test";
         Tenant systemTenant = tenantRepository.findBySlug("system")
             .orElseThrow(() -> new IllegalStateException("system tenant not bootstrapped"));
         String hash = passwordEncoder.encode(SHARED_TEST_PASSWORD);
         userRepository.save(new User(
-            null, systemTenant.id(), username, hash, true, false, false, LocalDateTime.now()));
-        return new SeededSystemAdmin(username, SHARED_TEST_PASSWORD);
+            null, systemTenant.id(), email, hash, true, false, false, LocalDateTime.now()));
+        return new SeededSystemAdmin(email, SHARED_TEST_PASSWORD);
     }
 
     private static String uniqueSuffix() {
@@ -180,17 +180,17 @@ public class TestTenantFactory {
         Long tenantId,
         String slug,
         String displayName,
-        String adminUsername,
+        String adminEmail,
         String adminPassword,
-        String endUserUsername,
+        String endUserEmail,
         String endUserPassword
     ) {}
 
-    public record SeededSystemAdmin(String username, String password) {}
+    public record SeededSystemAdmin(String email, String password) {}
 
     public record SeededApplication(Long appId, String name) {}
 
-    public record SeededForcedChangeUser(String username, String temporaryPassword) {}
+    public record SeededForcedChangeUser(String email, String temporaryPassword) {}
 
     public record SeededOAuth2Client(String clientId, String redirectUri) {}
 }

--- a/src/test/java/com/stucray/limen/user/EmailUniquenessIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/user/EmailUniquenessIntegrationTest.java
@@ -1,0 +1,79 @@
+package com.stucray.limen.user;
+
+import com.stucray.limen.TestcontainersConfiguration;
+import com.stucray.limen.management.users.UserManagementService;
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantProvisioningService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Pins the per-tenant email uniqueness contract (PRD #120, slice #122):
+ * the same email may identify two distinct Users in two different Tenants,
+ * but a duplicate within a single Tenant is rejected.
+ */
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest
+@DisplayName("Email is unique per tenant, not globally — same email permitted across tenants, rejected within one tenant")
+class EmailUniquenessIntegrationTest {
+
+    @Autowired TenantProvisioningService tenantProvisioningService;
+    @Autowired UserManagementService userManagementService;
+    @Autowired UserRepository userRepository;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    Tenant tenantA;
+    Tenant tenantB;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.execute("DELETE FROM client_membership");
+        jdbcTemplate.execute("DELETE FROM application_membership_role");
+        jdbcTemplate.execute("DELETE FROM application_membership");
+        jdbcTemplate.execute("DELETE FROM role");
+        jdbcTemplate.execute("DELETE FROM oauth2_registered_client WHERE application_id IS NOT NULL");
+        jdbcTemplate.execute("DELETE FROM applications");
+        jdbcTemplate.execute("DELETE FROM users WHERE tenant_id IN (SELECT id FROM tenants WHERE slug != 'system')");
+        jdbcTemplate.execute("DELETE FROM tenants WHERE slug != 'system'");
+
+        tenantA = tenantProvisioningService.createTenant("uniq-tenant-a", "Uniqueness Tenant A");
+        tenantB = tenantProvisioningService.createTenant("uniq-tenant-b", "Uniqueness Tenant B");
+    }
+
+    @Test
+    @DisplayName("Same email in two different tenants is permitted — both users persist independently")
+    void sameEmailAcrossDifferentTenantsIsPermitted() {
+        userManagementService.createUser(tenantA.id(), "shared@example.test", "temp-pwd-1");
+        userManagementService.createUser(tenantB.id(), "shared@example.test", "temp-pwd-2");
+
+        assertThat(userRepository.findByEmailAndTenantId("shared@example.test", tenantA.id())).isPresent();
+        assertThat(userRepository.findByEmailAndTenantId("shared@example.test", tenantB.id())).isPresent();
+        // Defence-in-depth: the two rows are distinct Users with distinct ids.
+        assertThat(userRepository.findByEmailAndTenantId("shared@example.test", tenantA.id()).orElseThrow().id())
+            .isNotEqualTo(userRepository.findByEmailAndTenantId("shared@example.test", tenantB.id()).orElseThrow().id());
+    }
+
+    @Test
+    @DisplayName("Duplicate email within a single tenant is rejected with 'Email already exists in this tenant'")
+    void duplicateEmailWithinSingleTenantIsRejected() {
+        userManagementService.createUser(tenantA.id(), "shared@example.test", "temp-pwd-1");
+
+        assertThatThrownBy(() ->
+            userManagementService.createUser(tenantA.id(), "shared@example.test", "temp-pwd-2"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Email already exists in this tenant");
+
+        // Only one row persists — the second call's attempt was rejected before save.
+        assertThat(userRepository.findAllByTenantId(tenantA.id()))
+            .filteredOn(u -> u.email().equals("shared@example.test"))
+            .hasSize(1);
+    }
+}


### PR DESCRIPTION
## Parent

Closes #122 (PRD #120 slice 1).

## Summary

- V6 Flyway migration: drops `users.username`, adds `email VARCHAR(255) NOT NULL` with `UNIQUE(tenant_id, email)`, swaps the old per-tenant unique constraint, and renames `persistent_logins.username` → `email`. Existing dev data is dropped at migration time per PRD #120 (no real customers; the alternative — nullable email + forced-fill — leaves permanent technical debt).
- Per-tenant uniqueness preserves the user-pool-per-tenant model (Auth0 / AWS Cognito shape): the same email can identify two distinct Users in two different Tenants.
- Production code: `User.username` → `email`; `UserRepository.findByUsernameAndTenantId` / `existsByUsernameAndTenantId` renamed to `findByEmailAndTenantId` / `existsByEmailAndTenantId`; `TenantUserDetailsService.loadByUsernameAndSlug` → `loadByEmailAndSlug`; `TenantUserDetails.displayUsername()` → `displayEmail()`. Spring framework method names (`UserDetails.getUsername()`, `loadUserByUsername`, `UsernameNotFoundException`, `PersistentRememberMeToken.getUsername()`) are intentionally kept — the values they carry are now emails, but the contract method names are framework-defined.
- Form parameter switches to `email`; both login forms (end-user + tenant-admin) ask for "Email" with `type="email"`. `SignupService` adds basic email-format validation; the rich verification flow lands in slice #125.
- Bootstrap admin properties: `LIMEN_BOOTSTRAP_ADMIN_USERNAME` env var is now `LIMEN_BOOTSTRAP_ADMIN_EMAIL` (operators must rename in their `.env`).
- Two new integration tests in `EmailUniquenessIntegrationTest` pin the acceptance criteria: same email is permitted across two tenants; rejected within a single tenant.

## Test plan

- [x] `mvn verify` — 306 tests pass across surefire + failsafe (11 UI journeys included).
- [x] No leftover `username` references in `src/` outside Spring Security framework methods (`loadUserByUsername`, `getUsername`, `UsernameNotFoundException`, `UsernamePasswordAuthenticationToken/Filter`, `PersistentRememberMeToken`).
- [x] V6 migration applies cleanly on a fresh Postgres (Testcontainers verifies this on every run).
- [x] Cross-tenant pool integration test: same email in tenant A and tenant B both succeed.
- [x] Within-tenant uniqueness integration test: duplicate email in the same tenant throws `IllegalArgumentException("Email already exists in this tenant")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)