### PR TITLE
feat: OTT infrastructure + email-verification flow (#125)

### DIFF
--- a/src/main/java/com/stucray/limen/audit/AuditEventListener.java
+++ b/src/main/java/com/stucray/limen/audit/AuditEventListener.java
@@ -1,11 +1,14 @@
 package com.stucray.limen.audit;
 
 import com.stucray.limen.audit.events.ClientSecretRotatedEvent;
+import com.stucray.limen.audit.events.EmailVerifiedEvent;
 import com.stucray.limen.audit.events.PasswordChangedEvent;
 import com.stucray.limen.audit.events.TenantCreatedEvent;
 import com.stucray.limen.audit.events.TenantDeletedEvent;
 import com.stucray.limen.audit.events.TenantSuspendedEvent;
 import com.stucray.limen.audit.events.TenantUnsuspendedEvent;
+import com.stucray.limen.audit.events.VerificationOttIssuedEvent;
+import com.stucray.limen.audit.events.VerificationResentEvent;
 import com.stucray.limen.auth.TenantUserDetails;
 import jakarta.servlet.http.HttpServletRequest;
 import org.jspecify.annotations.Nullable;
@@ -151,6 +154,47 @@ public class AuditEventListener {
             currentIp(), currentUserAgent(),
             LocalDateTime.now(ZoneId.systemDefault()),
             Map.of()));
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onVerificationOttIssued(VerificationOttIssuedEvent event) {
+        Map<String, Object> details = new HashMap<>();
+        details.put("email", event.email());
+        safeWrite(new AuditEvent(
+            null, event.tenantId(), event.userId(),
+            "verification_ott_issued",
+            "user", String.valueOf(event.userId()),
+            currentIp(), currentUserAgent(),
+            LocalDateTime.now(ZoneId.systemDefault()),
+            details));
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onEmailVerified(EmailVerifiedEvent event) {
+        Map<String, Object> details = new HashMap<>();
+        details.put("email", event.email());
+        safeWrite(new AuditEvent(
+            null, event.tenantId(), event.userId(),
+            "email_verified",
+            "user", String.valueOf(event.userId()),
+            currentIp(), currentUserAgent(),
+            LocalDateTime.now(ZoneId.systemDefault()),
+            details));
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onVerificationResent(VerificationResentEvent event) {
+        Map<String, Object> details = new HashMap<>();
+        details.put("email", event.email());
+        details.put("delivered", event.delivered());
+        safeWrite(new AuditEvent(
+            null, event.tenantId(), event.userId(),
+            "verification_resent",
+            event.userId() == null ? null : "user",
+            event.userId() == null ? null : String.valueOf(event.userId()),
+            currentIp(), currentUserAgent(),
+            LocalDateTime.now(ZoneId.systemDefault()),
+            details));
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)

--- a/src/main/java/com/stucray/limen/audit/events/EmailVerifiedEvent.java
+++ b/src/main/java/com/stucray/limen/audit/events/EmailVerifiedEvent.java
@@ -1,0 +1,11 @@
+package com.stucray.limen.audit.events;
+
+/**
+ * A user's email_verified flag transitioned from false to true after a
+ * successful OTT consume with intent=verify-email.
+ */
+public record EmailVerifiedEvent(
+    Long tenantId,
+    Long userId,
+    String email
+) {}

--- a/src/main/java/com/stucray/limen/audit/events/VerificationOttIssuedEvent.java
+++ b/src/main/java/com/stucray/limen/audit/events/VerificationOttIssuedEvent.java
@@ -1,0 +1,13 @@
+package com.stucray.limen.audit.events;
+
+/**
+ * A verification OTT was minted for a user — typically at signup, or as the
+ * "resend verification email" path. The {@code email} is recorded directly
+ * because at issue time the row may have just been inserted and any consumer
+ * looking up "what address received this token?" should not have to join.
+ */
+public record VerificationOttIssuedEvent(
+    Long tenantId,
+    Long userId,
+    String email
+) {}

--- a/src/main/java/com/stucray/limen/audit/events/VerificationResentEvent.java
+++ b/src/main/java/com/stucray/limen/audit/events/VerificationResentEvent.java
@@ -1,0 +1,15 @@
+package com.stucray.limen.audit.events;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A "resend verification email" request fired. {@code userId} is null when the
+ * submitted email did not match any user in the tenant — we still emit the
+ * event so audit records show the attempt, but nothing was sent.
+ */
+public record VerificationResentEvent(
+    Long tenantId,
+    @Nullable Long userId,
+    String email,
+    boolean delivered
+) {}

--- a/src/main/java/com/stucray/limen/auth/login/PostLoginIntents.java
+++ b/src/main/java/com/stucray/limen/auth/login/PostLoginIntents.java
@@ -7,11 +7,15 @@ import org.springframework.security.web.savedrequest.SavedRequest;
 import java.net.URI;
 
 /**
- * Static factories for the three default {@link PostLoginIntent}s wired by
+ * Static factories for the default {@link PostLoginIntent}s wired by
  * {@link TenantLoginAutoConfig}. Each is independently testable.
  *
  * Default chain order (terminal-last):
  * <ol>
+ *   <li>{@link #emailVerificationRequired()} — redirect to check-inbox when the
+ *       just-authenticated user has not yet verified their email. Sits ahead of
+ *       OAuth2-resume so an unverified principal cannot complete an authorize
+ *       flow before clicking the magic link.</li>
  *   <li>{@link #passwordChangeRequired()} — redirect when {@code mustChangePassword} is set.</li>
  *   <li>{@link #resumeOAuth2Authorize()} — consume a saved {@code /oauth2/authorize} request.</li>
  *   <li>{@link #tenantHome()} — terminal default; always returns the tenant home URL.</li>
@@ -23,6 +27,19 @@ import java.net.URI;
 public final class PostLoginIntents {
 
     private PostLoginIntents() {}
+
+    /**
+     * If the principal has {@code email_verified=false}, redirect to the
+     * tenant's check-inbox page so a fresh verification email can be requested.
+     * The OTT consume path itself flips the flag to {@code true} via
+     * {@code EmailVerificationService}, so a successful verify-email login
+     * falls through to the next intent in the chain.
+     */
+    public static PostLoginIntent emailVerificationRequired() {
+        return (req, res, principal, scheme) -> principal.user().emailVerified()
+            ? null
+            : "/t/" + principal.tenantSlug() + "/check-inbox";
+    }
 
     public static PostLoginIntent passwordChangeRequired() {
         return (req, res, principal, scheme) -> principal.mustChangePassword()

--- a/src/main/java/com/stucray/limen/auth/login/TenantLogin.java
+++ b/src/main/java/com/stucray/limen/auth/login/TenantLogin.java
@@ -102,6 +102,15 @@ public final class TenantLogin {
         return rememberMeEnabled;
     }
 
+    /**
+     * Build a success handler that runs the registered intent chain for {@code scheme}.
+     * Reused by the OTT login filter so post-OTT dispatch shares the same
+     * email-verification / password-change / authorize-resume policy as form login.
+     */
+    public AuthenticationSuccessHandler successHandlerFor(TenantUrlScheme scheme) {
+        return new IntentChainSuccessHandler(intents, scheme);
+    }
+
     /** Build the form-login filter for {@code scheme}. */
     public AbstractAuthenticationProcessingFilter filter(TenantUrlScheme scheme) {
         TenantLoginFilter filter = new TenantLoginFilter(scheme, authenticationManager);

--- a/src/main/java/com/stucray/limen/auth/login/TenantLoginAutoConfig.java
+++ b/src/main/java/com/stucray/limen/auth/login/TenantLoginAutoConfig.java
@@ -58,6 +58,7 @@ public class TenantLoginAutoConfig {
         List<TenantUrlScheme> allSchemes
     ) {
         List<PostLoginIntent> intents = new ArrayList<>(userIntents.orderedStream().toList());
+        intents.add(PostLoginIntents.emailVerificationRequired());
         intents.add(PostLoginIntents.passwordChangeRequired());
         intents.add(PostLoginIntents.resumeOAuth2Authorize());
         intents.add(PostLoginIntents.tenantHome());

--- a/src/main/java/com/stucray/limen/auth/ott/CheckInboxController.java
+++ b/src/main/java/com/stucray/limen/auth/ott/CheckInboxController.java
@@ -1,0 +1,41 @@
+package com.stucray.limen.auth.ott;
+
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * The "we just sent you a verification email" landing page shown after signup
+ * and after the resend form. The {@code email} query parameter is informational
+ * only — used to render "we sent a link to {{email}}" — and does not change
+ * server behaviour, so a user reloading the page does not retrigger sending.
+ */
+@Controller
+public class CheckInboxController {
+
+    private final TenantRepository tenantRepository;
+
+    public CheckInboxController(TenantRepository tenantRepository) {
+        this.tenantRepository = tenantRepository;
+    }
+
+    @GetMapping("/t/{slug}/check-inbox")
+    public String checkInbox(
+        @PathVariable String slug,
+        @RequestParam(required = false) String email,
+        Model model
+    ) {
+        Tenant tenant = tenantRepository.findBySlug(slug).orElse(null);
+        if (tenant == null) {
+            return "redirect:/";
+        }
+        model.addAttribute("slug", slug);
+        model.addAttribute("tenantName", tenant.displayName());
+        model.addAttribute("email", email == null ? "" : email);
+        return "check-inbox";
+    }
+}

--- a/src/main/java/com/stucray/limen/auth/ott/EmailVerificationService.java
+++ b/src/main/java/com/stucray/limen/auth/ott/EmailVerificationService.java
@@ -1,0 +1,120 @@
+package com.stucray.limen.auth.ott;
+
+import com.stucray.limen.audit.events.EmailVerifiedEvent;
+import com.stucray.limen.audit.events.VerificationOttIssuedEvent;
+import com.stucray.limen.audit.events.VerificationResentEvent;
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantScope;
+import com.stucray.limen.user.User;
+import com.stucray.limen.user.UserRepository;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+/**
+ * Orchestrates the verify-email flow:
+ *
+ * <ul>
+ *   <li>{@link #issueVerification(Tenant, User)} — generates an OTT under the
+ *       given tenant scope, dispatches the email, and publishes
+ *       {@link VerificationOttIssuedEvent} for audit. Used at signup and by
+ *       slice #129's system-admin tenant-create.</li>
+ *   <li>{@link #resendVerification(Tenant, String)} — same effect, but driven
+ *       by an unauthenticated form post; emits {@link VerificationResentEvent}
+ *       in both the delivered and silently-skipped (unknown email) cases so
+ *       audit shows the attempt without leaking which addresses are real.</li>
+ *   <li>{@link #markEmailVerified(Long, Long)} — flips
+ *       {@code users.email_verified=true} after a successful OTT consume and
+ *       emits {@link EmailVerifiedEvent}. Idempotent: a second consume of the
+ *       same intent is a no-op.</li>
+ * </ul>
+ */
+@Service
+public class EmailVerificationService {
+
+    private final TenantAwareOneTimeTokenService tokenService;
+    private final OttEmailNotifier emailNotifier;
+    private final UserRepository userRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public EmailVerificationService(
+        TenantAwareOneTimeTokenService tokenService,
+        OttEmailNotifier emailNotifier,
+        UserRepository userRepository,
+        ApplicationEventPublisher eventPublisher
+    ) {
+        this.tokenService = tokenService;
+        this.emailNotifier = emailNotifier;
+        this.userRepository = userRepository;
+        this.eventPublisher = eventPublisher;
+    }
+
+    /**
+     * Generate + send a verification OTT for {@code user} under {@code tenant}.
+     * Binds {@link TenantScope} so callers in non-tenant-scoped paths
+     * (e.g. {@code SignupService} mid-/signup, before any TenantScope filter
+     * has fired) don't have to know about it.
+     *
+     * <p>{@code @Transactional} so the AFTER_COMMIT audit listener has a
+     * transaction to hook onto when this is called outside a wrapping one.
+     */
+    @Transactional
+    public void issueVerification(Tenant tenant, User user) {
+        TenantScope.run(tenant.slug(), tenant.id(), () -> {
+            TenantOneTimeToken token =
+                tokenService.generateForIntent(user.email(), OttIntent.VERIFY_EMAIL);
+            emailNotifier.sendVerification(tenant, user.email(), token.tokenValue());
+        });
+        eventPublisher.publishEvent(new VerificationOttIssuedEvent(
+            tenant.id(), user.id(), user.email()));
+    }
+
+    /**
+     * Resend a verification OTT for the user identified by {@code email} in
+     * {@code tenant}. If no such user exists the operation is a silent no-op
+     * with respect to email delivery — preserving the user-existence-oracle
+     * defence — but an audit row is still recorded so investigators can see
+     * the attempt.
+     *
+     * <p>{@code @Transactional} so the AFTER_COMMIT audit listener fires; the
+     * unauthenticated controller path does not open a transaction of its own.
+     */
+    @Transactional
+    public void resendVerification(Tenant tenant, String email) {
+        Optional<User> maybeUser = userRepository.findByEmailAndTenantId(email, tenant.id());
+        boolean delivered = false;
+        Long userId = null;
+        if (maybeUser.isPresent() && !maybeUser.get().emailVerified()) {
+            User user = maybeUser.get();
+            userId = user.id();
+            TenantScope.run(tenant.slug(), tenant.id(), () -> {
+                TenantOneTimeToken token =
+                    tokenService.generateForIntent(user.email(), OttIntent.VERIFY_EMAIL);
+                emailNotifier.sendVerification(tenant, user.email(), token.tokenValue());
+            });
+            delivered = true;
+        }
+        eventPublisher.publishEvent(new VerificationResentEvent(
+            tenant.id(), userId, email, delivered));
+    }
+
+    /**
+     * Flip {@code email_verified=true} for the user. Idempotent on the
+     * already-verified case — no event is fired if the bit was already set,
+     * since the consume path can in principle be called twice if the link is
+     * clicked from two browser tabs in quick succession.
+     */
+    @Transactional
+    public void markEmailVerified(Long userId, Long tenantId) {
+        User user = userRepository.findByIdAndTenantId(userId, tenantId)
+            .orElseThrow(() -> new IllegalStateException(
+                "User missing for OTT consume: id=" + userId + " tenant=" + tenantId));
+        if (user.emailVerified()) {
+            return;
+        }
+        userRepository.save(user.withEmailVerified(true));
+        eventPublisher.publishEvent(new EmailVerifiedEvent(tenantId, userId, user.email()));
+    }
+}

--- a/src/main/java/com/stucray/limen/auth/ott/OttEmailNotifier.java
+++ b/src/main/java/com/stucray/limen/auth/ott/OttEmailNotifier.java
@@ -1,0 +1,147 @@
+package com.stucray.limen.auth.ott;
+
+import com.stucray.limen.email.EmailMessage;
+import com.stucray.limen.email.EmailSender;
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.tenant.TenantScope;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.authentication.ott.OneTimeToken;
+import org.springframework.security.web.DefaultRedirectStrategy;
+import org.springframework.security.web.RedirectStrategy;
+import org.springframework.security.web.authentication.ott.OneTimeTokenGenerationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Renders + sends OTT magic-link emails. The class plays two roles:
+ *
+ * <ol>
+ *   <li>It implements {@link OneTimeTokenGenerationSuccessHandler}, so that
+ *       Spring's {@code GenerateOneTimeTokenFilter} (registered by the
+ *       {@code oneTimeTokenLogin()} DSL) has the bean it needs. In normal
+ *       operation Limen does not route any UI to {@code /ott/generate};
+ *       this exists to satisfy the configurer contract.</li>
+ *   <li>It exposes {@link #sendVerification(Tenant, String, String)} for
+ *       direct invocation from the signup + resend-verification controllers,
+ *       which already know the tenant and intent at call time and don't need
+ *       a DB round-trip to look them up.</li>
+ * </ol>
+ *
+ * <p>Magic links are tenant-scoped: {@code /t/{slug}/login/ott?token=...}.
+ */
+@Component
+public class OttEmailNotifier implements OneTimeTokenGenerationSuccessHandler {
+
+    private static final String LOOKUP_SQL =
+        "SELECT tenant_id, intent FROM one_time_tokens WHERE token_value = ?";
+
+    private final EmailSender emailSender;
+    private final TenantRepository tenantRepository;
+    private final JdbcTemplate jdbcTemplate;
+    private final RedirectStrategy redirectStrategy = new DefaultRedirectStrategy();
+
+    public OttEmailNotifier(
+        EmailSender emailSender,
+        TenantRepository tenantRepository,
+        JdbcTemplate jdbcTemplate
+    ) {
+        this.emailSender = emailSender;
+        this.tenantRepository = tenantRepository;
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    /**
+     * Direct entry point used by signup + resend-verification: build the
+     * verification email and dispatch it via {@link EmailSender}.
+     */
+    public void sendVerification(Tenant tenant, String recipientEmail, String tokenValue) {
+        send(tenant, recipientEmail, tokenValue, OttIntent.VERIFY_EMAIL);
+    }
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, OneTimeToken oneTimeToken)
+            throws java.io.IOException {
+        // Path used only when Spring's /ott/generate filter fires. The freshly
+        // inserted row carries the intent + tenant; look them up so the right
+        // template + slug are picked.
+        Lookup lookup = lookupTenantAndIntent(oneTimeToken.getTokenValue());
+        Tenant tenant = tenantRepository.findById(lookup.tenantId())
+            .orElseThrow(() -> new IllegalStateException(
+                "OTT row references missing tenant id=" + lookup.tenantId()));
+        send(tenant, oneTimeToken.getUsername(), oneTimeToken.getTokenValue(), lookup.intent());
+        // The default Spring handler redirects after; mirror that so a real
+        // /ott/generate POST doesn't leave the browser on a blank page.
+        redirectStrategy.sendRedirect(request, response, "/t/" + tenant.slug() + "/check-inbox");
+    }
+
+    private void send(Tenant tenant, String recipientEmail, String tokenValue, OttIntent intent) {
+        String slug = tenant.slug();
+        String link = magicLink(slug, tokenValue, intent);
+        String subject = subjectFor(intent);
+        String body = bodyFor(intent, tenant.displayName(), link);
+        emailSender.send(new EmailMessage(recipientEmail, subject, body));
+    }
+
+    private static String magicLink(String slug, String tokenValue, OttIntent intent) {
+        // Slice 4 wires both intents through the same /login/ott consume path;
+        // the OTT row's intent column drives the post-consume behaviour
+        // (verify the email, force password change, etc.) on the auth-provider
+        // side, so the URL itself doesn't need to differ.
+        return "/t/" + slug + "/login/ott?token=" + tokenValue;
+    }
+
+    private static String subjectFor(OttIntent intent) {
+        return switch (intent) {
+            case VERIFY_EMAIL -> "Verify your Limen email address";
+            case PASSWORD_RESET -> "Reset your Limen password";
+        };
+    }
+
+    private static String bodyFor(OttIntent intent, String tenantName, String link) {
+        return switch (intent) {
+            case VERIFY_EMAIL -> ""
+                + "Welcome to " + tenantName + " on Limen.\n\n"
+                + "Click the link below to verify your email address and activate your account:\n\n"
+                + link + "\n\n"
+                + "This link is single-use and will expire in 60 minutes.\n";
+            case PASSWORD_RESET -> ""
+                + "We received a password-reset request for your account at " + tenantName + ".\n\n"
+                + "Click the link below to set a new password:\n\n"
+                + link + "\n\n"
+                + "This link is single-use and will expire in 60 minutes.\n"
+                + "If you didn't request this, you can safely ignore the message.\n";
+        };
+    }
+
+    private Lookup lookupTenantAndIntent(String tokenValue) {
+        // requireTenantId is intentionally not called here — the bound TenantScope
+        // is a function of how the request reached us, but Spring's generator
+        // filter populates the row before invoking handle(), so we trust the row.
+        List<Lookup> rows = jdbcTemplate.query(LOOKUP_SQL, (rs, idx) -> {
+            String wire = rs.getString("intent");
+            OttIntent intent = OttIntent.fromWire(wire);
+            if (intent == null) {
+                throw new IllegalStateException("Unknown OTT intent in storage: " + wire);
+            }
+            return new Lookup(rs.getLong("tenant_id"), intent);
+        }, tokenValue);
+        if (rows.isEmpty()) {
+            // Should not happen — Spring just inserted the row before calling us.
+            // Fall back to defaults rather than NPE so the email send path stays
+            // recoverable if a row is, say, deleted out from under us.
+            Long current = TenantScope.tenantId();
+            if (current == null) {
+                throw new IllegalStateException(
+                    "OTT row missing for token and TenantScope is unbound; cannot dispatch email");
+            }
+            return new Lookup(current, OttIntent.VERIFY_EMAIL);
+        }
+        return rows.get(0);
+    }
+
+    private record Lookup(Long tenantId, OttIntent intent) {}
+}

--- a/src/main/java/com/stucray/limen/auth/ott/OttIntent.java
+++ b/src/main/java/com/stucray/limen/auth/ott/OttIntent.java
@@ -1,0 +1,39 @@
+package com.stucray.limen.auth.ott;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Distinguishes the two flows that share the OTT substrate:
+ * <ul>
+ *   <li>{@link #VERIFY_EMAIL} — issued at signup or via the resend-verification
+ *       form; consume marks {@code users.email_verified=true}.</li>
+ *   <li>{@link #PASSWORD_RESET} — issued from the forgot-password flow
+ *       (slice #126); consume drops the user into the existing forced
+ *       password-change pipeline.</li>
+ * </ul>
+ *
+ * <p>The wire value is the lowercase-hyphenated form persisted in
+ * {@code one_time_tokens.intent} and matches the migration's CHECK constraint.
+ */
+public enum OttIntent {
+
+    VERIFY_EMAIL("verify-email"),
+    PASSWORD_RESET("password-reset");
+
+    private final String wire;
+
+    OttIntent(String wire) {
+        this.wire = wire;
+    }
+
+    public String wire() {
+        return wire;
+    }
+
+    public static @Nullable OttIntent fromWire(String value) {
+        for (OttIntent i : values()) {
+            if (i.wire.equals(value)) return i;
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/stucray/limen/auth/ott/OttSubmitController.java
+++ b/src/main/java/com/stucray/limen/auth/ott/OttSubmitController.java
@@ -1,0 +1,44 @@
+package com.stucray.limen.auth.ott;
+
+import com.stucray.limen.tenant.TenantRepository;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * Renders the auto-submitting form for a magic-link click.
+ *
+ * <p>Spring Security's {@code OneTimeTokenAuthenticationFilter} only handles
+ * POST, but a user clicking an email link issues a GET. Spring ships a
+ * {@code DefaultOneTimeTokenSubmitPageGeneratingFilter} that renders an
+ * equivalent page, but its form action is the literal configured
+ * {@code loginProcessingUrl} — which contains a {@code *} wildcard in our
+ * tenant-prefixed setup ({@code /t/*&#47;login/ott}) and therefore cannot be
+ * submitted directly. We render our own page so the form action carries the
+ * resolved slug.
+ */
+@Controller
+public class OttSubmitController {
+
+    private final TenantRepository tenantRepository;
+
+    public OttSubmitController(TenantRepository tenantRepository) {
+        this.tenantRepository = tenantRepository;
+    }
+
+    @GetMapping("/t/{slug}/login/ott")
+    public String submitForm(
+        @PathVariable String slug,
+        @RequestParam(required = false) String token,
+        Model model
+    ) {
+        if (tenantRepository.findBySlug(slug).isEmpty()) {
+            return "redirect:/";
+        }
+        model.addAttribute("slug", slug);
+        model.addAttribute("token", token == null ? "" : token);
+        return "ott-submit";
+    }
+}

--- a/src/main/java/com/stucray/limen/auth/ott/ResendVerificationController.java
+++ b/src/main/java/com/stucray/limen/auth/ott/ResendVerificationController.java
@@ -1,0 +1,70 @@
+package com.stucray.limen.auth.ott;
+
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * GET renders the form (pre-filling the email if present in the query); POST
+ * dispatches to {@link EmailVerificationService#resendVerification} and
+ * redirects to {@code /t/{slug}/check-inbox?email=...}.
+ *
+ * <p>Both verbs are anonymous — a user who just signed up has no session yet
+ * and so cannot authenticate to ask for a resend. The
+ * {@code resendVerification} method silently no-ops on an unknown email,
+ * preserving the user-existence-oracle defence laid out in PRD #120 story 14.
+ */
+@Controller
+public class ResendVerificationController {
+
+    private final TenantRepository tenantRepository;
+    private final EmailVerificationService verificationService;
+
+    public ResendVerificationController(
+        TenantRepository tenantRepository,
+        EmailVerificationService verificationService
+    ) {
+        this.tenantRepository = tenantRepository;
+        this.verificationService = verificationService;
+    }
+
+    @GetMapping("/t/{slug}/resend-verification")
+    public String form(
+        @PathVariable String slug,
+        @RequestParam(required = false) String email,
+        Model model
+    ) {
+        if (tenantRepository.findBySlug(slug).isEmpty()) {
+            return "redirect:/";
+        }
+        model.addAttribute("slug", slug);
+        model.addAttribute("email", email == null ? "" : email);
+        return "resend-verification";
+    }
+
+    @PostMapping("/t/{slug}/resend-verification")
+    public String submit(
+        @PathVariable String slug,
+        @RequestParam String email
+    ) {
+        Tenant tenant = tenantRepository.findBySlug(slug).orElse(null);
+        if (tenant == null) {
+            return "redirect:/";
+        }
+        verificationService.resendVerification(tenant, email);
+        return "redirect:" + UriComponentsBuilder
+            .fromPath("/t/" + slug + "/check-inbox")
+            .queryParam("email", email)
+            .build()
+            .encode(StandardCharsets.UTF_8)
+            .toUriString();
+    }
+}

--- a/src/main/java/com/stucray/limen/auth/ott/TenantAwareOneTimeTokenService.java
+++ b/src/main/java/com/stucray/limen/auth/ott/TenantAwareOneTimeTokenService.java
@@ -1,0 +1,150 @@
+package com.stucray.limen.auth.ott;
+
+import com.stucray.limen.tenant.TenantScope;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.authentication.ott.GenerateOneTimeTokenRequest;
+import org.springframework.security.authentication.ott.OneTimeToken;
+import org.springframework.security.authentication.ott.OneTimeTokenAuthenticationToken;
+import org.springframework.security.authentication.ott.OneTimeTokenService;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Timestamp;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Tenant-scoped {@link OneTimeTokenService}. Mirrors the storage shape of
+ * Spring Security's {@code JdbcOneTimeTokenService} (token_value PK, username,
+ * expires_at) plus the two columns added by the V8 migration: {@code tenant_id}
+ * and {@code intent}.
+ *
+ * <p>We re-implement rather than wrap because Spring's class is {@code final}
+ * and {@code consume()} couples SELECT + DELETE in a way that does not compose
+ * cleanly with a decorator that needs to read {@code tenant_id} + {@code intent}
+ * on the same row before it disappears. The SQL is straightforward and matches
+ * the framework's contract.
+ *
+ * <p>Tenant binding: every call requires an active {@link TenantScope}.
+ * {@link #generate(GenerateOneTimeTokenRequest)} stamps the calling tenant on
+ * the row. {@link #consume(OneTimeTokenAuthenticationToken)} returns null if
+ * the row's tenant does not match the calling tenant — that is the
+ * cross-tenant defence in depth that the {@code TenantAwareOAuth2AuthorizationService}
+ * pattern at {@code oauth2/TenantAwareOAuth2AuthorizationService.java} already
+ * established.
+ *
+ * <p>Intent: callers that know which flow they are issuing (signup,
+ * resend-verification, forgot-password) use {@link #generateForIntent}.
+ * The interface method falls back to {@link OttIntent#VERIFY_EMAIL} so a
+ * generic {@code /ott/generate} endpoint defaults to the safe interpretation.
+ *
+ * <p>Cleanup: Spring's {@code JdbcOneTimeTokenService} schedules an hourly
+ * task to delete expired rows. We omit that here — the {@code expires_at}
+ * index is in place so a future cleanup job (or a scheduled Modulith
+ * application event) can run cheaply.
+ */
+@Component
+public class TenantAwareOneTimeTokenService implements OneTimeTokenService {
+
+    private static final String INSERT_SQL =
+        "INSERT INTO one_time_tokens (token_value, username, expires_at, tenant_id, intent) "
+            + "VALUES (?, ?, ?, ?, ?)";
+
+    private static final String SELECT_SQL =
+        "SELECT token_value, username, expires_at, tenant_id, intent "
+            + "FROM one_time_tokens WHERE token_value = ?";
+
+    private static final String DELETE_SQL =
+        "DELETE FROM one_time_tokens WHERE token_value = ?";
+
+    private final JdbcTemplate jdbcTemplate;
+    private final Clock clock;
+
+    @Autowired
+    public TenantAwareOneTimeTokenService(JdbcTemplate jdbcTemplate) {
+        this(jdbcTemplate, Clock.systemUTC());
+    }
+
+    /** Test seam: inject a clock to drive expiry deterministically. */
+    public TenantAwareOneTimeTokenService(JdbcTemplate jdbcTemplate, Clock clock) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.clock = clock;
+    }
+
+    /**
+     * Generate a token for a specific intent. Used by {@code SignupService},
+     * the resend-verification controller, and (in slice #126) forgot-password.
+     */
+    public TenantOneTimeToken generateForIntent(String username, OttIntent intent) {
+        Long tenantId = requireTenantId();
+        String tokenValue = UUID.randomUUID().toString();
+        Instant expiresAt = clock.instant().plus(java.time.Duration.ofMinutes(60));
+        jdbcTemplate.update(INSERT_SQL,
+            tokenValue, username, Timestamp.from(expiresAt), tenantId, intent.wire());
+        return new TenantOneTimeToken(tokenValue, username, expiresAt, tenantId, intent);
+    }
+
+    @Override
+    public OneTimeToken generate(GenerateOneTimeTokenRequest request) {
+        return generateForIntent(request.getUsername(), OttIntent.VERIFY_EMAIL);
+    }
+
+    /**
+     * Consume by token value. Returns null when the token is missing, was
+     * issued under a different tenant than the current {@link TenantScope},
+     * or has expired. Always deletes the row when one was matched, so a
+     * second consume of the same value returns null even if the first was
+     * a cross-tenant rejection — single-use is enforced storage-side.
+     */
+    @Override
+    @Transactional
+    public @Nullable OneTimeToken consume(OneTimeTokenAuthenticationToken authenticationToken) {
+        Long tenantId = requireTenantId();
+        String tokenValue = authenticationToken.getTokenValue();
+        if (tokenValue == null || tokenValue.isBlank()) {
+            return null;
+        }
+
+        List<TenantOneTimeToken> rows = jdbcTemplate.query(SELECT_SQL, (rs, idx) -> {
+            String wire = rs.getString("intent");
+            OttIntent intent = OttIntent.fromWire(wire);
+            if (intent == null) {
+                throw new IllegalStateException("Unknown OTT intent in storage: " + wire);
+            }
+            return new TenantOneTimeToken(
+                rs.getString("token_value"),
+                rs.getString("username"),
+                rs.getTimestamp("expires_at").toInstant(),
+                rs.getLong("tenant_id"),
+                intent
+            );
+        }, tokenValue);
+
+        if (rows.isEmpty()) {
+            return null;
+        }
+        TenantOneTimeToken row = rows.get(0);
+        // Always delete on a match — single-use even if the consumer is wrong about tenant.
+        jdbcTemplate.update(DELETE_SQL, tokenValue);
+        if (!row.tenantId().equals(tenantId)) {
+            return null;
+        }
+        if (clock.instant().isAfter(row.expiresAt())) {
+            return null;
+        }
+        return row;
+    }
+
+    private static Long requireTenantId() {
+        Long tenantId = TenantScope.tenantId();
+        if (tenantId == null) {
+            throw new IllegalStateException(
+                "TenantAwareOneTimeTokenService called without TenantScope");
+        }
+        return tenantId;
+    }
+}

--- a/src/main/java/com/stucray/limen/auth/ott/TenantOneTimeToken.java
+++ b/src/main/java/com/stucray/limen/auth/ott/TenantOneTimeToken.java
@@ -1,0 +1,36 @@
+package com.stucray.limen.auth.ott;
+
+import org.springframework.security.authentication.ott.OneTimeToken;
+
+import java.time.Instant;
+
+/**
+ * The Spring framework's {@link OneTimeToken} carries only token + username +
+ * expiresAt. {@code TenantAwareOneTimeTokenService} returns this richer record
+ * so callers downstream of {@code consume()} (the OTT auth provider, the
+ * post-OTT dispatch logic) can read the issuing tenant and the original intent
+ * without a second SELECT.
+ */
+public record TenantOneTimeToken(
+    String tokenValue,
+    String username,
+    Instant expiresAt,
+    Long tenantId,
+    OttIntent intent
+) implements OneTimeToken {
+
+    @Override
+    public String getTokenValue() {
+        return tokenValue;
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public Instant getExpiresAt() {
+        return expiresAt;
+    }
+}

--- a/src/main/java/com/stucray/limen/auth/ott/TenantOttAuthenticationProvider.java
+++ b/src/main/java/com/stucray/limen/auth/ott/TenantOttAuthenticationProvider.java
@@ -1,0 +1,108 @@
+package com.stucray.limen.auth.ott;
+
+import com.stucray.limen.auth.TenantUserDetails;
+import com.stucray.limen.auth.TenantUserDetailsService;
+import com.stucray.limen.tenant.TenantScope;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.ott.InvalidOneTimeTokenException;
+import org.springframework.security.authentication.ott.OneTimeToken;
+import org.springframework.security.authentication.ott.OneTimeTokenAuthentication;
+import org.springframework.security.authentication.ott.OneTimeTokenAuthenticationToken;
+import org.springframework.security.authentication.ott.OneTimeTokenService;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.FactorGrantedAuthority;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Tenant-aware replacement for Spring's {@code OneTimeTokenAuthenticationProvider}.
+ *
+ * <p>The framework's provider calls {@code UserDetailsService.loadUserByUsername(token.username())},
+ * which Limen's {@link TenantUserDetailsService} explicitly rejects — every
+ * authentication path in this codebase already knows the tenant slug. Here, the
+ * slug comes from {@link TenantScope}, bound by {@code TenantOttRoutingFilter}
+ * before the security chain runs. Issuing the lookup as
+ * {@code loadByEmailAndSlug(email, slug)} preserves the per-tenant user-pool
+ * isolation that the rest of Limen depends on.
+ *
+ * <p>Side effects on consume:
+ * <ul>
+ *   <li>{@link OttIntent#VERIFY_EMAIL} — flips {@code email_verified=true} via
+ *       {@link EmailVerificationService#markEmailVerified} (idempotent on a
+ *       second consume).</li>
+ *   <li>{@link OttIntent#PASSWORD_RESET} — left to slice #126; the principal
+ *       is returned authenticated so the post-login dispatch can route to
+ *       change-password.</li>
+ * </ul>
+ */
+@Component
+public class TenantOttAuthenticationProvider implements AuthenticationProvider {
+
+    private final OneTimeTokenService tokenService;
+    private final TenantUserDetailsService userDetailsService;
+    private final EmailVerificationService verificationService;
+
+    public TenantOttAuthenticationProvider(
+        OneTimeTokenService tokenService,
+        TenantUserDetailsService userDetailsService,
+        EmailVerificationService verificationService
+    ) {
+        this.tokenService = tokenService;
+        this.userDetailsService = userDetailsService;
+        this.verificationService = verificationService;
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        OneTimeTokenAuthenticationToken otpToken = (OneTimeTokenAuthenticationToken) authentication;
+        OneTimeToken consumed = tokenService.consume(otpToken);
+        if (!(consumed instanceof TenantOneTimeToken row)) {
+            // consume() returns null for missing / expired / cross-tenant; either
+            // is an invalid-token from the client's perspective.
+            throw new InvalidOneTimeTokenException("Invalid or expired one-time token");
+        }
+
+        String slug = TenantScope.slug();
+        if (slug == null) {
+            throw new IllegalStateException(
+                "TenantOttAuthenticationProvider invoked outside TenantScope");
+        }
+
+        TenantUserDetails principal;
+        try {
+            principal = (TenantUserDetails) userDetailsService.loadByEmailAndSlug(row.username(), slug);
+        } catch (UsernameNotFoundException ex) {
+            // The token row's email does not resolve to a user in the tenant
+            // (e.g. user deleted between issue and consume). Treat as bad creds
+            // rather than leaking which case we hit.
+            throw new BadCredentialsException("Failed to authenticate the one-time token");
+        }
+
+        if (row.intent() == OttIntent.VERIFY_EMAIL) {
+            verificationService.markEmailVerified(principal.userId(), principal.tenantId());
+            // Reflect the just-applied flip on the in-memory principal so the
+            // PostLoginIntent.emailVerificationRequired() check that runs from
+            // the success handler doesn't see stale state and bounce the user
+            // back to check-inbox.
+            principal = new TenantUserDetails(
+                principal.user().withEmailVerified(true), principal.tenant());
+        }
+
+        Set<GrantedAuthority> authorities = new HashSet<>(principal.getAuthorities());
+        authorities.add(FactorGrantedAuthority.fromAuthority(FactorGrantedAuthority.OTT_AUTHORITY));
+        OneTimeTokenAuthentication authenticated = new OneTimeTokenAuthentication(principal, authorities);
+        authenticated.setDetails(otpToken.getDetails());
+        return authenticated;
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return OneTimeTokenAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+}

--- a/src/main/java/com/stucray/limen/auth/ott/TenantOttRoutingFilter.java
+++ b/src/main/java/com/stucray/limen/auth/ott/TenantOttRoutingFilter.java
@@ -1,0 +1,81 @@
+package com.stucray.limen.auth.ott;
+
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.tenant.TenantScope;
+import com.stucray.limen.tenant.TenantStatus;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Binds {@link TenantScope} for the OTT URLs ({@code /t/{slug}/login/ott},
+ * {@code /t/{slug}/check-inbox}, {@code /t/{slug}/resend-verification}) so the
+ * OTT auth provider, the tenant-aware token service, and the controllers below
+ * can read tenant identity from {@link TenantScope} instead of plumbing it
+ * through every method signature.
+ *
+ * <p>Modelled on {@code TenantOAuth2RoutingFilter} but does <em>not</em> strip
+ * the URL prefix — these endpoints are owned by Limen's own controllers and
+ * filters, which expect to see the slug.
+ *
+ * <p>Runs at {@code MIN_VALUE + 11} so it is sequenced after
+ * {@code TenantOAuth2RoutingFilter} (which holds {@code MIN_VALUE + 10} and is
+ * already responsible for the {@code /oauth2/...} prefix-strip) and well before
+ * any of the security-chain filters.
+ */
+@Component
+@Order(Integer.MIN_VALUE + 11)
+public class TenantOttRoutingFilter extends OncePerRequestFilter {
+
+    private static final Pattern TENANT_OTT_PATH =
+        Pattern.compile("^/t/([^/]+)/(login/ott|check-inbox|resend-verification)(?:[/?].*)?$");
+
+    private final TenantRepository tenantRepository;
+
+    public TenantOttRoutingFilter(TenantRepository tenantRepository) {
+        this.tenantRepository = tenantRepository;
+    }
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request, HttpServletResponse response, FilterChain chain
+    ) throws ServletException, IOException {
+        String uri = request.getRequestURI();
+        Matcher m = TENANT_OTT_PATH.matcher(uri);
+        if (!m.matches()) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        String slug = m.group(1);
+        Tenant tenant = tenantRepository.findBySlug(slug).orElse(null);
+        if (tenant == null) {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND, "Unknown tenant: " + slug);
+            return;
+        }
+        if (tenant.status() == TenantStatus.SUSPENDED) {
+            response.sendError(HttpServletResponse.SC_FORBIDDEN, "Tenant is suspended");
+            return;
+        }
+
+        try {
+            TenantScope.call(slug, tenant.id(), () -> {
+                chain.doFilter(request, response);
+                return null;
+            });
+        } catch (IOException | ServletException | RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new ServletException(e);
+        }
+    }
+}

--- a/src/main/java/com/stucray/limen/identity/UserBootstrap.java
+++ b/src/main/java/com/stucray/limen/identity/UserBootstrap.java
@@ -53,7 +53,7 @@ public class UserBootstrap implements CommandLineRunner {
             .ifPresentOrElse(
                 existing -> userRepository.save(existing.withPasswordHash(hash).withMustChangePassword(false)),
                 () -> userRepository.save(
-                    new User(null, systemTenant.id(), adminProperties.email(), hash, true, false, false, LocalDateTime.now())
+                    new User(null, systemTenant.id(), adminProperties.email(), hash, true, false, false, true, LocalDateTime.now())
                 )
             );
     }

--- a/src/main/java/com/stucray/limen/management/signup/SignupController.java
+++ b/src/main/java/com/stucray/limen/management/signup/SignupController.java
@@ -5,6 +5,9 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.nio.charset.StandardCharsets;
 
 @Controller
 public class SignupController {
@@ -33,7 +36,16 @@ public class SignupController {
         SignupService.SignupResult result = signupService.signup(form);
 
         if (result instanceof SignupService.SignupResult.Success success) {
-            return "redirect:/manage/t/" + success.slug() + "/login?registered";
+            // Land on the check-inbox page so the new tenant owner sees the
+            // verification email instructions before they try to log in.
+            // The forwarder /login is also tenant-aware, so we encode the slug
+            // explicitly here rather than relying on it.
+            return "redirect:" + UriComponentsBuilder
+                .fromPath("/t/" + success.slug() + "/check-inbox")
+                .queryParam("email", success.email())
+                .build()
+                .encode(StandardCharsets.UTF_8)
+                .toUriString();
         }
 
         SignupService.SignupResult.Error error = (SignupService.SignupResult.Error) result;

--- a/src/main/java/com/stucray/limen/management/signup/SignupService.java
+++ b/src/main/java/com/stucray/limen/management/signup/SignupService.java
@@ -1,5 +1,6 @@
 package com.stucray.limen.management.signup;
 
+import com.stucray.limen.auth.ott.EmailVerificationService;
 import com.stucray.limen.tenant.Tenant;
 import com.stucray.limen.tenant.TenantProvisioningService;
 import com.stucray.limen.tenant.TenantRepository;
@@ -27,21 +28,24 @@ public class SignupService {
     private final TenantProvisioningService tenantProvisioningService;
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final EmailVerificationService emailVerificationService;
 
     public SignupService(
         TenantRepository tenantRepository,
         TenantProvisioningService tenantProvisioningService,
         UserRepository userRepository,
-        PasswordEncoder passwordEncoder
+        PasswordEncoder passwordEncoder,
+        EmailVerificationService emailVerificationService
     ) {
         this.tenantRepository = tenantRepository;
         this.tenantProvisioningService = tenantProvisioningService;
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
+        this.emailVerificationService = emailVerificationService;
     }
 
     public sealed interface SignupResult {
-        record Success(String slug) implements SignupResult {}
+        record Success(String slug, String email) implements SignupResult {}
         record Error(String field, String message) implements SignupResult {}
     }
 
@@ -84,12 +88,14 @@ public class SignupService {
         }
 
         Tenant tenant = tenantProvisioningService.createTenant(slug, orgName);
-        userRepository.save(new User(
+        User savedOwner = userRepository.save(new User(
             null, tenant.id(), email,
             Objects.requireNonNull(passwordEncoder.encode(form.password())),
-            true, false, true, LocalDateTime.now()
+            true, false, true, false, LocalDateTime.now()
         ));
 
-        return new SignupResult.Success(slug);
+        emailVerificationService.issueVerification(tenant, savedOwner);
+
+        return new SignupResult.Success(slug, email);
     }
 }

--- a/src/main/java/com/stucray/limen/management/users/UserManagementService.java
+++ b/src/main/java/com/stucray/limen/management/users/UserManagementService.java
@@ -41,7 +41,7 @@ public class UserManagementService {
         userRepository.save(new User(
             null, tenantId, email,
             Objects.requireNonNull(passwordEncoder.encode(temporaryPassword)),
-            true, true, false, LocalDateTime.now()
+            true, true, false, true, LocalDateTime.now()
         ));
     }
 

--- a/src/main/java/com/stucray/limen/oauth2/OAuth2LoginSecurityConfig.java
+++ b/src/main/java/com/stucray/limen/oauth2/OAuth2LoginSecurityConfig.java
@@ -2,6 +2,9 @@ package com.stucray.limen.oauth2;
 
 import com.stucray.limen.auth.login.TenantLogin;
 import com.stucray.limen.auth.login.TenantUrlScheme;
+import com.stucray.limen.auth.ott.OttEmailNotifier;
+import com.stucray.limen.auth.ott.TenantAwareOneTimeTokenService;
+import com.stucray.limen.auth.ott.TenantOttAuthenticationProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -24,6 +27,14 @@ import java.util.regex.Pattern;
  * management chain (Order 2). Form-login wiring is delegated to {@link TenantLogin};
  * everything left here is distinctive to this surface (URL scope, CSRF, request cache,
  * tenant-aware entry point, logout).
+ *
+ * <p>One-Time Token Login is wired here as well: the magic link issued during
+ * email verification (and, in slice #126, during password reset) lands at
+ * {@code /t/{slug}/login/ott} where {@link TenantOttAuthenticationProvider}
+ * exchanges the token for an authenticated session. Post-OTT dispatch reuses
+ * the same {@link TenantLogin#successHandlerFor intent chain} as form login
+ * so email-verification, must-change-password, and saved-/oauth2/authorize-resume
+ * behave identically across surfaces.
  */
 @Configuration
 @Order(1)
@@ -31,13 +42,22 @@ public class OAuth2LoginSecurityConfig {
 
     private final TenantLogin login;
     private final TenantUrlScheme oauth2UrlScheme;
+    private final TenantAwareOneTimeTokenService oneTimeTokenService;
+    private final OttEmailNotifier ottEmailNotifier;
+    private final TenantOttAuthenticationProvider ottAuthenticationProvider;
 
     public OAuth2LoginSecurityConfig(
         TenantLogin login,
-        @Qualifier("oauth2UrlScheme") TenantUrlScheme oauth2UrlScheme
+        @Qualifier("oauth2UrlScheme") TenantUrlScheme oauth2UrlScheme,
+        TenantAwareOneTimeTokenService oneTimeTokenService,
+        OttEmailNotifier ottEmailNotifier,
+        TenantOttAuthenticationProvider ottAuthenticationProvider
     ) {
         this.login = login;
         this.oauth2UrlScheme = oauth2UrlScheme;
+        this.oneTimeTokenService = oneTimeTokenService;
+        this.ottEmailNotifier = ottEmailNotifier;
+        this.ottAuthenticationProvider = ottAuthenticationProvider;
     }
 
     @Bean
@@ -51,12 +71,27 @@ public class OAuth2LoginSecurityConfig {
             .securityMatcher("/t/**")
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/t/*/login").permitAll()
+                .requestMatchers("/t/*/login/ott").permitAll()
+                .requestMatchers("/t/*/check-inbox").permitAll()
+                .requestMatchers("/t/*/resend-verification").permitAll()
                 .anyRequest().authenticated()
             )
             .requestCache(rc -> rc.requestCache(requestCache))
             .exceptionHandling(ex -> ex.authenticationEntryPoint(
                 TenantLoginUrlAuthenticationEntryPoint.fromUrl()
             ))
+            .oneTimeTokenLogin(ott -> ott
+                .tokenService(oneTimeTokenService)
+                .tokenGenerationSuccessHandler(ottEmailNotifier)
+                .authenticationProvider(ottAuthenticationProvider)
+                .loginProcessingUrl("/t/*/login/ott")
+                // Spring's default submit page filter renders a form whose action
+                // is the literal loginProcessingUrl ("/t/*/login/ott") — the
+                // unexpanded wildcard breaks the form. {@code OttSubmitController}
+                // renders the equivalent page with the resolved slug.
+                .showDefaultSubmitPage(false)
+                .successHandler(login.successHandlerFor(oauth2UrlScheme))
+            )
             .logout(logout -> logout
                 .logoutRequestMatcher(PathPatternRequestMatcher.withDefaults()
                     .matcher(HttpMethod.POST, "/t/*/logout"))

--- a/src/main/java/com/stucray/limen/user/User.java
+++ b/src/main/java/com/stucray/limen/user/User.java
@@ -14,21 +14,26 @@ public record User(
     boolean enabled,
     boolean mustChangePassword,
     boolean tenantOwner,
+    boolean emailVerified,
     LocalDateTime createdAt
 ) {
     public User withPasswordHash(String newHash) {
-        return new User(id, tenantId, email, newHash, enabled, true, tenantOwner, createdAt);
+        return new User(id, tenantId, email, newHash, enabled, true, tenantOwner, emailVerified, createdAt);
     }
 
     public User withEnabled(boolean newEnabled) {
-        return new User(id, tenantId, email, passwordHash, newEnabled, mustChangePassword, tenantOwner, createdAt);
+        return new User(id, tenantId, email, passwordHash, newEnabled, mustChangePassword, tenantOwner, emailVerified, createdAt);
     }
 
     public User withMustChangePassword(boolean value) {
-        return new User(id, tenantId, email, passwordHash, enabled, value, tenantOwner, createdAt);
+        return new User(id, tenantId, email, passwordHash, enabled, value, tenantOwner, emailVerified, createdAt);
     }
 
     public User withTenantOwner(boolean value) {
-        return new User(id, tenantId, email, passwordHash, enabled, mustChangePassword, value, createdAt);
+        return new User(id, tenantId, email, passwordHash, enabled, mustChangePassword, value, emailVerified, createdAt);
+    }
+
+    public User withEmailVerified(boolean value) {
+        return new User(id, tenantId, email, passwordHash, enabled, mustChangePassword, tenantOwner, value, createdAt);
     }
 }

--- a/src/main/resources/db/migration/V8__one_time_tokens_and_email_verification.sql
+++ b/src/main/resources/db/migration/V8__one_time_tokens_and_email_verification.sql
@@ -1,0 +1,37 @@
+-- One-Time Token storage plus the user-side flag the verification flow flips.
+--
+-- Spring Security 7 ships JdbcOneTimeTokenService with a fixed schema
+-- ("classpath:org/springframework/security/core/ott/jdbc/one-time-tokens-schema.sql")
+-- of (token_value, username, expires_at). We keep the same primary-key + value
+-- columns Spring's RowMapper expects, then add two columns the framework does
+-- not know about:
+--
+--   * tenant_id — enforced by TenantAwareOneTimeTokenService so a token issued
+--     under tenant A cannot be consumed when the request resolves to tenant B
+--     (mirrors the TenantAwareOAuth2AuthorizationService isolation pattern).
+--
+--   * intent    — verify-email | password-reset, so one storage layer carries
+--     both flows. The OTT email notifier and the post-OTT login dispatcher
+--     read it to choose template + redirect target.
+--
+-- The framework's varchar_ignorecase(50) for username is HSQL-only syntax and
+-- 50 chars is too narrow for emails; we widen to varchar(255).
+
+CREATE TABLE one_time_tokens (
+    token_value varchar(36)  NOT NULL PRIMARY KEY,
+    username    varchar(255) NOT NULL,
+    expires_at  timestamp    NOT NULL,
+    tenant_id   bigint       NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    intent      varchar(32)  NOT NULL
+        CHECK (intent IN ('verify-email', 'password-reset'))
+);
+
+CREATE INDEX one_time_tokens_tenant_idx  ON one_time_tokens (tenant_id);
+CREATE INDEX one_time_tokens_expires_idx ON one_time_tokens (expires_at);
+
+-- Email verification gate. Defaults to FALSE so any user inserted without
+-- explicit verification (signup, system-admin tenant create) lands unverified;
+-- the OTT magic link flips it to TRUE. The PostLoginIntent.emailVerificationRequired()
+-- intent reads this column to block /oauth2/authorize until it is set.
+ALTER TABLE users
+    ADD COLUMN email_verified boolean NOT NULL DEFAULT false;

--- a/src/main/resources/templates/check-inbox.html
+++ b/src/main/resources/templates/check-inbox.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{fragments/layout :: layout(~{::title}, ~{::main})}">
+<head><title>Check your inbox — Limen</title></head>
+<body>
+<main>
+    <article class="card card--auth">
+        <hgroup>
+            <h1>Check your inbox</h1>
+            <p th:if="${tenantName}" th:text="${tenantName}">Tenant</p>
+        </hgroup>
+        <p>
+            We've sent a verification link
+            <span th:if="${email != null and !email.isEmpty()}">
+                to <strong th:text="${email}" data-test-action="verification-email">you@example.com</strong>
+            </span>.
+            Click the link in the email to activate your account.
+        </p>
+        <p class="muted">The link is single-use and expires in 60 minutes.</p>
+        <hr/>
+        <p>
+            Didn't receive the email?
+            <a th:href="@{/t/{slug}/resend-verification(slug=${slug}, email=${email})}"
+               data-test-action="resend-verification-link">Resend it</a>.
+        </p>
+        <p>
+            <a th:href="@{/t/{slug}/login(slug=${slug})}" data-test-action="back-to-login">Back to sign in</a>
+        </p>
+    </article>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/ott-submit.html
+++ b/src/main/resources/templates/ott-submit.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{fragments/layout :: layout(~{::title}, ~{::main})}">
+<head><title>Sign in with magic link — Limen</title></head>
+<body>
+<main>
+    <article class="card card--auth">
+        <hgroup>
+            <h1>Sign in with your magic link</h1>
+            <p>Click the button to complete sign-in.</p>
+        </hgroup>
+        <form method="post" th:action="@{/t/{slug}/login/ott(slug=${slug})}" class="stack">
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+            <input type="hidden" name="token" th:value="${token}"/>
+            <button type="submit" class="btn--block" data-test-action="ott-submit"
+                    autofocus>Sign in</button>
+        </form>
+    </article>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/resend-verification.html
+++ b/src/main/resources/templates/resend-verification.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{fragments/layout :: layout(~{::title}, ~{::main})}">
+<head><title>Resend verification email — Limen</title></head>
+<body>
+<main>
+    <article class="card card--auth">
+        <hgroup>
+            <h1>Resend verification email</h1>
+            <p>Enter your email address and we'll send a new verification link.</p>
+        </hgroup>
+        <form method="post" th:action="@{/t/{slug}/resend-verification(slug=${slug})}" class="stack">
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+            <label>
+                Email
+                <input type="email" name="email" th:value="${email}" autofocus required/>
+            </label>
+            <button type="submit" class="btn--block" data-test-action="resend-submit">Send link</button>
+        </form>
+    </article>
+</main>
+</body>
+</html>

--- a/src/test/java/com/stucray/limen/IssuerContractTest.java
+++ b/src/test/java/com/stucray/limen/IssuerContractTest.java
@@ -46,7 +46,7 @@ class IssuerContractTest {
     void setUp() {
         Long systemTenantId = tenantRepository.findBySlug("system").orElseThrow().id();
         if (!userRepository.existsByEmailAndTenantId("testuser@example.test", systemTenantId)) {
-            userRepository.save(new User(null, systemTenantId, "testuser@example.test", passwordEncoder.encode("password"), true, false, false, LocalDateTime.now()));
+            userRepository.save(new User(null, systemTenantId, "testuser@example.test", passwordEncoder.encode("password"), true, false, false, true, LocalDateTime.now()));
         }
 
         RegisteredClient existing = registeredClientRepository.findByClientId(CLIENT_ID);

--- a/src/test/java/com/stucray/limen/LoginIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/LoginIntegrationTest.java
@@ -51,7 +51,7 @@ class LoginIntegrationTest {
         jdbcTemplate.execute("DELETE FROM users WHERE tenant_id = (SELECT id FROM tenants WHERE slug = 'system')");
 
         systemTenantId = tenantRepository.findBySlug("system").orElseThrow().id();
-        userRepository.save(new User(null, systemTenantId, "testuser@example.test", passwordEncoder.encode("password"), true, false, false, LocalDateTime.now()));
+        userRepository.save(new User(null, systemTenantId, "testuser@example.test", passwordEncoder.encode("password"), true, false, false, true, LocalDateTime.now()));
     }
 
     @Test

--- a/src/test/java/com/stucray/limen/audit/AuditEventEmitIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/audit/AuditEventEmitIntegrationTest.java
@@ -219,7 +219,7 @@ class AuditEventEmitIntegrationTest {
         String email = "user-" + UUID.randomUUID().toString().substring(0, 8) + "@example.test";
         return userRepository.save(new User(
             null, tenantId, email, passwordEncoder.encode("oldPass1234"),
-            true, mustChangePassword, false, LocalDateTime.now()));
+            true, mustChangePassword, false, true, LocalDateTime.now()));
     }
 
     @SuppressWarnings("NullAway") // Spring Data convention
@@ -228,7 +228,7 @@ class AuditEventEmitIntegrationTest {
         String email = "actor-" + UUID.randomUUID().toString().substring(0, 8) + "@example.test";
         User admin = userRepository.save(new User(
             null, system.id(), email, passwordEncoder.encode("pw"),
-            true, false, false, LocalDateTime.now()));
+            true, false, false, true, LocalDateTime.now()));
         return admin.id();
     }
 

--- a/src/test/java/com/stucray/limen/auth/CrossTenantLoginIsolationIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/auth/CrossTenantLoginIsolationIntegrationTest.java
@@ -55,12 +55,12 @@ class CrossTenantLoginIsolationIntegrationTest {
         userRepository.save(new User(
             null, alpha.id(), "alice@example.test",
             passwordEncoder.encode("alpha-pwd"),
-            true, false, false, LocalDateTime.now()
+            true, false, false, true, LocalDateTime.now()
         ));
         userRepository.save(new User(
             null, beta.id(), "alice@example.test",
             passwordEncoder.encode("beta-pwd"),
-            true, false, false, LocalDateTime.now()
+            true, false, false, true, LocalDateTime.now()
         ));
     }
 

--- a/src/test/java/com/stucray/limen/auth/TenantPersistentTokenBasedRememberMeServicesIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/auth/TenantPersistentTokenBasedRememberMeServicesIntegrationTest.java
@@ -62,9 +62,9 @@ class TenantPersistentTokenBasedRememberMeServicesIntegrationTest {
         beta = tenantRepository.save(new Tenant(null, "beta-rm", "Beta", TenantStatus.ACTIVE, LocalDateTime.now()));
 
         userRepository.save(new User(null, alpha.id(), "alice@example.test",
-            passwordEncoder.encode("alpha-pwd"), true, false, false, LocalDateTime.now()));
+            passwordEncoder.encode("alpha-pwd"), true, false, false, true, LocalDateTime.now()));
         userRepository.save(new User(null, beta.id(), "alice@example.test",
-            passwordEncoder.encode("beta-pwd"), true, false, false, LocalDateTime.now()));
+            passwordEncoder.encode("beta-pwd"), true, false, false, true, LocalDateTime.now()));
     }
 
     @Test

--- a/src/test/java/com/stucray/limen/auth/TenantPersistentTokenBasedRememberMeServicesUnitTest.java
+++ b/src/test/java/com/stucray/limen/auth/TenantPersistentTokenBasedRememberMeServicesUnitTest.java
@@ -58,7 +58,7 @@ class TenantPersistentTokenBasedRememberMeServicesUnitTest {
         services.setTokenValiditySeconds(3600);
 
         alpha = new Tenant(1L, "alpha", "Alpha", TenantStatus.ACTIVE, LocalDateTime.now());
-        alice = new User(10L, 1L, "alice@example.test", "hash", true, false, false, LocalDateTime.now());
+        alice = new User(10L, 1L, "alice@example.test", "hash", true, false, false, true, LocalDateTime.now());
     }
 
     @Test

--- a/src/test/java/com/stucray/limen/auth/TenantUserDetailsServiceUnitTest.java
+++ b/src/test/java/com/stucray/limen/auth/TenantUserDetailsServiceUnitTest.java
@@ -37,7 +37,7 @@ class TenantUserDetailsServiceUnitTest {
     void setUp() {
         service = new TenantUserDetailsService(tenantRepository, userRepository);
         alpha = new Tenant(1L, "alpha", "Alpha", TenantStatus.ACTIVE, LocalDateTime.now());
-        alice = new User(10L, 1L, "alice@example.test", "hash", true, false, false, LocalDateTime.now());
+        alice = new User(10L, 1L, "alice@example.test", "hash", true, false, false, true, LocalDateTime.now());
     }
 
     @Test

--- a/src/test/java/com/stucray/limen/auth/login/PostLoginIntentsUnitTest.java
+++ b/src/test/java/com/stucray/limen/auth/login/PostLoginIntentsUnitTest.java
@@ -53,7 +53,7 @@ class PostLoginIntentsUnitTest {
     @BeforeEach
     void setUp() {
         alpha = new Tenant(1L, "alpha", "Alpha", TenantStatus.ACTIVE, LocalDateTime.now());
-        aliceFresh = new User(10L, 1L, "alice", "hash", true, false, false, LocalDateTime.now());
+        aliceFresh = new User(10L, 1L, "alice", "hash", true, false, false, true, LocalDateTime.now());
         aliceMustChange = aliceFresh.withMustChangePassword(true);
         freshPrincipal = new TenantUserDetails(aliceFresh, alpha);
         mustChangePrincipal = new TenantUserDetails(aliceMustChange, alpha);

--- a/src/test/java/com/stucray/limen/auth/login/SyntheticSchemeIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/auth/login/SyntheticSchemeIntegrationTest.java
@@ -72,7 +72,7 @@ class SyntheticSchemeIntegrationTest {
         userRepository.save(new User(
             null, alpha.id(), "owner@example.test",
             passwordEncoder.encode("alpha-pwd"),
-            true, false, false, LocalDateTime.now()));
+            true, false, false, true, LocalDateTime.now()));
     }
 
     @Test

--- a/src/test/java/com/stucray/limen/auth/ott/EmailVerificationFlowIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/auth/ott/EmailVerificationFlowIntegrationTest.java
@@ -1,0 +1,309 @@
+package com.stucray.limen.auth.ott;
+
+import com.stucray.limen.TestcontainersConfiguration;
+import com.stucray.limen.management.applications.Application;
+import com.stucray.limen.management.applications.ApplicationRepository;
+import com.stucray.limen.management.clients.TenantClient;
+import com.stucray.limen.management.clients.TenantClientRepository;
+import com.stucray.limen.management.memberships.ApplicationMembershipService;
+import com.stucray.limen.management.memberships.ClientMembershipService;
+import com.stucray.limen.management.memberships.ClientMembershipTestFixture;
+import com.stucray.limen.management.signup.SignupForm;
+import com.stucray.limen.management.signup.SignupService;
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantProvisioningService;
+import com.stucray.limen.tenant.TenantScope;
+import com.stucray.limen.user.User;
+import com.stucray.limen.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.oidc.OidcScopes;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * End-to-end coverage of the email-verification flow at the HTTP layer:
+ *
+ * <ul>
+ *   <li>An unverified user attempting {@code /oauth2/authorize} is bounced to
+ *       check-inbox by the {@code emailVerificationRequired()} post-login intent
+ *       — even after a successful password login. The saved authorize request
+ *       is held in the session, so the same user clicking the magic link
+ *       afterwards completes the authorization without re-entering credentials.</li>
+ *   <li>Clicking the magic link (POST /t/&#123;slug&#125;/login/ott with token)
+ *       flips {@code email_verified=true} and lands the user on tenant home.</li>
+ *   <li>Audit rows appear for every event published in the verification flow.</li>
+ * </ul>
+ */
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@DisplayName("Email verification: unverified users blocked from /oauth2/authorize; magic-link consume flips the bit and audit rows land")
+class EmailVerificationFlowIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired SignupService signupService;
+    @Autowired TenantProvisioningService tenantProvisioningService;
+    @Autowired ApplicationRepository applicationRepository;
+    @Autowired ApplicationMembershipService applicationMembershipService;
+    @Autowired ClientMembershipService clientMembershipService;
+    @Autowired RegisteredClientRepository registeredClientRepository;
+    @Autowired TenantClientRepository tenantClientRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired PasswordEncoder passwordEncoder;
+    @Autowired TenantAwareOneTimeTokenService tokenService;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanAudit() {
+        // Tests look at "the latest" event by tenant; clearing keeps assertions
+        // unambiguous when prior tests also wrote rows.
+        jdbcTemplate.execute("DELETE FROM audit_event WHERE event_type IN "
+            + "('verification_ott_issued', 'email_verified', 'verification_resent')");
+    }
+
+    @Nested
+    @DisplayName("Unverified user attempting /oauth2/authorize")
+    class UnverifiedAuthorize {
+
+        @Test
+        @DisplayName("Successful password login redirects to /t/{slug}/check-inbox instead of completing the authorize flow")
+        void unverifiedUserBouncedFromAuthorize() throws Exception {
+            String suffix = uniqueSuffix();
+            String slug = "verify-" + suffix;
+            String email = "owner-" + suffix + "@example.test";
+            Tenant tenant = tenantProvisioningService.createTenant(slug, "Verify " + suffix);
+            // Insert an unverified user directly so the integration test does not
+            // depend on the precise mail behaviour of SignupService.
+            User user = userRepository.save(new User(
+                null, tenant.id(), email,
+                passwordEncoder.encode("password"),
+                true, false, true, false, LocalDateTime.now()));
+            TenantClient client = createPkceClient(tenant, "unverified-authz");
+            ClientMembershipTestFixture.grant(
+                applicationMembershipService, clientMembershipService,
+                client.applicationId(), tenant.id(), user.id(), user.id(),
+                client.registeredClientId(), Set.of()
+            );
+
+            MockHttpSession session = new MockHttpSession();
+            String authzUri = authorizeUri(slug, client);
+            mockMvc.perform(get(authzUri).session(session))
+                .andExpect(status().is3xxRedirection());
+
+            MvcResult loginResult = mockMvc.perform(post("/t/" + slug + "/login")
+                    .param("email", email).param("password", "password")
+                    .session(session).with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andReturn();
+
+            String location = loginResult.getResponse().getHeader("Location");
+            assertThat(location).endsWith("/t/" + slug + "/check-inbox");
+            assertThat(location).doesNotContain("/oauth2/authorize");
+        }
+
+        @Test
+        @DisplayName("After OTT consume the same session resumes the saved authorize request — the magic link both verifies the user and unblocks the original flow")
+        void postOttConsumeResumesAuthorize() throws Exception {
+            String suffix = uniqueSuffix();
+            String slug = "verify-" + suffix;
+            String email = "owner-" + suffix + "@example.test";
+            Tenant tenant = tenantProvisioningService.createTenant(slug, "Verify " + suffix);
+            User user = userRepository.save(new User(
+                null, tenant.id(), email,
+                passwordEncoder.encode("password"),
+                true, false, true, false, LocalDateTime.now()));
+            TenantClient client = createPkceClient(tenant, "ott-resumes-authz");
+            ClientMembershipTestFixture.grant(
+                applicationMembershipService, clientMembershipService,
+                client.applicationId(), tenant.id(), user.id(), user.id(),
+                client.registeredClientId(), Set.of()
+            );
+
+            // Issue the OTT directly under the tenant scope (mirrors what
+            // EmailVerificationService.issueVerification does after signup).
+            TenantOneTimeToken issued = TenantScope.call(tenant.slug(), tenant.id(), () ->
+                tokenService.generateForIntent(email, OttIntent.VERIFY_EMAIL));
+
+            MockHttpSession session = new MockHttpSession();
+            String authzUri = authorizeUri(slug, client);
+            mockMvc.perform(get(authzUri).session(session))
+                .andExpect(status().is3xxRedirection());
+
+            // POST the OTT — Spring's filter runs consume + auth + success-handler.
+            MvcResult ottResult = mockMvc.perform(post("/t/" + slug + "/login/ott")
+                    .param("token", issued.tokenValue())
+                    .session(session).with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andReturn();
+            String afterOtt = ottResult.getResponse().getHeader("Location");
+            // The PostLoginIntent chain runs emailVerificationRequired() first
+            // (now passes — flag was just flipped), then resumeOAuth2Authorize()
+            // (saved request is the /oauth2/authorize call).
+            assertThat(afterOtt).contains("/t/" + slug + "/oauth2/authorize");
+
+            Boolean verified = jdbcTemplate.queryForObject(
+                "SELECT email_verified FROM users WHERE id = ?",
+                Boolean.class, user.id());
+            assertThat(verified).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("Audit rows for verification events")
+    class AuditRows {
+
+        @Test
+        @DisplayName("Signup publishes VerificationOttIssuedEvent → verification_ott_issued row with email in details")
+        void signupEmitsVerificationOttIssuedAuditRow() {
+            String suffix = uniqueSuffix();
+            String slug = "audit-" + suffix;
+            String email = "owner-" + suffix + "@example.test";
+
+            SignupService.SignupResult result =
+                signupService.signup(new SignupForm("Audit " + suffix, slug, email, "password"));
+
+            assertThat(result).isInstanceOf(SignupService.SignupResult.Success.class);
+            Map<String, Object> row = jdbcTemplate.queryForMap(
+                "SELECT event_type, target_type, details::text AS details FROM audit_event "
+                    + "WHERE event_type = 'verification_ott_issued' "
+                    + "AND tenant_id = (SELECT id FROM tenants WHERE slug = ?) "
+                    + "ORDER BY occurred_at DESC LIMIT 1",
+                slug);
+            assertThat(row.get("target_type")).isEqualTo("user");
+            assertThat(row.get("details").toString()).contains(email);
+        }
+
+        @Test
+        @DisplayName("Magic-link consume publishes EmailVerifiedEvent → email_verified row with email in details")
+        void ottConsumeEmitsEmailVerifiedAuditRow() throws Exception {
+            String suffix = uniqueSuffix();
+            String slug = "audit2-" + suffix;
+            String email = "owner-" + suffix + "@example.test";
+            Tenant tenant = tenantProvisioningService.createTenant(slug, "Audit2 " + suffix);
+            User user = userRepository.save(new User(
+                null, tenant.id(), email,
+                passwordEncoder.encode("password"),
+                true, false, true, false, LocalDateTime.now()));
+
+            TenantOneTimeToken issued = TenantScope.call(tenant.slug(), tenant.id(), () ->
+                tokenService.generateForIntent(email, OttIntent.VERIFY_EMAIL));
+            mockMvc.perform(post("/t/" + slug + "/login/ott")
+                    .param("token", issued.tokenValue())
+                    .with(csrf()))
+                .andExpect(status().is3xxRedirection());
+
+            Map<String, Object> row = jdbcTemplate.queryForMap(
+                "SELECT actor_user_id, target_id, details::text AS details FROM audit_event "
+                    + "WHERE event_type = 'email_verified' AND tenant_id = ? "
+                    + "ORDER BY occurred_at DESC LIMIT 1",
+                tenant.id());
+            assertThat(row.get("actor_user_id")).isEqualTo(user.id());
+            assertThat(row.get("target_id")).isEqualTo(String.valueOf(user.id()));
+            assertThat(row.get("details").toString()).contains(email);
+        }
+
+        @Test
+        @DisplayName("Resend for an unknown email publishes VerificationResentEvent → row with delivered=false and null user")
+        void resendUnknownEmailEmitsAuditRowWithDeliveredFalse() throws Exception {
+            String suffix = uniqueSuffix();
+            String slug = "audit3-" + suffix;
+            Tenant tenant = tenantProvisioningService.createTenant(slug, "Audit3 " + suffix);
+
+            mockMvc.perform(post("/t/" + slug + "/resend-verification")
+                    .param("email", "ghost-" + suffix + "@example.test")
+                    .with(csrf()))
+                .andExpect(status().is3xxRedirection());
+
+            Map<String, Object> row = jdbcTemplate.queryForMap(
+                "SELECT actor_user_id, target_id, details::text AS details FROM audit_event "
+                    + "WHERE event_type = 'verification_resent' AND tenant_id = ? "
+                    + "ORDER BY occurred_at DESC LIMIT 1",
+                tenant.id());
+            assertThat(row.get("actor_user_id")).isNull();
+            assertThat(row.get("target_id")).isNull();
+            assertThat(row.get("details").toString().replace(" ", ""))
+                .contains("\"delivered\":false");
+        }
+    }
+
+    // --- helpers ---
+
+    private static String uniqueSuffix() {
+        return UUID.randomUUID().toString().substring(0, 8);
+    }
+
+    private TenantClient createPkceClient(Tenant tenant, String name) {
+        Application app = applicationRepository.save(new Application(
+            null, tenant.id(), name + "-app", null, LocalDateTime.now()));
+        String internalId = UUID.randomUUID().toString();
+        String oauthClientId = UUID.randomUUID().toString();
+        RegisteredClient rc = RegisteredClient.withId(internalId)
+            .clientId(oauthClientId)
+            .clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .redirectUri("http://localhost/callback")
+            .scope(OidcScopes.OPENID)
+            .clientSettings(ClientSettings.builder()
+                .requireProofKey(true)
+                .requireAuthorizationConsent(false)
+                .build())
+            .build();
+        registeredClientRepository.save(rc);
+        return tenantClientRepository.save(new TenantClient(
+            null, internalId, app.id(), tenant.id(), name, false));
+    }
+
+    private String authorizeUri(String slug, TenantClient client) throws Exception {
+        String oauthClientId = jdbcTemplate.queryForObject(
+            "SELECT client_id FROM oauth2_registered_client WHERE id = ?",
+            String.class, client.registeredClientId());
+        return UriComponentsBuilder.fromPath("/t/" + slug + "/oauth2/authorize")
+            .queryParam("response_type", "code")
+            .queryParam("client_id", oauthClientId)
+            .queryParam("redirect_uri", "http://localhost/callback")
+            .queryParam("scope", OidcScopes.OPENID)
+            .queryParam("state", "s1")
+            .queryParam("code_challenge", pkceChallenge())
+            .queryParam("code_challenge_method", "S256")
+            .build().toUriString();
+    }
+
+    private static String pkceChallenge() throws Exception {
+        byte[] verifierBytes = new byte[32];
+        new SecureRandom().nextBytes(verifierBytes);
+        String verifier = Base64.getUrlEncoder().withoutPadding().encodeToString(verifierBytes);
+        byte[] hash = MessageDigest.getInstance("SHA-256").digest(verifier.getBytes(StandardCharsets.US_ASCII));
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+    }
+}

--- a/src/test/java/com/stucray/limen/auth/ott/TenantAwareOneTimeTokenServiceIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/auth/ott/TenantAwareOneTimeTokenServiceIntegrationTest.java
@@ -1,0 +1,154 @@
+package com.stucray.limen.auth.ott;
+
+import com.stucray.limen.TestcontainersConfiguration;
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.tenant.TenantScope;
+import com.stucray.limen.tenant.TenantStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.authentication.ott.OneTimeToken;
+import org.springframework.security.authentication.ott.OneTimeTokenAuthenticationToken;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@Import(TestcontainersConfiguration.class)
+@DisplayName("TenantAwareOneTimeTokenService: TenantScope-required generate/consume with cross-tenant isolation")
+class TenantAwareOneTimeTokenServiceIntegrationTest {
+
+    @Autowired TenantAwareOneTimeTokenService tokenService;
+    @Autowired TenantRepository tenantRepository;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    Tenant alpha;
+    Tenant beta;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.execute("DELETE FROM one_time_tokens");
+        jdbcTemplate.execute("DELETE FROM tenants WHERE slug IN ('ott-alpha', 'ott-beta')");
+        alpha = tenantRepository.save(new Tenant(
+            null, "ott-alpha", "OTT Alpha", TenantStatus.ACTIVE, LocalDateTime.now()));
+        beta = tenantRepository.save(new Tenant(
+            null, "ott-beta", "OTT Beta", TenantStatus.ACTIVE, LocalDateTime.now()));
+    }
+
+    @Test
+    @DisplayName("generateForIntent() outside TenantScope throws IllegalStateException")
+    void generateWithoutTenantScopeThrows() {
+        assertThatThrownBy(() ->
+            tokenService.generateForIntent("alice@example.test", OttIntent.VERIFY_EMAIL))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("TenantScope");
+    }
+
+    @Test
+    @DisplayName("consume() outside TenantScope throws IllegalStateException")
+    void consumeWithoutTenantScopeThrows() {
+        assertThatThrownBy(() -> tokenService.consume(
+            new OneTimeTokenAuthenticationToken("any")))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("TenantScope");
+    }
+
+    @Test
+    @DisplayName("generateForIntent() persists tenant_id and intent on the row")
+    void generatePersistsTenantIdAndIntent() {
+        TenantOneTimeToken issued = TenantScope.call(alpha.slug(), alpha.id(), () ->
+            tokenService.generateForIntent("alice@example.test", OttIntent.VERIFY_EMAIL));
+
+        var row = jdbcTemplate.queryForMap(
+            "SELECT tenant_id, intent, username FROM one_time_tokens WHERE token_value = ?",
+            issued.tokenValue());
+        assertThat(row.get("tenant_id")).isEqualTo(alpha.id());
+        assertThat(row.get("intent")).isEqualTo("verify-email");
+        assertThat(row.get("username")).isEqualTo("alice@example.test");
+    }
+
+    @Test
+    @DisplayName("A token issued under alpha consumes successfully under alpha")
+    void sameTenantConsumeSucceeds() {
+        TenantOneTimeToken issued = TenantScope.call(alpha.slug(), alpha.id(), () ->
+            tokenService.generateForIntent("alice@example.test", OttIntent.VERIFY_EMAIL));
+
+        OneTimeToken consumed = TenantScope.call(alpha.slug(), alpha.id(), () ->
+            tokenService.consume(new OneTimeTokenAuthenticationToken(issued.tokenValue())));
+
+        assertThat(consumed).isInstanceOf(TenantOneTimeToken.class);
+        TenantOneTimeToken tot = (TenantOneTimeToken) consumed;
+        assertThat(tot.tenantId()).isEqualTo(alpha.id());
+        assertThat(tot.intent()).isEqualTo(OttIntent.VERIFY_EMAIL);
+        assertThat(tot.username()).isEqualTo("alice@example.test");
+    }
+
+    @Test
+    @DisplayName("A token issued under alpha cannot be consumed under beta — and is deleted in the attempt (single-use)")
+    void crossTenantConsumeReturnsNullAndDeletes() {
+        TenantOneTimeToken issued = TenantScope.call(alpha.slug(), alpha.id(), () ->
+            tokenService.generateForIntent("alice@example.test", OttIntent.VERIFY_EMAIL));
+
+        OneTimeToken result = TenantScope.call(beta.slug(), beta.id(), () ->
+            tokenService.consume(new OneTimeTokenAuthenticationToken(issued.tokenValue())));
+
+        assertThat(result).isNull();
+        Integer remaining = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM one_time_tokens WHERE token_value = ?",
+            Integer.class, issued.tokenValue());
+        assertThat(remaining).isZero();
+    }
+
+    @Test
+    @DisplayName("Second consume of the same token returns null — single-use enforced storage-side")
+    void secondConsumeReturnsNull() {
+        TenantOneTimeToken issued = TenantScope.call(alpha.slug(), alpha.id(), () ->
+            tokenService.generateForIntent("alice@example.test", OttIntent.VERIFY_EMAIL));
+
+        OneTimeToken first = TenantScope.call(alpha.slug(), alpha.id(), () ->
+            tokenService.consume(new OneTimeTokenAuthenticationToken(issued.tokenValue())));
+        OneTimeToken second = TenantScope.call(alpha.slug(), alpha.id(), () ->
+            tokenService.consume(new OneTimeTokenAuthenticationToken(issued.tokenValue())));
+
+        assertThat(first).isNotNull();
+        assertThat(second).isNull();
+    }
+
+    @Test
+    @DisplayName("A token whose expires_at is in the past returns null on consume — even under the right tenant")
+    void expiredTokenReturnsNull() {
+        // Use a fixed-clock service so we can issue at T0 and consume at T0+10min,
+        // past the 60-minute default. Wire it directly rather than touching the
+        // bean wiring of the SUT — the real bean is unaffected.
+        var pastClock = Clock.fixed(Instant.parse("2020-01-01T00:00:00Z"), ZoneOffset.UTC);
+        var futureClock = Clock.fixed(Instant.parse("2020-01-01T02:00:00Z"), ZoneOffset.UTC);
+        var pastService = new TenantAwareOneTimeTokenService(jdbcTemplate, pastClock);
+        var futureService = new TenantAwareOneTimeTokenService(jdbcTemplate, futureClock);
+
+        TenantOneTimeToken issued = TenantScope.call(alpha.slug(), alpha.id(), () ->
+            pastService.generateForIntent("alice@example.test", OttIntent.VERIFY_EMAIL));
+        OneTimeToken result = TenantScope.call(alpha.slug(), alpha.id(), () ->
+            futureService.consume(new OneTimeTokenAuthenticationToken(issued.tokenValue())));
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("consume() with a never-issued token value returns null (no row, no leak)")
+    void unknownTokenReturnsNull() {
+        OneTimeToken result = TenantScope.call(alpha.slug(), alpha.id(), () ->
+            tokenService.consume(new OneTimeTokenAuthenticationToken(UUID.randomUUID().toString())));
+        assertThat(result).isNull();
+    }
+}

--- a/src/test/java/com/stucray/limen/enduser/EndUserHomeIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/enduser/EndUserHomeIntegrationTest.java
@@ -60,7 +60,7 @@ class EndUserHomeIntegrationTest {
         userRepository.save(new User(
             null, testTenant.id(), "alice@example.test",
             passwordEncoder.encode("password"),
-            true, false, false, LocalDateTime.now()
+            true, false, false, true, LocalDateTime.now()
         ));
     }
 

--- a/src/test/java/com/stucray/limen/identity/UserBootstrapTest.java
+++ b/src/test/java/com/stucray/limen/identity/UserBootstrapTest.java
@@ -83,7 +83,7 @@ class UserBootstrapTest {
     @Test
     @DisplayName("Re-hashes and saves the admin password when the admin user already exists")
     void updatesPasswordHashWhenAdminUserExists() throws Exception {
-        var existing = new User(10L, 1L, "admin@example.test", "oldhash", true, false, false, LocalDateTime.now());
+        var existing = new User(10L, 1L, "admin@example.test", "oldhash", true, false, false, true, LocalDateTime.now());
         given(userRepository.findByEmailAndTenantId("admin@example.test", 1L)).willReturn(Optional.of(existing));
         given(passwordEncoder.encode("newpass")).willReturn("newhash");
 

--- a/src/test/java/com/stucray/limen/management/ManagementForcedPasswordChangeIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/ManagementForcedPasswordChangeIntegrationTest.java
@@ -109,7 +109,7 @@ class ManagementForcedPasswordChangeIntegrationTest {
         userRepository.save(new User(
             null, tenant.id(), "alice@example.test",
             passwordEncoder.encode("temp"),
-            true, true, false, LocalDateTime.now()));
+            true, true, false, true, LocalDateTime.now()));
 
         MvcResult loginResult = mockMvc.perform(post("/manage/t/alpha-corp/login")
                 .param("email", "alice@example.test").param("password", "temp")
@@ -127,7 +127,7 @@ class ManagementForcedPasswordChangeIntegrationTest {
         userRepository.save(new User(
             null, tenant.id(), "owner@example.test",
             passwordEncoder.encode("password"),
-            true, false, false, LocalDateTime.now()));
+            true, false, false, true, LocalDateTime.now()));
 
         MockHttpSession session = startAuthorize(newPkce().challenge());
 
@@ -149,7 +149,7 @@ class ManagementForcedPasswordChangeIntegrationTest {
         User original = userRepository.save(new User(
             null, tenant.id(), "alice@example.test",
             passwordEncoder.encode("temp"),
-            true, true, false, LocalDateTime.now()));
+            true, true, false, true, LocalDateTime.now()));
 
         MockHttpSession session = startAuthorize(newPkce().challenge());
 
@@ -176,7 +176,7 @@ class ManagementForcedPasswordChangeIntegrationTest {
         User original = userRepository.save(new User(
             null, tenant.id(), "alice@example.test",
             passwordEncoder.encode("temp"),
-            true, true, false, LocalDateTime.now()));
+            true, true, false, true, LocalDateTime.now()));
 
         MockHttpSession session = new MockHttpSession();
         mockMvc.perform(post("/manage/t/alpha-corp/login")
@@ -199,7 +199,7 @@ class ManagementForcedPasswordChangeIntegrationTest {
         User original = userRepository.save(new User(
             null, tenant.id(), "alice@example.test",
             passwordEncoder.encode("temp"),
-            true, true, false, LocalDateTime.now()));
+            true, true, false, true, LocalDateTime.now()));
 
         MockHttpSession session = new MockHttpSession();
         mockMvc.perform(post("/manage/t/alpha-corp/login")
@@ -221,7 +221,7 @@ class ManagementForcedPasswordChangeIntegrationTest {
         User original = userRepository.save(new User(
             null, tenant.id(), "alice@example.test",
             passwordEncoder.encode("temp"),
-            true, true, false, LocalDateTime.now()));
+            true, true, false, true, LocalDateTime.now()));
 
         MockHttpSession session = new MockHttpSession();
         mockMvc.perform(post("/manage/t/alpha-corp/login")
@@ -246,7 +246,7 @@ class ManagementForcedPasswordChangeIntegrationTest {
         userRepository.save(new User(
             null, tenant.id(), "alice@example.test",
             passwordEncoder.encode("temp"),
-            true, true, false, LocalDateTime.now()));
+            true, true, false, true, LocalDateTime.now()));
 
         MockHttpSession session = new MockHttpSession();
         mockMvc.perform(post("/manage/t/alpha-corp/login")

--- a/src/test/java/com/stucray/limen/management/ManagementLoginIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/ManagementLoginIntegrationTest.java
@@ -58,7 +58,7 @@ class ManagementLoginIntegrationTest {
         userRepository.save(new User(
             null, testTenant.id(), "owner@example.test",
             passwordEncoder.encode("password"),
-            true, false, false, LocalDateTime.now()
+            true, false, false, true, LocalDateTime.now()
         ));
     }
 
@@ -124,7 +124,7 @@ class ManagementLoginIntegrationTest {
         userRepository.save(new User(
             null, systemTenant.id(), "sysadmin@example.test",
             passwordEncoder.encode("syspassword"),
-            true, false, false, LocalDateTime.now()
+            true, false, false, true, LocalDateTime.now()
         ));
 
         mockMvc.perform(post("/manage/t/system/login")

--- a/src/test/java/com/stucray/limen/management/SignupIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/SignupIntegrationTest.java
@@ -47,7 +47,7 @@ class SignupIntegrationTest {
     }
 
     @Test
-    @DisplayName("Successful POST /signup creates the tenant + owner user and redirects to the tenant login page")
+    @DisplayName("Successful POST /signup creates the tenant + owner user (email_verified=false) and redirects to the tenant check-inbox page")
     void successfulSignupCreatesTenantAndOwner() throws Exception {
         mockMvc.perform(post("/signup")
                 .param("organizationName", "Acme Corp")
@@ -56,13 +56,17 @@ class SignupIntegrationTest {
                 .param("password", "secret123")
                 .with(csrf()))
             .andExpect(status().is3xxRedirection())
-            .andExpect(redirectedUrl("/manage/t/acme-corp/login?registered"));
+            .andExpect(redirectedUrl("/t/acme-corp/check-inbox?email=alice@example.test"));
 
         assertThat(tenantRepository.findBySlug("acme-corp")).isPresent();
         Integer userCount = jdbcTemplate.queryForObject(
             "SELECT COUNT(*) FROM users u JOIN tenants t ON u.tenant_id = t.id WHERE t.slug = 'acme-corp'",
             Integer.class);
         assertThat(userCount).isEqualTo(1);
+        Boolean verified = jdbcTemplate.queryForObject(
+            "SELECT email_verified FROM users WHERE email = 'alice@example.test'",
+            Boolean.class);
+        assertThat(verified).isFalse();
     }
 
     @Test

--- a/src/test/java/com/stucray/limen/management/applications/ApplicationManagementIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/applications/ApplicationManagementIntegrationTest.java
@@ -56,7 +56,7 @@ class ApplicationManagementIntegrationTest {
 
         tenantA = tenantRepository.save(new Tenant(null, "corp-a", "Corp A", TenantStatus.ACTIVE, LocalDateTime.now()));
         tenantB = tenantRepository.save(new Tenant(null, "corp-b", "Corp B", TenantStatus.ACTIVE, LocalDateTime.now()));
-        userRepository.save(new User(null, tenantA.id(), "owner@example.test", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        userRepository.save(new User(null, tenantA.id(), "owner@example.test", passwordEncoder.encode("pass"), true, false, true, true, LocalDateTime.now()));
 
         MvcResult login = mockMvc.perform(post("/manage/t/corp-a/login")
                 .param("email", "owner@example.test").param("password", "pass").with(csrf()))
@@ -167,7 +167,7 @@ class ApplicationManagementIntegrationTest {
     @DisplayName("Tenant A's applications are not visible to a tenant B session — TenantAccessFilter forces logout")
     void tenantAApplicationsNotVisibleToTenantBSession() throws Exception {
         Application appA = applicationRepository.save(new Application(null, tenantA.id(), "App A", null, LocalDateTime.now()));
-        userRepository.save(new User(null, tenantB.id(), "ownerB@example.test", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        userRepository.save(new User(null, tenantB.id(), "ownerB@example.test", passwordEncoder.encode("pass"), true, false, true, true, LocalDateTime.now()));
         MvcResult loginB = mockMvc.perform(post("/manage/t/corp-b/login")
                 .param("email", "ownerB@example.test").param("password", "pass").with(csrf()))
             .andReturn();

--- a/src/test/java/com/stucray/limen/management/clients/ClientManagementIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/clients/ClientManagementIntegrationTest.java
@@ -72,7 +72,7 @@ class ClientManagementIntegrationTest {
         tenantA = tenantRepository.save(new Tenant(null, "corp-a", "Corp A", TenantStatus.ACTIVE, LocalDateTime.now()));
         tenantB = tenantRepository.save(new Tenant(null, "corp-b", "Corp B", TenantStatus.ACTIVE, LocalDateTime.now()));
         appA = applicationRepository.save(new Application(null, tenantA.id(), "App A", null, LocalDateTime.now()));
-        userRepository.save(new User(null, tenantA.id(), "owner@example.test", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        userRepository.save(new User(null, tenantA.id(), "owner@example.test", passwordEncoder.encode("pass"), true, false, true, true, LocalDateTime.now()));
 
         MvcResult login = mockMvc.perform(post("/manage/t/corp-a/login")
                 .param("email", "owner@example.test").param("password", "pass").with(csrf()))
@@ -216,7 +216,7 @@ class ClientManagementIntegrationTest {
     @DisplayName("Tenant A's clients list is not visible to a tenant B session — TenantAccessFilter forces logout")
     void tenantAClientsNotVisibleToTenantBSession() throws Exception {
         createConfidentialClient("Tenant A Client");
-        userRepository.save(new User(null, tenantB.id(), "ownerB@example.test", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        userRepository.save(new User(null, tenantB.id(), "ownerB@example.test", passwordEncoder.encode("pass"), true, false, true, true, LocalDateTime.now()));
         MvcResult loginB = mockMvc.perform(post("/manage/t/corp-b/login")
                 .param("email", "ownerB@example.test").param("password", "pass").with(csrf()))
             .andReturn();

--- a/src/test/java/com/stucray/limen/management/clients/ClientTokenSettingsIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/clients/ClientTokenSettingsIntegrationTest.java
@@ -85,7 +85,7 @@ class ClientTokenSettingsIntegrationTest {
 
         tenant = tenantProvisioningService.createTenant("token-test", "Token Test");
         app = applicationRepository.save(new Application(null, tenant.id(), "Test App", null, LocalDateTime.now()));
-        alice = userRepository.save(new User(null, tenant.id(), "alice@example.test", passwordEncoder.encode("password"), true, false, false, LocalDateTime.now()));
+        alice = userRepository.save(new User(null, tenant.id(), "alice@example.test", passwordEncoder.encode("password"), true, false, false, true, LocalDateTime.now()));
     }
 
     private void grantMembership(String registeredClientId) {

--- a/src/test/java/com/stucray/limen/management/memberships/ApplicationMembershipServiceIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/memberships/ApplicationMembershipServiceIntegrationTest.java
@@ -64,10 +64,10 @@ class ApplicationMembershipServiceIntegrationTest {
         tenantB = tenantRepository.save(new Tenant(null, "mem-b", "Mem B", TenantStatus.ACTIVE, LocalDateTime.now()));
         appA = applicationRepository.save(new Application(null, tenantA.id(), "App A", null, LocalDateTime.now()));
         appB = applicationRepository.save(new Application(null, tenantB.id(), "App B", null, LocalDateTime.now()));
-        aliceA = userRepository.save(new User(null, tenantA.id(), "alice@example.test", "x", true, false, false, LocalDateTime.now()));
-        bobA = userRepository.save(new User(null, tenantA.id(), "bob@example.test",   "x", true, false, false, LocalDateTime.now()));
-        adminA = userRepository.save(new User(null, tenantA.id(), "admin@example.test", "x", true, false, true,  LocalDateTime.now()));
-        carolB = userRepository.save(new User(null, tenantB.id(), "carol@example.test", "x", true, false, false, LocalDateTime.now()));
+        aliceA = userRepository.save(new User(null, tenantA.id(), "alice@example.test", "x", true, false, false, true, LocalDateTime.now()));
+        bobA = userRepository.save(new User(null, tenantA.id(), "bob@example.test",   "x", true, false, false, true, LocalDateTime.now()));
+        adminA = userRepository.save(new User(null, tenantA.id(), "admin@example.test", "x", true, false, true, true,  LocalDateTime.now()));
+        carolB = userRepository.save(new User(null, tenantB.id(), "carol@example.test", "x", true, false, false, true, LocalDateTime.now()));
     }
 
     @Test

--- a/src/test/java/com/stucray/limen/management/memberships/ClientMembersControllerIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/memberships/ClientMembersControllerIntegrationTest.java
@@ -75,8 +75,8 @@ class ClientMembersControllerIntegrationTest {
 
         tenantA = tenantRepository.save(new Tenant(null, "client-mem-a", "Client Mem A", TenantStatus.ACTIVE, LocalDateTime.now()));
         tenantB = tenantRepository.save(new Tenant(null, "client-mem-b", "Client Mem B", TenantStatus.ACTIVE, LocalDateTime.now()));
-        ownerA = userRepository.save(new User(null, tenantA.id(), "owner@example.test", passwordEncoder.encode("pass"), true, false, true,  LocalDateTime.now()));
-        aliceA = userRepository.save(new User(null, tenantA.id(), "alice@example.test", passwordEncoder.encode("pass"), true, false, false, LocalDateTime.now()));
+        ownerA = userRepository.save(new User(null, tenantA.id(), "owner@example.test", passwordEncoder.encode("pass"), true, false, true, true,  LocalDateTime.now()));
+        aliceA = userRepository.save(new User(null, tenantA.id(), "alice@example.test", passwordEncoder.encode("pass"), true, false, false, true, LocalDateTime.now()));
         appA = applicationRepository.save(new Application(null, tenantA.id(), "App A", "desc", LocalDateTime.now()));
         clientA = clientManagementService.createClient(
             appA.id(), tenantA.id(), "client-a",
@@ -251,7 +251,7 @@ class ClientMembersControllerIntegrationTest {
     @Test
     @DisplayName("Tenant B session is force-redirected to tenant A's login when reaching tenant A's client members")
     void tenantBSessionCannotReachTenantAClientMembers() throws Exception {
-        userRepository.save(new User(null, tenantB.id(), "ownerB@example.test", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        userRepository.save(new User(null, tenantB.id(), "ownerB@example.test", passwordEncoder.encode("pass"), true, false, true, true, LocalDateTime.now()));
         MvcResult loginB = mockMvc.perform(post("/manage/t/client-mem-b/login")
                 .param("email", "ownerB@example.test").param("password", "pass").with(csrf()))
             .andReturn();

--- a/src/test/java/com/stucray/limen/management/memberships/ClientMembershipQueryIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/memberships/ClientMembershipQueryIntegrationTest.java
@@ -68,10 +68,10 @@ class ClientMembershipQueryIntegrationTest {
         tenantB = tenantRepository.save(new Tenant(null, "cmq-b", "CMQ B", TenantStatus.ACTIVE, LocalDateTime.now()));
         appA = applicationRepository.save(new Application(null, tenantA.id(), "App A", null, LocalDateTime.now()));
         appB = applicationRepository.save(new Application(null, tenantB.id(), "App B", null, LocalDateTime.now()));
-        aliceA = userRepository.save(new User(null, tenantA.id(), "alice", "x", true, false, false, LocalDateTime.now()));
-        adminA = userRepository.save(new User(null, tenantA.id(), "admin", "x", true, false, true,  LocalDateTime.now()));
-        carolB = userRepository.save(new User(null, tenantB.id(), "carol", "x", true, false, false, LocalDateTime.now()));
-        adminB = userRepository.save(new User(null, tenantB.id(), "admin-b", "x", true, false, true, LocalDateTime.now()));
+        aliceA = userRepository.save(new User(null, tenantA.id(), "alice", "x", true, false, false, true, LocalDateTime.now()));
+        adminA = userRepository.save(new User(null, tenantA.id(), "admin", "x", true, false, true, true,  LocalDateTime.now()));
+        carolB = userRepository.save(new User(null, tenantB.id(), "carol", "x", true, false, false, true, LocalDateTime.now()));
+        adminB = userRepository.save(new User(null, tenantB.id(), "admin-b", "x", true, false, true, true, LocalDateTime.now()));
 
         clientA = createClient(appA.id(), tenantA.id(), "client-a");
         clientB = createClient(appB.id(), tenantB.id(), "client-b");

--- a/src/test/java/com/stucray/limen/management/memberships/ClientMembershipServiceIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/memberships/ClientMembershipServiceIntegrationTest.java
@@ -75,10 +75,10 @@ class ClientMembershipServiceIntegrationTest {
         appA  = applicationRepository.save(new Application(null, tenantA.id(), "App A",  null, LocalDateTime.now()));
         appA2 = applicationRepository.save(new Application(null, tenantA.id(), "App A2", null, LocalDateTime.now()));
         appB  = applicationRepository.save(new Application(null, tenantB.id(), "App B",  null, LocalDateTime.now()));
-        aliceA = userRepository.save(new User(null, tenantA.id(), "alice@example.test", "x", true, false, false, LocalDateTime.now()));
-        bobA   = userRepository.save(new User(null, tenantA.id(), "bob@example.test",   "x", true, false, false, LocalDateTime.now()));
-        adminA = userRepository.save(new User(null, tenantA.id(), "admin@example.test", "x", true, false, true,  LocalDateTime.now()));
-        carolB = userRepository.save(new User(null, tenantB.id(), "carol@example.test", "x", true, false, false, LocalDateTime.now()));
+        aliceA = userRepository.save(new User(null, tenantA.id(), "alice@example.test", "x", true, false, false, true, LocalDateTime.now()));
+        bobA   = userRepository.save(new User(null, tenantA.id(), "bob@example.test",   "x", true, false, false, true, LocalDateTime.now()));
+        adminA = userRepository.save(new User(null, tenantA.id(), "admin@example.test", "x", true, false, true, true,  LocalDateTime.now()));
+        carolB = userRepository.save(new User(null, tenantB.id(), "carol@example.test", "x", true, false, false, true, LocalDateTime.now()));
 
         clientA  = createClient(appA.id(),  tenantA.id(), "client-a");
         clientA2 = createClient(appA2.id(), tenantA.id(), "client-a2");

--- a/src/test/java/com/stucray/limen/management/memberships/MembersControllerIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/memberships/MembersControllerIntegrationTest.java
@@ -71,8 +71,8 @@ class MembersControllerIntegrationTest {
 
         tenantA = tenantRepository.save(new Tenant(null, "members-corp-a", "Members Corp A", TenantStatus.ACTIVE, LocalDateTime.now()));
         tenantB = tenantRepository.save(new Tenant(null, "members-corp-b", "Members Corp B", TenantStatus.ACTIVE, LocalDateTime.now()));
-        ownerA = userRepository.save(new User(null, tenantA.id(), "owner@example.test", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
-        aliceA = userRepository.save(new User(null, tenantA.id(), "alice@example.test", passwordEncoder.encode("pass"), true, false, false, LocalDateTime.now()));
+        ownerA = userRepository.save(new User(null, tenantA.id(), "owner@example.test", passwordEncoder.encode("pass"), true, false, true, true, LocalDateTime.now()));
+        aliceA = userRepository.save(new User(null, tenantA.id(), "alice@example.test", passwordEncoder.encode("pass"), true, false, false, true, LocalDateTime.now()));
         appA = applicationRepository.save(new Application(null, tenantA.id(), "App A", "desc", LocalDateTime.now()));
 
         MvcResult login = mockMvc.perform(post("/manage/t/members-corp-a/login")
@@ -219,7 +219,7 @@ class MembersControllerIntegrationTest {
     @Test
     @DisplayName("Tenant B session is force-redirected to tenant A's login when reaching tenant A's members")
     void tenantBSessionCannotReachTenantAMembers() throws Exception {
-        userRepository.save(new User(null, tenantB.id(), "ownerB@example.test", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        userRepository.save(new User(null, tenantB.id(), "ownerB@example.test", passwordEncoder.encode("pass"), true, false, true, true, LocalDateTime.now()));
         MvcResult loginB = mockMvc.perform(post("/manage/t/members-corp-b/login")
                 .param("email", "ownerB@example.test").param("password", "pass").with(csrf()))
             .andReturn();

--- a/src/test/java/com/stucray/limen/management/roles/RolesControllerIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/roles/RolesControllerIntegrationTest.java
@@ -62,7 +62,7 @@ class RolesControllerIntegrationTest {
 
         tenantA = tenantRepository.save(new Tenant(null, "roles-corp-a", "Roles Corp A", TenantStatus.ACTIVE, LocalDateTime.now()));
         tenantB = tenantRepository.save(new Tenant(null, "roles-corp-b", "Roles Corp B", TenantStatus.ACTIVE, LocalDateTime.now()));
-        userRepository.save(new User(null, tenantA.id(), "owner@example.test", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        userRepository.save(new User(null, tenantA.id(), "owner@example.test", passwordEncoder.encode("pass"), true, false, true, true, LocalDateTime.now()));
         appA = applicationRepository.save(new Application(null, tenantA.id(), "App A", "desc", LocalDateTime.now()));
 
         MvcResult login = mockMvc.perform(post("/manage/t/roles-corp-a/login")
@@ -195,7 +195,7 @@ class RolesControllerIntegrationTest {
     @Test
     @DisplayName("Tenant B session is force-redirected to tenant A's login when reaching tenant A's roles")
     void tenantBSessionCannotReachTenantARoles() throws Exception {
-        userRepository.save(new User(null, tenantB.id(), "ownerB@example.test", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        userRepository.save(new User(null, tenantB.id(), "ownerB@example.test", passwordEncoder.encode("pass"), true, false, true, true, LocalDateTime.now()));
         MvcResult loginB = mockMvc.perform(post("/manage/t/roles-corp-b/login")
                 .param("email", "ownerB@example.test").param("password", "pass").with(csrf()))
             .andReturn();

--- a/src/test/java/com/stucray/limen/management/system/SystemAdminCrossTenantIsolationIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/system/SystemAdminCrossTenantIsolationIntegrationTest.java
@@ -59,7 +59,7 @@ class SystemAdminCrossTenantIsolationIntegrationTest {
         userRepository.save(new User(
             null, systemTenant.id(), "sysadmin@example.test",
             passwordEncoder.encode("syspass"),
-            true, false, false, LocalDateTime.now()
+            true, false, false, true, LocalDateTime.now()
         ));
 
         acme = tenantRepository.save(new Tenant(

--- a/src/test/java/com/stucray/limen/management/system/SystemAdminIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/system/SystemAdminIntegrationTest.java
@@ -53,7 +53,7 @@ class SystemAdminIntegrationTest {
         jdbcTemplate.execute("DELETE FROM users WHERE tenant_id = (SELECT id FROM tenants WHERE slug = 'system')");
 
         Tenant systemTenant = tenantRepository.findBySlug("system").orElseThrow();
-        userRepository.save(new User(null, systemTenant.id(), "sysadmin@example.test", passwordEncoder.encode("syspass"), true, false, false, LocalDateTime.now()));
+        userRepository.save(new User(null, systemTenant.id(), "sysadmin@example.test", passwordEncoder.encode("syspass"), true, false, false, true, LocalDateTime.now()));
 
         MvcResult login = mockMvc.perform(post("/manage/t/system/login")
                 .param("email", "sysadmin@example.test").param("password", "syspass").with(csrf()))
@@ -84,7 +84,7 @@ class SystemAdminIntegrationTest {
     @Test
     @DisplayName("Login at a suspended tenant fails (redirects to ?error)")
     void suspendedTenantLoginIsBlocked() throws Exception {
-        userRepository.save(new User(null, customerTenant.id(), "owner@example.test", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        userRepository.save(new User(null, customerTenant.id(), "owner@example.test", passwordEncoder.encode("pass"), true, false, true, true, LocalDateTime.now()));
         tenantRepository.save(customerTenant.withStatus(TenantStatus.SUSPENDED));
 
         mockMvc.perform(post("/manage/t/customer/login")
@@ -141,7 +141,7 @@ class SystemAdminIntegrationTest {
     @DisplayName("A tenant owner can view their tenant settings and update its display name")
     void tenantOwnerCanViewAndUpdateTenantDetails() throws Exception {
         Tenant corp = tenantRepository.save(new Tenant(null, "my-corp", "My Corp", TenantStatus.ACTIVE, LocalDateTime.now()));
-        userRepository.save(new User(null, corp.id(), "owner@example.test", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        userRepository.save(new User(null, corp.id(), "owner@example.test", passwordEncoder.encode("pass"), true, false, true, true, LocalDateTime.now()));
         MvcResult login = mockMvc.perform(post("/manage/t/my-corp/login")
                 .param("email", "owner@example.test").param("password", "pass").with(csrf()))
             .andReturn();

--- a/src/test/java/com/stucray/limen/management/users/UserDetailControllerIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/users/UserDetailControllerIntegrationTest.java
@@ -82,8 +82,8 @@ class UserDetailControllerIntegrationTest {
 
         tenantA = tenantRepository.save(new Tenant(null, "user-detail-a", "User Detail A", TenantStatus.ACTIVE, LocalDateTime.now()));
         tenantB = tenantRepository.save(new Tenant(null, "user-detail-b", "User Detail B", TenantStatus.ACTIVE, LocalDateTime.now()));
-        ownerA = userRepository.save(new User(null, tenantA.id(), "owner@example.test", passwordEncoder.encode("pass"), true, false, true,  LocalDateTime.now()));
-        aliceA = userRepository.save(new User(null, tenantA.id(), "alice@example.test", passwordEncoder.encode("pass"), true, false, false, LocalDateTime.now()));
+        ownerA = userRepository.save(new User(null, tenantA.id(), "owner@example.test", passwordEncoder.encode("pass"), true, false, true, true,  LocalDateTime.now()));
+        aliceA = userRepository.save(new User(null, tenantA.id(), "alice@example.test", passwordEncoder.encode("pass"), true, false, false, true, LocalDateTime.now()));
         appA = applicationRepository.save(new Application(null, tenantA.id(), "Acme Web", "desc", LocalDateTime.now()));
         clientA = clientManagementService.createClient(
             appA.id(), tenantA.id(), "acme-spa",
@@ -162,7 +162,7 @@ class UserDetailControllerIntegrationTest {
     @Test
     @DisplayName("A session for tenant B cannot view a user-detail page in tenant A — redirects to tenant A's login")
     void crossTenantSessionCannotReachUserDetail() throws Exception {
-        userRepository.save(new User(null, tenantB.id(), "ownerB@example.test", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        userRepository.save(new User(null, tenantB.id(), "ownerB@example.test", passwordEncoder.encode("pass"), true, false, true, true, LocalDateTime.now()));
         MvcResult loginB = mockMvc.perform(post("/manage/t/user-detail-b/login")
                 .param("email", "ownerB@example.test").param("password", "pass").with(csrf()))
             .andReturn();
@@ -187,7 +187,7 @@ class UserDetailControllerIntegrationTest {
     @DisplayName("Empty-state still shows when other users in the same tenant have memberships but the target user does not")
     void detailPageRendersWhenMembershipsExistInOtherAppsButNotForThisUser() throws Exception {
         // Other user has memberships, target user does not — empty state still shows.
-        User bob = userRepository.save(new User(null, tenantA.id(), "bob@example.test", passwordEncoder.encode("pass"), true, false, false, LocalDateTime.now()));
+        User bob = userRepository.save(new User(null, tenantA.id(), "bob@example.test", passwordEncoder.encode("pass"), true, false, false, true, LocalDateTime.now()));
         appMembershipRepository.save(new ApplicationMembership(
             null, bob.id(), appA.id(), LocalDateTime.now(), ownerA.id(), Set.of()
         ));

--- a/src/test/java/com/stucray/limen/management/users/UserManagementIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/users/UserManagementIntegrationTest.java
@@ -48,7 +48,7 @@ class UserManagementIntegrationTest {
         jdbcTemplate.execute("DELETE FROM tenants WHERE slug != 'system'");
 
         tenant = tenantRepository.save(new Tenant(null, "corp", "Corp", TenantStatus.ACTIVE, LocalDateTime.now()));
-        userRepository.save(new User(null, tenant.id(), "owner@example.test", passwordEncoder.encode("pass"), true, false, true, LocalDateTime.now()));
+        userRepository.save(new User(null, tenant.id(), "owner@example.test", passwordEncoder.encode("pass"), true, false, true, true, LocalDateTime.now()));
 
         MvcResult login = mockMvc.perform(post("/manage/t/corp/login")
                 .param("email", "owner@example.test").param("password", "pass").with(csrf()))
@@ -78,7 +78,7 @@ class UserManagementIntegrationTest {
     @Test
     @DisplayName("Tenant owner can disable a user and re-enable them, flipping the enabled flag in both directions")
     void ownerCanDisableAndEnableUser() throws Exception {
-        User alice = userRepository.save(new User(null, tenant.id(), "alice@example.test", passwordEncoder.encode("pass"), true, false, false, LocalDateTime.now()));
+        User alice = userRepository.save(new User(null, tenant.id(), "alice@example.test", passwordEncoder.encode("pass"), true, false, false, true, LocalDateTime.now()));
 
         mockMvc.perform(post("/manage/t/corp/users/" + alice.id() + "/disable").session(ownerSession).with(csrf()))
             .andExpect(status().is3xxRedirection());
@@ -92,7 +92,7 @@ class UserManagementIntegrationTest {
     @Test
     @DisplayName("Tenant owner can delete a user — the row is removed from the users table")
     void ownerCanDeleteUser() throws Exception {
-        User alice = userRepository.save(new User(null, tenant.id(), "alice@example.test", passwordEncoder.encode("pass"), true, false, false, LocalDateTime.now()));
+        User alice = userRepository.save(new User(null, tenant.id(), "alice@example.test", passwordEncoder.encode("pass"), true, false, false, true, LocalDateTime.now()));
 
         mockMvc.perform(post("/manage/t/corp/users/" + alice.id() + "/delete").session(ownerSession).with(csrf()))
             .andExpect(status().is3xxRedirection());
@@ -102,7 +102,7 @@ class UserManagementIntegrationTest {
     @Test
     @DisplayName("Reset-password sets a temporary password and flips mustChangePassword=true so the user must change it on next login")
     void ownerCanResetPassword() throws Exception {
-        User alice = userRepository.save(new User(null, tenant.id(), "alice@example.test", passwordEncoder.encode("oldpass"), true, false, false, LocalDateTime.now()));
+        User alice = userRepository.save(new User(null, tenant.id(), "alice@example.test", passwordEncoder.encode("oldpass"), true, false, false, true, LocalDateTime.now()));
 
         mockMvc.perform(post("/manage/t/corp/users/" + alice.id() + "/reset-password").session(ownerSession).with(csrf())
                 .param("temporaryPassword", "newpass123"))
@@ -115,7 +115,7 @@ class UserManagementIntegrationTest {
     @Test
     @DisplayName("Tenant owner can grant the tenant-owner role to another user and revoke it again")
     void ownerCanGrantAndRevokeTenantOwnerRole() throws Exception {
-        User alice = userRepository.save(new User(null, tenant.id(), "alice@example.test", passwordEncoder.encode("pass"), true, false, false, LocalDateTime.now()));
+        User alice = userRepository.save(new User(null, tenant.id(), "alice@example.test", passwordEncoder.encode("pass"), true, false, false, true, LocalDateTime.now()));
 
         mockMvc.perform(post("/manage/t/corp/users/" + alice.id() + "/grant-owner").session(ownerSession).with(csrf()))
             .andExpect(status().is3xxRedirection());
@@ -129,7 +129,7 @@ class UserManagementIntegrationTest {
     @Test
     @DisplayName("A user with mustChangePassword=true is redirected to the change-password page on every authenticated request")
     void userWithMustChangePasswordIsInterceptedToChangePasswordPage() throws Exception {
-        userRepository.save(new User(null, tenant.id(), "newuser@example.test", passwordEncoder.encode("temp"), true, true, false, LocalDateTime.now()));
+        userRepository.save(new User(null, tenant.id(), "newuser@example.test", passwordEncoder.encode("temp"), true, true, false, true, LocalDateTime.now()));
 
         MvcResult login = mockMvc.perform(post("/manage/t/corp/login")
                 .param("email", "newuser@example.test").param("password", "temp").with(csrf()))
@@ -144,7 +144,7 @@ class UserManagementIntegrationTest {
     @Test
     @DisplayName("After successfully changing the password, mustChangePassword is cleared so the user can use the app normally")
     void mustChangePasswordClearedAfterChange() throws Exception {
-        User newUser = userRepository.save(new User(null, tenant.id(), "newuser@example.test", passwordEncoder.encode("temp"), true, true, false, LocalDateTime.now()));
+        User newUser = userRepository.save(new User(null, tenant.id(), "newuser@example.test", passwordEncoder.encode("temp"), true, true, false, true, LocalDateTime.now()));
 
         MvcResult login = mockMvc.perform(post("/manage/t/corp/login")
                 .param("email", "newuser@example.test").param("password", "temp").with(csrf()))
@@ -161,7 +161,7 @@ class UserManagementIntegrationTest {
     @Test
     @DisplayName("Mismatched new/confirm passwords re-render the form with an error and leave mustChangePassword=true")
     void changePasswordRedisplaysFormWhenNewAndConfirmDoNotMatch() throws Exception {
-        User newUser = userRepository.save(new User(null, tenant.id(), "newuser@example.test", passwordEncoder.encode("temp"), true, true, false, LocalDateTime.now()));
+        User newUser = userRepository.save(new User(null, tenant.id(), "newuser@example.test", passwordEncoder.encode("temp"), true, true, false, true, LocalDateTime.now()));
 
         MvcResult login = mockMvc.perform(post("/manage/t/corp/login")
                 .param("email", "newuser@example.test").param("password", "temp").with(csrf()))
@@ -180,7 +180,7 @@ class UserManagementIntegrationTest {
     @Test
     @DisplayName("Blank/whitespace new password re-renders the form with 'Password is required' and leaves mustChangePassword=true")
     void changePasswordRedisplaysFormWhenNewPasswordIsBlank() throws Exception {
-        User newUser = userRepository.save(new User(null, tenant.id(), "newuser@example.test", passwordEncoder.encode("temp"), true, true, false, LocalDateTime.now()));
+        User newUser = userRepository.save(new User(null, tenant.id(), "newuser@example.test", passwordEncoder.encode("temp"), true, true, false, true, LocalDateTime.now()));
 
         MvcResult login = mockMvc.perform(post("/manage/t/corp/login")
                 .param("email", "newuser@example.test").param("password", "temp").with(csrf()))

--- a/src/test/java/com/stucray/limen/oauth2/MembershipGateFilterUnitTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/MembershipGateFilterUnitTest.java
@@ -58,7 +58,7 @@ class MembershipGateFilterUnitTest {
     void setUp() {
         filter = new MembershipGateFilter(registeredClientRepository, clientMembershipQuery);
         alpha = new Tenant(1L, "alpha", "Alpha", TenantStatus.ACTIVE, LocalDateTime.now());
-        alice = new User(10L, 1L, "alice", "hash", true, false, false, LocalDateTime.now());
+        alice = new User(10L, 1L, "alice", "hash", true, false, false, true, LocalDateTime.now());
         principal = new TenantUserDetails(alice, alpha);
         SecurityContextHolder.getContext().setAuthentication(
             UsernamePasswordAuthenticationToken.authenticated(principal, null, principal.getAuthorities()));

--- a/src/test/java/com/stucray/limen/oauth2/OAuth2AuthorizeMembershipGateIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/OAuth2AuthorizeMembershipGateIntegrationTest.java
@@ -113,22 +113,22 @@ class OAuth2AuthorizeMembershipGateIntegrationTest {
         aliceAlpha = userRepository.save(new User(
             null, alphaTenant.id(), "alice@example.test",
             passwordEncoder.encode("password"),
-            true, false, false, LocalDateTime.now()
+            true, false, false, true, LocalDateTime.now()
         ));
         adminAlpha = userRepository.save(new User(
             null, alphaTenant.id(), "alpha-admin@example.test",
             passwordEncoder.encode("password"),
-            true, false, true, LocalDateTime.now()
+            true, false, true, true, LocalDateTime.now()
         ));
         bobBeta = userRepository.save(new User(
             null, betaTenant.id(), "bob@example.test",
             passwordEncoder.encode("password"),
-            true, false, false, LocalDateTime.now()
+            true, false, false, true, LocalDateTime.now()
         ));
         adminBeta = userRepository.save(new User(
             null, betaTenant.id(), "beta-admin@example.test",
             passwordEncoder.encode("password"),
-            true, false, true, LocalDateTime.now()
+            true, false, true, true, LocalDateTime.now()
         ));
     }
 

--- a/src/test/java/com/stucray/limen/oauth2/OAuth2ForcedPasswordChangeIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/OAuth2ForcedPasswordChangeIntegrationTest.java
@@ -109,7 +109,7 @@ class OAuth2ForcedPasswordChangeIntegrationTest {
         userRepository.save(new User(
             null, tenant.id(), "alice@example.test",
             passwordEncoder.encode("temp"),
-            true, true, false, LocalDateTime.now()));
+            true, true, false, true, LocalDateTime.now()));
 
         MockHttpSession session = startAuthorize(newPkce().challenge());
 
@@ -129,7 +129,7 @@ class OAuth2ForcedPasswordChangeIntegrationTest {
         User original = userRepository.save(new User(
             null, tenant.id(), "alice@example.test",
             passwordEncoder.encode("temp"),
-            true, true, false, LocalDateTime.now()));
+            true, true, false, true, LocalDateTime.now()));
         ClientMembershipTestFixture.grant(
             applicationMembershipService, clientMembershipService,
             app.id(), tenant.id(), original.id(), original.id(),
@@ -169,7 +169,7 @@ class OAuth2ForcedPasswordChangeIntegrationTest {
         User original = userRepository.save(new User(
             null, tenant.id(), "alice@example.test",
             passwordEncoder.encode("temp"),
-            true, true, false, LocalDateTime.now()));
+            true, true, false, true, LocalDateTime.now()));
 
         MockHttpSession session = startAuthorize(newPkce().challenge());
 
@@ -193,7 +193,7 @@ class OAuth2ForcedPasswordChangeIntegrationTest {
         userRepository.save(new User(
             null, tenant.id(), "bob@example.test",
             passwordEncoder.encode("password"),
-            true, false, false, LocalDateTime.now()));
+            true, false, false, true, LocalDateTime.now()));
 
         MockHttpSession session = startAuthorize(newPkce().challenge());
 
@@ -213,7 +213,7 @@ class OAuth2ForcedPasswordChangeIntegrationTest {
         User original = userRepository.save(new User(
             null, tenant.id(), "alice@example.test",
             passwordEncoder.encode("temp"),
-            true, true, false, LocalDateTime.now()));
+            true, true, false, true, LocalDateTime.now()));
 
         MockHttpSession session = startAuthorize(newPkce().challenge());
 
@@ -239,7 +239,7 @@ class OAuth2ForcedPasswordChangeIntegrationTest {
         User original = userRepository.save(new User(
             null, tenant.id(), "alice@example.test",
             passwordEncoder.encode("temp"),
-            true, true, false, LocalDateTime.now()));
+            true, true, false, true, LocalDateTime.now()));
 
         MockHttpSession session = new MockHttpSession();
         mockMvc.perform(post("/t/alpha-corp/login")
@@ -264,7 +264,7 @@ class OAuth2ForcedPasswordChangeIntegrationTest {
         userRepository.save(new User(
             null, tenant.id(), "alice@example.test",
             passwordEncoder.encode("temp"),
-            true, true, false, LocalDateTime.now()));
+            true, true, false, true, LocalDateTime.now()));
 
         MockHttpSession session = new MockHttpSession();
         mockMvc.perform(post("/t/alpha-corp/login")

--- a/src/test/java/com/stucray/limen/oauth2/OAuth2JwtRolesClaimIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/OAuth2JwtRolesClaimIntegrationTest.java
@@ -103,12 +103,12 @@ class OAuth2JwtRolesClaimIntegrationTest {
         alice = userRepository.save(new User(
             null, tenant.id(), "alice@example.test",
             passwordEncoder.encode("password"),
-            true, false, false, LocalDateTime.now()
+            true, false, false, true, LocalDateTime.now()
         ));
         admin = userRepository.save(new User(
             null, tenant.id(), "admin@example.test",
             passwordEncoder.encode("password"),
-            true, false, true, LocalDateTime.now()
+            true, false, true, true, LocalDateTime.now()
         ));
     }
 

--- a/src/test/java/com/stucray/limen/oauth2/TenantAccessFilterIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/TenantAccessFilterIntegrationTest.java
@@ -61,7 +61,7 @@ class TenantAccessFilterIntegrationTest {
         userRepository.save(new User(
             null, alpha.id(), "owner@example.test",
             passwordEncoder.encode("alpha-pwd"),
-            true, false, false, LocalDateTime.now()
+            true, false, false, true, LocalDateTime.now()
         ));
     }
 

--- a/src/test/java/com/stucray/limen/oauth2/TenantOAuth2RoutingIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/TenantOAuth2RoutingIntegrationTest.java
@@ -109,7 +109,7 @@ class TenantOAuth2RoutingIntegrationTest {
         alphaAdmin = userRepository.save(new User(
             null, alphaCorpTenant.id(), "alpha-admin@example.test",
             passwordEncoder.encode("password"),
-            true, false, true, LocalDateTime.now()
+            true, false, true, true, LocalDateTime.now()
         ));
     }
 
@@ -241,7 +241,7 @@ class TenantOAuth2RoutingIntegrationTest {
         User alice = userRepository.save(new User(
             null, alphaCorpTenant.id(), "alice@example.test",
             passwordEncoder.encode("password"),
-            true, false, false, LocalDateTime.now()
+            true, false, false, true, LocalDateTime.now()
         ));
 
         // Create public PKCE client with consent disabled (bypasses consent step in test)
@@ -390,7 +390,7 @@ class TenantOAuth2RoutingIntegrationTest {
         User bob = userRepository.save(new User(
             null, alphaCorpTenant.id(), "bob@example.test",
             passwordEncoder.encode("password"),
-            true, false, false, LocalDateTime.now()
+            true, false, false, true, LocalDateTime.now()
         ));
 
         String internalId = UUID.randomUUID().toString();

--- a/src/test/java/com/stucray/limen/ui/journey/EmailVerificationJourneyUiIT.java
+++ b/src/test/java/com/stucray/limen/ui/journey/EmailVerificationJourneyUiIT.java
@@ -1,0 +1,121 @@
+package com.stucray.limen.ui.journey;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.playwright.Page;
+import com.stucray.limen.TestcontainersConfiguration;
+import com.stucray.limen.email.MailpitContainer;
+import com.stucray.limen.email.MailpitTestConfiguration;
+import com.stucray.limen.ui.pages.CheckInboxPage;
+import com.stucray.limen.ui.pages.LandingPage;
+import com.stucray.limen.ui.support.PlaywrightExtension;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.client.RestClient;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end Playwright UI journey: a brand-new tenant owner signs up, lands on
+ * the check-inbox page, the verification email arrives in Mailpit, the user
+ * clicks the magic link, the OTT submit page POSTs the token, and the browser
+ * lands on the tenant home with {@code email_verified=true} in the database.
+ *
+ * <p>Activates the {@code test} profile so the SMTP {@link com.stucray.limen.email.SmtpEmailSender}
+ * fires (rather than the default LoggingEmailSender) and imports
+ * {@link MailpitTestConfiguration} for the Mailpit Testcontainer + JavaMailSender.
+ * Other UI tests stay on the logging driver to skip the Mailpit startup cost.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import({TestcontainersConfiguration.class, MailpitTestConfiguration.class})
+@ActiveProfiles("test")
+@ExtendWith(PlaywrightExtension.class)
+@DisplayName("New tenant owner signs up, retrieves the verification email from Mailpit, clicks the magic link, and lands on home — fully verified")
+class EmailVerificationJourneyUiIT {
+
+    private static final Pattern MAGIC_LINK_PATTERN =
+        Pattern.compile("(/t/[^/]+/login/ott\\?token=[A-Fa-f0-9-]+)");
+
+    @LocalServerPort int port;
+    @Autowired MailpitContainer mailpit;
+    @Autowired JdbcTemplate jdbcTemplate;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("happy path: signup → check-inbox → click Mailpit magic link → tenant home; email_verified flips to true")
+    void happyPath(Page page) throws Exception {
+        String suffix = unique();
+        String slug = "vrfy-" + suffix;
+        String orgName = "Verify " + suffix;
+        String email = "owner-" + suffix + "@example.test";
+        String password = "secret123";
+
+        CheckInboxPage checkInbox = new LandingPage(page, baseUrl())
+            .visit()
+            .clickSignUp()
+            .fillForm(orgName, slug, email, password)
+            .submit(slug)
+            .assertHeading()
+            .assertEmailShown(email);
+
+        // Verification mail arrives in Mailpit; pull the magic link out of the body.
+        String magicPath = waitForMagicLink(email);
+        // Quick sanity: the link points at this tenant's prefix, not somebody else's.
+        assertThat(magicPath).startsWith("/t/" + slug + "/login/ott?token=");
+
+        // Clicking the link is a GET → renders the auto-submit OTT form.
+        page.navigate(baseUrl() + magicPath);
+        page.getByTestId("ott-submit").click();
+        // Post-OTT dispatch lands on the tenant home (no saved request, no
+        // pending password change, just the terminal tenantHome() intent).
+        page.waitForURL(baseUrl() + "/t/" + slug + "/");
+
+        Boolean verified = jdbcTemplate.queryForObject(
+            "SELECT email_verified FROM users WHERE email = ?",
+            Boolean.class, email);
+        assertThat(verified).isTrue();
+    }
+
+    private String waitForMagicLink(String recipientEmail) throws Exception {
+        RestClient restClient = RestClient.create(mailpit.httpApiBaseUrl());
+        long deadline = System.currentTimeMillis() + 15_000;
+        while (System.currentTimeMillis() < deadline) {
+            JsonNode messages = objectMapper.readTree(
+                restClient.get().uri("/api/v1/messages?limit=50").retrieve().body(String.class));
+            for (JsonNode m : messages.path("messages")) {
+                JsonNode toArray = m.path("To");
+                if (toArray.isArray() && toArray.size() > 0
+                    && recipientEmail.equals(toArray.get(0).path("Address").asText())) {
+                    String id = m.get("ID").asText();
+                    JsonNode full = objectMapper.readTree(
+                        restClient.get().uri("/api/v1/message/{id}", id).retrieve().body(String.class));
+                    String text = full.path("Text").asText();
+                    Matcher matcher = MAGIC_LINK_PATTERN.matcher(text);
+                    if (matcher.find()) {
+                        return matcher.group(1);
+                    }
+                }
+            }
+            Thread.sleep(150);
+        }
+        throw new AssertionError("Timed out waiting for verification email to " + recipientEmail);
+    }
+
+    private String baseUrl() {
+        return "http://localhost:" + port;
+    }
+
+    private static String unique() {
+        return java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+    }
+}

--- a/src/test/java/com/stucray/limen/ui/journey/SignupJourneyUiIT.java
+++ b/src/test/java/com/stucray/limen/ui/journey/SignupJourneyUiIT.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 class SignupJourneyUiIT extends BaseUiIT {
 
     @Test
-    @DisplayName("happy path: lands on /, follows Sign up, submits the form, redirects to the new tenant's login page with a registered banner")
+    @DisplayName("happy path: lands on /, follows Sign up, submits the form, redirects to the new tenant's check-inbox page with the email shown")
     void happyPath(Page page) {
         String suffix = uniqueSuffix();
         String slug = "t-" + suffix;
@@ -25,8 +25,8 @@ class SignupJourneyUiIT extends BaseUiIT {
             .clickSignUp()
             .fillForm(orgName, slug, email, password)
             .submit(slug)
-            .assertOnLoginForTenant(orgName)
-            .assertJustRegisteredBannerVisible();
+            .assertHeading()
+            .assertEmailShown(email);
     }
 
     private static String uniqueSuffix() {

--- a/src/test/java/com/stucray/limen/ui/pages/CheckInboxPage.java
+++ b/src/test/java/com/stucray/limen/ui/pages/CheckInboxPage.java
@@ -1,0 +1,43 @@
+package com.stucray.limen.ui.pages;
+
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.assertions.PlaywrightAssertions;
+import com.microsoft.playwright.options.AriaRole;
+
+public final class CheckInboxPage {
+
+    private final Page page;
+    private final String baseUrl;
+    private final String slug;
+
+    public CheckInboxPage(Page page, String baseUrl, String slug) {
+        this.page = page;
+        this.baseUrl = baseUrl;
+        this.slug = slug;
+    }
+
+    public CheckInboxPage assertHeading() {
+        PlaywrightAssertions.assertThat(
+            page.getByRole(AriaRole.HEADING, new Page.GetByRoleOptions().setName("Check your inbox"))
+        ).isVisible();
+        return this;
+    }
+
+    public CheckInboxPage assertEmailShown(String expectedEmail) {
+        PlaywrightAssertions.assertThat(page.getByTestId("verification-email"))
+            .hasText(expectedEmail);
+        return this;
+    }
+
+    public String slug() {
+        return slug;
+    }
+
+    public String baseUrl() {
+        return baseUrl;
+    }
+
+    public Page page() {
+        return page;
+    }
+}

--- a/src/test/java/com/stucray/limen/ui/pages/SignupPage.java
+++ b/src/test/java/com/stucray/limen/ui/pages/SignupPage.java
@@ -1,7 +1,6 @@
 package com.stucray.limen.ui.pages;
 
 import com.microsoft.playwright.Page;
-import com.stucray.limen.ui.pages.manage.ManageLoginPage;
 
 public final class SignupPage {
 
@@ -21,9 +20,9 @@ public final class SignupPage {
         return this;
     }
 
-    public ManageLoginPage submit(String expectedSlug) {
+    public CheckInboxPage submit(String expectedSlug) {
         page.getByTestId("signup-submit").click();
-        page.waitForURL(baseUrl + "/manage/t/" + expectedSlug + "/login**");
-        return new ManageLoginPage(page, baseUrl, expectedSlug);
+        page.waitForURL(baseUrl + "/t/" + expectedSlug + "/check-inbox**");
+        return new CheckInboxPage(page, baseUrl, expectedSlug);
     }
 }

--- a/src/test/java/com/stucray/limen/ui/support/TestTenantFactory.java
+++ b/src/test/java/com/stucray/limen/ui/support/TestTenantFactory.java
@@ -135,7 +135,7 @@ public class TestTenantFactory {
         String email = "forcechange-" + suffix + "@example.test";
         String hash = passwordEncoder.encode(SHARED_TEST_PASSWORD);
         userRepository.save(new User(
-            null, tenant.tenantId(), email, hash, true, true, false, LocalDateTime.now()));
+            null, tenant.tenantId(), email, hash, true, true, false, true, LocalDateTime.now()));
         return new SeededForcedChangeUser(email, SHARED_TEST_PASSWORD);
     }
 
@@ -150,9 +150,9 @@ public class TestTenantFactory {
         Tenant tenant = tenantProvisioningService.createTenant(slug, displayName);
         String hash = passwordEncoder.encode(SHARED_TEST_PASSWORD);
         userRepository.save(new User(
-            null, tenant.id(), adminEmail, hash, true, false, true, LocalDateTime.now()));
+            null, tenant.id(), adminEmail, hash, true, false, true, true, LocalDateTime.now()));
         userRepository.save(new User(
-            null, tenant.id(), endUserEmail, hash, true, false, false, LocalDateTime.now()));
+            null, tenant.id(), endUserEmail, hash, true, false, false, true, LocalDateTime.now()));
 
         return new SeededTenant(
             tenant.id(), slug, displayName,
@@ -168,7 +168,7 @@ public class TestTenantFactory {
             .orElseThrow(() -> new IllegalStateException("system tenant not bootstrapped"));
         String hash = passwordEncoder.encode(SHARED_TEST_PASSWORD);
         userRepository.save(new User(
-            null, systemTenant.id(), email, hash, true, false, false, LocalDateTime.now()));
+            null, systemTenant.id(), email, hash, true, false, false, true, LocalDateTime.now()));
         return new SeededSystemAdmin(email, SHARED_TEST_PASSWORD);
     }
 


### PR DESCRIPTION
Closes #125 (slice 4 of PRD #120).

## Summary

- Tenant-aware One-Time Token storage: V8 migration adds Spring Security 7's `JdbcOneTimeTokenService` schema, extended with `tenant_id` and `intent` (`verify-email` | `password-reset`) columns so one substrate serves both this slice and slice 5 (password reset). `TenantAwareOneTimeTokenService` decorates the JDBC service, stamping `tenant_id` from `TenantContext` on `generate` and rejecting cross-tenant `consume`.
- Email-verification flow: V8 also adds `users.email_verified BOOLEAN NOT NULL DEFAULT FALSE`. Signup now creates users unverified and immediately issues a `verify-email` OTT. `OttEmailNotifier` (a `OneTimeTokenGenerationSuccessHandler`) builds tenant-scoped magic links and dispatches via `EmailSender`. A new `PostLoginIntent.emailVerificationRequired()` blocks `/oauth2/authorize` resume for unverified users. New "check your inbox" + "resend verification email" pages complete the UX.
- Audit: `VerificationOttIssuedEvent`, `EmailVerifiedEvent`, `VerificationResentEvent` defined and emitted; listeners write rows.

## Test plan

- [x] `TenantAwareOneTimeTokenServiceIntegrationTest` — cross-tenant isolation + intent stamping + token expiry rejection
- [x] `EmailVerificationFlowIntegrationTest` — end-to-end signup → consume → `email_verified=true`; unverified `/oauth2/authorize` is redirected away
- [x] `EmailVerificationJourneyUiIT` (Playwright) — signup → retrieve email from Mailpit → click magic link → home + DB asserts
- [x] Audit listener integration test asserts new event rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)