### PR TITLE
Slice 2: EmailSender infrastructure (#123)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-mail</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>org.postgresql</groupId>

--- a/src/main/java/com/stucray/limen/email/EmailMessage.java
+++ b/src/main/java/com/stucray/limen/email/EmailMessage.java
@@ -1,0 +1,18 @@
+package com.stucray.limen.email;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A single outbound email. {@code htmlBody} is optional; when null, the message
+ * is sent as plain text only.
+ */
+public record EmailMessage(
+    String recipient,
+    String subject,
+    String plainTextBody,
+    @Nullable String htmlBody
+) {
+    public EmailMessage(String recipient, String subject, String plainTextBody) {
+        this(recipient, subject, plainTextBody, null);
+    }
+}

--- a/src/main/java/com/stucray/limen/email/EmailSender.java
+++ b/src/main/java/com/stucray/limen/email/EmailSender.java
@@ -1,0 +1,14 @@
+package com.stucray.limen.email;
+
+/**
+ * Provider-agnostic outbound email port. Implementation is selected at startup
+ * via {@code limen.email.driver} ({@code logging} | {@code smtp}).
+ *
+ * <p>Callers in upcoming slices (OTT verification, password reset, system-admin
+ * tenant create) depend on this interface, not on a concrete provider — the
+ * production swap from Mailpit to Resend / SES / etc. is a one-bean
+ * configuration change (see roadmap §6 v4).
+ */
+public interface EmailSender {
+    void send(EmailMessage message);
+}

--- a/src/main/java/com/stucray/limen/email/LoggingEmailSender.java
+++ b/src/main/java/com/stucray/limen/email/LoggingEmailSender.java
@@ -1,0 +1,26 @@
+package com.stucray.limen.email;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+/**
+ * Default {@link EmailSender}. Renders the message to slf4j INFO with a
+ * deterministic {@code key=value} structure so a developer can read magic
+ * links and verification codes from the application log without running
+ * mail infrastructure. Used by the {@code dev} profile and by any deployment
+ * where {@code limen.email.driver} is unset or set to {@code logging}.
+ */
+@Component
+@ConditionalOnProperty(name = "limen.email.driver", havingValue = "logging", matchIfMissing = true)
+public class LoggingEmailSender implements EmailSender {
+
+    private static final Logger log = LoggerFactory.getLogger(LoggingEmailSender.class);
+
+    @Override
+    public void send(EmailMessage message) {
+        log.info("limen.email.send recipient=\"{}\" subject=\"{}\" body=\"{}\"",
+            message.recipient(), message.subject(), message.plainTextBody());
+    }
+}

--- a/src/main/java/com/stucray/limen/email/SmtpEmailSender.java
+++ b/src/main/java/com/stucray/limen/email/SmtpEmailSender.java
@@ -1,0 +1,65 @@
+package com.stucray.limen.email;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+/**
+ * SMTP {@link EmailSender}. Activated when {@code limen.email.driver=smtp}.
+ * In tests this is wired against a Mailpit Testcontainer; in production it
+ * points at a real SMTP host (or a transactional provider's SMTP gateway).
+ *
+ * <p>If {@link EmailMessage#htmlBody()} is non-null the message is sent as a
+ * multipart/alternative with both plain text and HTML; otherwise a plain-text
+ * SimpleMailMessage shape is used (still as a MimeMessage so the From header
+ * and encoding are explicit).
+ */
+@Component
+@ConditionalOnProperty(name = "limen.email.driver", havingValue = "smtp")
+public class SmtpEmailSender implements EmailSender {
+
+    private static final String DEFAULT_FROM = "no-reply@limen.local";
+
+    private final JavaMailSender mailSender;
+
+    public SmtpEmailSender(JavaMailSender mailSender) {
+        this.mailSender = mailSender;
+    }
+
+    @Override
+    public void send(EmailMessage message) {
+        MimeMessage mime = mailSender.createMimeMessage();
+        try {
+            String html = message.htmlBody();
+            boolean multipart = html != null;
+            MimeMessageHelper helper = new MimeMessageHelper(mime, multipart, "UTF-8");
+            helper.setFrom(DEFAULT_FROM);
+            helper.setTo(message.recipient());
+            helper.setSubject(message.subject());
+            if (multipart) {
+                helper.setText(message.plainTextBody(), Objects.requireNonNull(html));
+            } else {
+                helper.setText(message.plainTextBody(), false);
+            }
+        } catch (MessagingException e) {
+            throw new EmailDeliveryException("Failed to compose email", e);
+        }
+        try {
+            mailSender.send(mime);
+        } catch (MailException e) {
+            throw new EmailDeliveryException("Failed to deliver email via SMTP", e);
+        }
+    }
+
+    public static final class EmailDeliveryException extends RuntimeException {
+        public EmailDeliveryException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,6 +4,12 @@ limen:
     remember-me-key: dev-remember-me-key-change-me
     # 14 days
     remember-me-validity-seconds: 1209600
+  email:
+    # logging | smtp. Default writes outbound emails to slf4j INFO so a developer
+    # can read magic links from the application log without running mail
+    # infrastructure. Set to `smtp` (and configure spring.mail.*) in any
+    # deployment that should actually deliver mail.
+    driver: logging
 spring:
   application:
     name: limen

--- a/src/test/java/com/stucray/limen/email/LoggingEmailSenderIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/email/LoggingEmailSenderIntegrationTest.java
@@ -1,0 +1,72 @@
+package com.stucray.limen.email;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.stucray.limen.TestcontainersConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@link LoggingEmailSender} writes a single INFO line containing
+ * the recipient, subject and body in a parseable form. The default profile is
+ * intentionally used: no profile activation, no property overrides — this is
+ * the developer-mode shape every contributor sees out of the box.
+ */
+@SpringBootTest
+@Import(TestcontainersConfiguration.class)
+@DisplayName("LoggingEmailSender writes recipient + subject + body to slf4j INFO")
+class LoggingEmailSenderIntegrationTest {
+
+    @Autowired
+    EmailSender emailSender;
+
+    private Logger loggingEmailSenderLogger;
+    private ListAppender<ILoggingEvent> appender;
+
+    @BeforeEach
+    void attachAppender() {
+        loggingEmailSenderLogger = (Logger) LoggerFactory.getLogger(LoggingEmailSender.class);
+        appender = new ListAppender<>();
+        appender.start();
+        loggingEmailSenderLogger.addAppender(appender);
+    }
+
+    @AfterEach
+    void detachAppender() {
+        loggingEmailSenderLogger.detachAppender(appender);
+    }
+
+    @Test
+    @DisplayName("Default driver is logging — outbound message lands in the application log")
+    void defaultDriverIsLogging() {
+        assertThat(emailSender).isInstanceOf(LoggingEmailSender.class);
+
+        emailSender.send(new EmailMessage(
+            "alice@example.test",
+            "Verify your email",
+            "Click https://example.test/verify?token=abc123 to verify."));
+
+        List<ILoggingEvent> infoEvents = appender.list.stream()
+            .filter(e -> e.getLevel() == Level.INFO)
+            .toList();
+        assertThat(infoEvents).hasSize(1);
+
+        String formatted = infoEvents.get(0).getFormattedMessage();
+        assertThat(formatted)
+            .contains("alice@example.test")
+            .contains("Verify your email")
+            .contains("Click https://example.test/verify?token=abc123 to verify.");
+    }
+}

--- a/src/test/java/com/stucray/limen/email/MailpitContainer.java
+++ b/src/test/java/com/stucray/limen/email/MailpitContainer.java
@@ -1,0 +1,38 @@
+package com.stucray.limen.email;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Mailpit (https://mailpit.axllent.org/) — a developer SMTP server with an HTTP
+ * API for inspecting captured messages. Used by the SMTP integration tests so
+ * the {@link SmtpEmailSender} round-trip can be verified end-to-end without
+ * mocking {@code JavaMailSender}.
+ *
+ * <p>SMTP listens on 1025; the inspection API on 8025. Both are mapped to
+ * ephemeral host ports; callers should read {@link #getMappedPort(int)}.
+ */
+public final class MailpitContainer extends GenericContainer<MailpitContainer> {
+
+    public static final int SMTP_PORT = 1025;
+    public static final int HTTP_API_PORT = 8025;
+
+    public MailpitContainer() {
+        super(DockerImageName.parse("axllent/mailpit:latest"));
+        withExposedPorts(SMTP_PORT, HTTP_API_PORT);
+        waitingFor(Wait.forHttp("/api/v1/info").forPort(HTTP_API_PORT));
+    }
+
+    public int smtpPort() {
+        return getMappedPort(SMTP_PORT);
+    }
+
+    public int httpApiPort() {
+        return getMappedPort(HTTP_API_PORT);
+    }
+
+    public String httpApiBaseUrl() {
+        return "http://" + getHost() + ":" + httpApiPort();
+    }
+}

--- a/src/test/java/com/stucray/limen/email/MailpitTestConfiguration.java
+++ b/src/test/java/com/stucray/limen/email/MailpitTestConfiguration.java
@@ -1,0 +1,37 @@
+package com.stucray.limen.email;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+/**
+ * Wires a {@link MailpitContainer} into the application context and exposes a
+ * {@link JavaMailSender} pointing at its ephemeral SMTP port. Imported only by
+ * tests that exercise the SMTP path (currently
+ * {@code SmtpEmailSenderIntegrationTest}) so the broader IT suite doesn't pay
+ * the container startup cost.
+ *
+ * <p>The {@code JavaMailSender} bean is constructed directly rather than
+ * relying on Spring Boot's {@code MailSenderAutoConfiguration} — that
+ * auto-configuration evaluates {@code spring.mail.host} at condition time,
+ * which is before the dynamic Mailpit port is known.
+ */
+@TestConfiguration(proxyBeanMethods = false)
+public class MailpitTestConfiguration {
+
+    @Bean
+    public MailpitContainer mailpitContainer() {
+        MailpitContainer container = new MailpitContainer();
+        container.start();
+        return container;
+    }
+
+    @Bean
+    public JavaMailSender javaMailSender(MailpitContainer mailpit) {
+        JavaMailSenderImpl sender = new JavaMailSenderImpl();
+        sender.setHost(mailpit.getHost());
+        sender.setPort(mailpit.smtpPort());
+        return sender;
+    }
+}

--- a/src/test/java/com/stucray/limen/email/SmtpEmailSenderIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/email/SmtpEmailSenderIntegrationTest.java
@@ -1,0 +1,91 @@
+package com.stucray.limen.email;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stucray.limen.TestcontainersConfiguration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Round-trips a real outbound message through {@link SmtpEmailSender} into a
+ * Mailpit Testcontainer, then retrieves it via Mailpit's HTTP API and asserts
+ * recipient / subject / body. No mocking of {@link org.springframework.mail.javamail.JavaMailSender}
+ * — the SMTP path is exercised end-to-end so a regression in the MIME building
+ * or the Spring auto-configuration is caught at this layer.
+ */
+@SpringBootTest
+@Import({TestcontainersConfiguration.class, MailpitTestConfiguration.class})
+@ActiveProfiles("test")
+@DisplayName("SmtpEmailSender delivers via Mailpit and Mailpit captures the message")
+class SmtpEmailSenderIntegrationTest {
+
+    @Autowired
+    EmailSender emailSender;
+
+    @Autowired
+    MailpitContainer mailpit;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("Plain-text message lands in Mailpit with recipient, subject and body intact")
+    void plainTextMessageRoundTripsThroughMailpit() throws Exception {
+        assertThat(emailSender).isInstanceOf(SmtpEmailSender.class);
+
+        String subject = "Limen SMTP IT subject " + System.nanoTime();
+        String body = "Limen SMTP IT body — magic link https://example.test/verify?token=xyz";
+        emailSender.send(new EmailMessage("bob@example.test", subject, body));
+
+        RestClient restClient = RestClient.create(mailpit.httpApiBaseUrl());
+        JsonNode messages = waitForOneMessage(restClient, subject);
+
+        JsonNode firstMatch = findBySubject(messages, subject);
+        String messageId = firstMatch.get("ID").asText();
+
+        JsonNode full = objectMapper.readTree(
+            restClient.get().uri("/api/v1/message/{id}", messageId).retrieve().body(String.class));
+
+        assertThat(full.get("Subject").asText()).isEqualTo(subject);
+        assertThat(full.get("Text").asText()).contains(body);
+        JsonNode toArray = full.get("To");
+        assertThat(toArray).isNotNull();
+        assertThat(toArray.get(0).get("Address").asText()).isEqualTo("bob@example.test");
+    }
+
+    private JsonNode waitForOneMessage(RestClient restClient, String expectedSubject) throws Exception {
+        long deadline = System.currentTimeMillis() + 5_000;
+        while (System.currentTimeMillis() < deadline) {
+            JsonNode messages = objectMapper.readTree(
+                restClient.get().uri("/api/v1/messages?limit=50").retrieve().body(String.class));
+            if (findBySubjectOrNull(messages, expectedSubject) != null) {
+                return messages;
+            }
+            Thread.sleep(100);
+        }
+        throw new AssertionError("Timed out waiting for message with subject: " + expectedSubject);
+    }
+
+    private static JsonNode findBySubject(JsonNode messages, String subject) {
+        JsonNode match = findBySubjectOrNull(messages, subject);
+        if (match == null) {
+            throw new AssertionError("No message with subject: " + subject);
+        }
+        return match;
+    }
+
+    private static JsonNode findBySubjectOrNull(JsonNode messages, String subject) {
+        for (JsonNode m : messages.path("messages")) {
+            if (subject.equals(m.path("Subject").asText())) {
+                return m;
+            }
+        }
+        return null;
+    }
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -1,0 +1,18 @@
+# Test profile. Activated via @ActiveProfiles("test") on integration tests that
+# need the SMTP path (e.g. SmtpEmailSenderIntegrationTest); everyone else falls
+# through to application.yaml's `limen.email.driver=logging` default.
+#
+# spring.mail.host / spring.mail.port are wired dynamically at runtime by
+# TestcontainersConfiguration's MailpitContainer bean, since the container
+# binds an ephemeral host port.
+limen:
+  email:
+    driver: smtp
+spring:
+  mail:
+    properties:
+      mail:
+        smtp:
+          auth: false
+          starttls:
+            enable: false


### PR DESCRIPTION
## Parent

Closes #123 (PRD #120 slice 2).

## Summary

- New `com.stucray.limen.email` package: `EmailSender` interface + `EmailMessage` record + two implementations.
- `LoggingEmailSender` (default and dev profile) — writes the message to slf4j INFO with a parseable `key=value` structure so a developer can read magic links from the application log without running mail infrastructure.
- `SmtpEmailSender` (test profile and later production) — backed by Spring's `JavaMailSender`. Composes a `MimeMessage` via `MimeMessageHelper`; sends multipart/alternative when an HTML body is supplied.
- Selection is via `@ConditionalOnProperty(limen.email.driver)` — `logging` | `smtp` — defaulting to `logging`.
- `application-test.yaml` overrides `limen.email.driver=smtp`; activated by tests that need the SMTP path.
- `MailpitContainer` (axllent/mailpit) wired via `MailpitTestConfiguration`. The `JavaMailSender` bean is constructed directly against the container's ephemeral SMTP port — sidesteps Spring Boot's `MailSenderAutoConfiguration`, which evaluates `@ConditionalOnProperty(spring.mail.host)` before the dynamic port is known.
- No user-visible feature change. Pure infrastructure consumed by slices #125 (OTT verification), #126 (password reset), and #129 (tenant-create UI).

## Test plan

- [x] `LoggingEmailSenderIntegrationTest` — attaches a logback `ListAppender` and asserts recipient + subject + body all land in the INFO line.
- [x] `SmtpEmailSenderIntegrationTest` — round-trips a real message through Mailpit, retrieves it via Mailpit's HTTP API, and asserts on subject + recipient + body. No `JavaMailSender` mocking.
- [x] `mvn verify` — 308 tests pass (306 carried + 2 new).
- [x] Default profile gives `LoggingEmailSender` (verified by `assertThat(emailSender).isInstanceOf(LoggingEmailSender.class)`).
- [x] `test` profile gives `SmtpEmailSender` (same instanceof assertion in the SMTP IT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)