### PR TITLE
feat: self-service password reset via OTT (#126)

### DIFF
--- a/src/main/java/com/stucray/limen/audit/AuditEventListener.java
+++ b/src/main/java/com/stucray/limen/audit/AuditEventListener.java
@@ -3,6 +3,8 @@ package com.stucray.limen.audit;
 import com.stucray.limen.audit.events.ClientSecretRotatedEvent;
 import com.stucray.limen.audit.events.EmailVerifiedEvent;
 import com.stucray.limen.audit.events.PasswordChangedEvent;
+import com.stucray.limen.audit.events.PasswordResetCompletedEvent;
+import com.stucray.limen.audit.events.PasswordResetOttIssuedEvent;
 import com.stucray.limen.audit.events.TenantCreatedEvent;
 import com.stucray.limen.audit.events.TenantDeletedEvent;
 import com.stucray.limen.audit.events.TenantSuspendedEvent;
@@ -195,6 +197,32 @@ public class AuditEventListener {
             currentIp(), currentUserAgent(),
             LocalDateTime.now(ZoneId.systemDefault()),
             details));
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onPasswordResetOttIssued(PasswordResetOttIssuedEvent event) {
+        Map<String, Object> details = new HashMap<>();
+        details.put("email", event.email());
+        details.put("delivered", event.delivered());
+        safeWrite(new AuditEvent(
+            null, event.tenantId(), event.userId(),
+            "password_reset_ott_issued",
+            event.userId() == null ? null : "user",
+            event.userId() == null ? null : String.valueOf(event.userId()),
+            currentIp(), currentUserAgent(),
+            LocalDateTime.now(ZoneId.systemDefault()),
+            details));
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onPasswordResetCompleted(PasswordResetCompletedEvent event) {
+        safeWrite(new AuditEvent(
+            null, event.tenantId(), event.userId(),
+            "password_reset_completed",
+            "user", String.valueOf(event.userId()),
+            currentIp(), currentUserAgent(),
+            LocalDateTime.now(ZoneId.systemDefault()),
+            Map.of()));
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)

--- a/src/main/java/com/stucray/limen/audit/events/PasswordResetCompletedEvent.java
+++ b/src/main/java/com/stucray/limen/audit/events/PasswordResetCompletedEvent.java
@@ -1,0 +1,13 @@
+package com.stucray.limen.audit.events;
+
+/**
+ * A user finished the OTT-driven password-reset flow: clicked the magic link,
+ * authenticated via OTT, and submitted a new password. The accompanying
+ * {@link PasswordChangedEvent} (trigger {@code SELF_SERVICE}) covers the hash
+ * rotation; this event marks completion of the reset journey specifically so
+ * audit can correlate the issue → consume → completion arc.
+ */
+public record PasswordResetCompletedEvent(
+    Long tenantId,
+    Long userId
+) {}

--- a/src/main/java/com/stucray/limen/audit/events/PasswordResetOttIssuedEvent.java
+++ b/src/main/java/com/stucray/limen/audit/events/PasswordResetOttIssuedEvent.java
@@ -1,0 +1,18 @@
+package com.stucray.limen.audit.events;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A "forgot password" request fired. {@code userId} is null when the submitted
+ * email did not match any user in the tenant — we still emit the event so audit
+ * records show the attempt, but nothing was sent. Mirrors
+ * {@link VerificationResentEvent}: the controller-level response is identical
+ * for known and unknown emails (no user-existence oracle), and the audit row's
+ * {@code delivered} flag is the only place the distinction surfaces.
+ */
+public record PasswordResetOttIssuedEvent(
+    Long tenantId,
+    @Nullable Long userId,
+    String email,
+    boolean delivered
+) {}

--- a/src/main/java/com/stucray/limen/auth/login/PostLoginIntents.java
+++ b/src/main/java/com/stucray/limen/auth/login/PostLoginIntents.java
@@ -1,5 +1,6 @@
 package com.stucray.limen.auth.login;
 
+import com.stucray.limen.auth.ott.PasswordResetSessionMarker;
 import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
 import org.springframework.security.web.savedrequest.RequestCache;
 import org.springframework.security.web.savedrequest.SavedRequest;
@@ -16,13 +17,19 @@ import java.net.URI;
  *       just-authenticated user has not yet verified their email. Sits ahead of
  *       OAuth2-resume so an unverified principal cannot complete an authorize
  *       flow before clicking the magic link.</li>
+ *   <li>{@link #passwordChangeAfterReset()} — redirect to change-password when
+ *       the just-authenticated session carries the password-reset breadcrumb
+ *       set by {@code TenantOttAuthenticationProvider} on a {@code password-reset}
+ *       OTT consume. Ahead of OAuth2-resume so a reset interrupts any saved
+ *       authorize.</li>
  *   <li>{@link #passwordChangeRequired()} — redirect when {@code mustChangePassword} is set.</li>
  *   <li>{@link #resumeOAuth2Authorize()} — consume a saved {@code /oauth2/authorize} request.</li>
  *   <li>{@link #tenantHome()} — terminal default; always returns the tenant home URL.</li>
  * </ol>
  *
- * The password-change check fires <em>before</em> OAuth2-resume so a user with an
- * expired password cannot complete an authorize flow before updating their password.
+ * The password-change checks fire <em>before</em> OAuth2-resume so a user with an
+ * expired password — or one mid password-reset — cannot complete an authorize
+ * flow before updating their password.
  */
 public final class PostLoginIntents {
 
@@ -43,6 +50,19 @@ public final class PostLoginIntents {
 
     public static PostLoginIntent passwordChangeRequired() {
         return (req, res, principal, scheme) -> principal.mustChangePassword()
+            ? scheme.changePasswordUrl(principal.tenantSlug())
+            : null;
+    }
+
+    /**
+     * If the just-completed login was an OTT consume with intent=password-reset,
+     * route to change-password. The marker is read here, cleared by
+     * {@code TenantPasswordChangeFlow} after a successful submission so a reload
+     * of the form does not fall back to tenant home before the user has actually
+     * set a new password.
+     */
+    public static PostLoginIntent passwordChangeAfterReset() {
+        return (req, res, principal, scheme) -> PasswordResetSessionMarker.isPresent(req)
             ? scheme.changePasswordUrl(principal.tenantSlug())
             : null;
     }

--- a/src/main/java/com/stucray/limen/auth/login/TenantLoginAutoConfig.java
+++ b/src/main/java/com/stucray/limen/auth/login/TenantLoginAutoConfig.java
@@ -59,6 +59,7 @@ public class TenantLoginAutoConfig {
     ) {
         List<PostLoginIntent> intents = new ArrayList<>(userIntents.orderedStream().toList());
         intents.add(PostLoginIntents.emailVerificationRequired());
+        intents.add(PostLoginIntents.passwordChangeAfterReset());
         intents.add(PostLoginIntents.passwordChangeRequired());
         intents.add(PostLoginIntents.resumeOAuth2Authorize());
         intents.add(PostLoginIntents.tenantHome());

--- a/src/main/java/com/stucray/limen/auth/login/TenantPasswordChangeFlow.java
+++ b/src/main/java/com/stucray/limen/auth/login/TenantPasswordChangeFlow.java
@@ -1,6 +1,8 @@
 package com.stucray.limen.auth.login;
 
 import com.stucray.limen.auth.TenantUserDetails;
+import com.stucray.limen.auth.ott.PasswordResetService;
+import com.stucray.limen.auth.ott.PasswordResetSessionMarker;
 import com.stucray.limen.management.users.UserManagementService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -25,10 +27,15 @@ import java.net.URI;
 public class TenantPasswordChangeFlow {
 
     private final UserManagementService userManagementService;
+    private final PasswordResetService passwordResetService;
     private final HttpSessionRequestCache requestCache = new HttpSessionRequestCache();
 
-    public TenantPasswordChangeFlow(UserManagementService userManagementService) {
+    public TenantPasswordChangeFlow(
+        UserManagementService userManagementService,
+        PasswordResetService passwordResetService
+    ) {
         this.userManagementService = userManagementService;
+        this.passwordResetService = passwordResetService;
     }
 
     /** Returns an error message if validation fails, else null. */
@@ -52,6 +59,17 @@ public class TenantPasswordChangeFlow {
     ) {
         userManagementService.changePassword(
             principal.userId(), principal.tenantId(), newPassword);
+
+        // If the marker is present, this submission is the tail of a
+        // password-reset journey. Clear it (so a refresh of the form does not
+        // double-fire completion) and emit the reset-completed audit event,
+        // before computing the redirect target. The PasswordChangedEvent fired
+        // by changePassword above covers the hash-rotation audit row; this is
+        // the additional "the reset journey is done" marker.
+        if (PasswordResetSessionMarker.isPresent(request)) {
+            PasswordResetSessionMarker.clear(request);
+            passwordResetService.completeReset(principal.userId(), principal.tenantId());
+        }
 
         SavedRequest saved = requestCache.getRequest(request, response);
         if (saved != null && saved.getRedirectUrl().contains("/oauth2/authorize")) {

--- a/src/main/java/com/stucray/limen/auth/ott/CheckInboxController.java
+++ b/src/main/java/com/stucray/limen/auth/ott/CheckInboxController.java
@@ -27,6 +27,7 @@ public class CheckInboxController {
     public String checkInbox(
         @PathVariable String slug,
         @RequestParam(required = false) String email,
+        @RequestParam(required = false) String flow,
         Model model
     ) {
         Tenant tenant = tenantRepository.findBySlug(slug).orElse(null);
@@ -36,6 +37,11 @@ public class CheckInboxController {
         model.addAttribute("slug", slug);
         model.addAttribute("tenantName", tenant.displayName());
         model.addAttribute("email", email == null ? "" : email);
+        // Two flows land on this page: verify-email (default) and password-reset.
+        // The template branches on this so the copy mentions the right link
+        // and the resend prompt only renders for verify-email (resending is
+        // implicit for forgot-password — the user just resubmits the form).
+        model.addAttribute("flow", "password-reset".equals(flow) ? "password-reset" : "verify-email");
         return "check-inbox";
     }
 }

--- a/src/main/java/com/stucray/limen/auth/ott/ForgotPasswordController.java
+++ b/src/main/java/com/stucray/limen/auth/ott/ForgotPasswordController.java
@@ -1,0 +1,73 @@
+package com.stucray.limen.auth.ott;
+
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * GET renders the email-collection form; POST dispatches to
+ * {@link PasswordResetService#requestReset} and redirects to the shared
+ * check-inbox landing with {@code flow=password-reset} so the page text
+ * mentions a reset link rather than verification.
+ *
+ * <p>Both verbs are anonymous. The POST response is identical for known and
+ * unknown emails — the same redirect target, the same query parameters — so
+ * the form is not a user-existence oracle (PRD #120 user story 14).
+ */
+@Controller
+public class ForgotPasswordController {
+
+    private final TenantRepository tenantRepository;
+    private final PasswordResetService passwordResetService;
+
+    public ForgotPasswordController(
+        TenantRepository tenantRepository,
+        PasswordResetService passwordResetService
+    ) {
+        this.tenantRepository = tenantRepository;
+        this.passwordResetService = passwordResetService;
+    }
+
+    @GetMapping("/t/{slug}/forgot-password")
+    public String form(
+        @PathVariable String slug,
+        @RequestParam(required = false) String email,
+        Model model
+    ) {
+        Tenant tenant = tenantRepository.findBySlug(slug).orElse(null);
+        if (tenant == null) {
+            return "redirect:/";
+        }
+        model.addAttribute("slug", slug);
+        model.addAttribute("tenantName", tenant.displayName());
+        model.addAttribute("email", email == null ? "" : email);
+        return "forgot-password";
+    }
+
+    @PostMapping("/t/{slug}/forgot-password")
+    public String submit(
+        @PathVariable String slug,
+        @RequestParam String email
+    ) {
+        Tenant tenant = tenantRepository.findBySlug(slug).orElse(null);
+        if (tenant == null) {
+            return "redirect:/";
+        }
+        passwordResetService.requestReset(tenant, email);
+        return "redirect:" + UriComponentsBuilder
+            .fromPath("/t/" + slug + "/check-inbox")
+            .queryParam("email", email)
+            .queryParam("flow", "password-reset")
+            .build()
+            .encode(StandardCharsets.UTF_8)
+            .toUriString();
+    }
+}

--- a/src/main/java/com/stucray/limen/auth/ott/OttEmailNotifier.java
+++ b/src/main/java/com/stucray/limen/auth/ott/OttEmailNotifier.java
@@ -62,6 +62,14 @@ public class OttEmailNotifier implements OneTimeTokenGenerationSuccessHandler {
         send(tenant, recipientEmail, tokenValue, OttIntent.VERIFY_EMAIL);
     }
 
+    /**
+     * Direct entry point used by the forgot-password flow: build the
+     * password-reset email and dispatch it via {@link EmailSender}.
+     */
+    public void sendPasswordReset(Tenant tenant, String recipientEmail, String tokenValue) {
+        send(tenant, recipientEmail, tokenValue, OttIntent.PASSWORD_RESET);
+    }
+
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response, OneTimeToken oneTimeToken)
             throws java.io.IOException {

--- a/src/main/java/com/stucray/limen/auth/ott/PasswordResetService.java
+++ b/src/main/java/com/stucray/limen/auth/ott/PasswordResetService.java
@@ -1,0 +1,77 @@
+package com.stucray.limen.auth.ott;
+
+import com.stucray.limen.audit.events.PasswordResetCompletedEvent;
+import com.stucray.limen.audit.events.PasswordResetOttIssuedEvent;
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantScope;
+import com.stucray.limen.user.User;
+import com.stucray.limen.user.UserRepository;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+/**
+ * Orchestrates the OTT-driven password-reset flow:
+ *
+ * <ul>
+ *   <li>{@link #requestReset(Tenant, String)} — driven by the unauthenticated
+ *       forgot-password form. Issues a {@code password-reset} OTT and dispatches
+ *       the email iff the address resolves to a user in the tenant; otherwise a
+ *       silent no-op with respect to email delivery so the form is not a
+ *       user-existence oracle (PRD #120 user story 14). Always emits
+ *       {@link PasswordResetOttIssuedEvent} so audit shows the attempt without
+ *       leaking which addresses are real.</li>
+ *   <li>{@link #completeReset(Long, Long)} — emits
+ *       {@link PasswordResetCompletedEvent} after the user submits their new
+ *       password. The hash rotation itself is owned by
+ *       {@code UserManagementService.changePassword}, which fires its own
+ *       {@code PasswordChangedEvent}; this is the "the reset journey is done"
+ *       marker that lets audit correlate the issue → consume → completion arc.</li>
+ * </ul>
+ */
+@Service
+public class PasswordResetService {
+
+    private final TenantAwareOneTimeTokenService tokenService;
+    private final OttEmailNotifier emailNotifier;
+    private final UserRepository userRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public PasswordResetService(
+        TenantAwareOneTimeTokenService tokenService,
+        OttEmailNotifier emailNotifier,
+        UserRepository userRepository,
+        ApplicationEventPublisher eventPublisher
+    ) {
+        this.tokenService = tokenService;
+        this.emailNotifier = emailNotifier;
+        this.userRepository = userRepository;
+        this.eventPublisher = eventPublisher;
+    }
+
+    @Transactional
+    public void requestReset(Tenant tenant, String email) {
+        Optional<User> maybeUser = userRepository.findByEmailAndTenantId(email, tenant.id());
+        boolean delivered = false;
+        Long userId = null;
+        if (maybeUser.isPresent()) {
+            User user = maybeUser.get();
+            userId = user.id();
+            TenantScope.run(tenant.slug(), tenant.id(), () -> {
+                TenantOneTimeToken token =
+                    tokenService.generateForIntent(user.email(), OttIntent.PASSWORD_RESET);
+                emailNotifier.sendPasswordReset(tenant, user.email(), token.tokenValue());
+            });
+            delivered = true;
+        }
+        eventPublisher.publishEvent(new PasswordResetOttIssuedEvent(
+            tenant.id(), userId, email, delivered));
+    }
+
+    @Transactional
+    public void completeReset(Long userId, Long tenantId) {
+        eventPublisher.publishEvent(new PasswordResetCompletedEvent(tenantId, userId));
+    }
+}

--- a/src/main/java/com/stucray/limen/auth/ott/PasswordResetSessionMarker.java
+++ b/src/main/java/com/stucray/limen/auth/ott/PasswordResetSessionMarker.java
@@ -1,0 +1,66 @@
+package com.stucray.limen.auth.ott;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.jspecify.annotations.Nullable;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+/**
+ * Session-scoped breadcrumb that tells the post-login pipeline "the user just
+ * consumed a password-reset OTT, route them through change-password before
+ * anything else." Set inside {@link TenantOttAuthenticationProvider} (where the
+ * intent on the consumed row is the only authoritative source for which flow
+ * we're in), read by {@code PostLoginIntents.passwordChangeAfterReset}, and
+ * cleared by {@code TenantPasswordChangeFlow} on successful submission.
+ *
+ * <p>The marker also doubles as the "completion event has been emitted" guard:
+ * the flow only fires {@link PasswordResetService#completeReset} if the
+ * attribute was present, so a vanilla self-service password change does not
+ * masquerade as a reset.
+ *
+ * <p>Lives on the HTTP session because the OTT authentication step (where the
+ * marker is set) runs in a different request from the change-password POST
+ * (where it is read + cleared); session is the smallest scope that spans both.
+ */
+public final class PasswordResetSessionMarker {
+
+    public static final String ATTRIBUTE_NAME = "limen.passwordResetRequired";
+
+    private PasswordResetSessionMarker() {}
+
+    /** Set the marker for the current request's session. Creates a session if one does not exist. */
+    public static void setOnCurrentRequest() {
+        HttpServletRequest req = currentRequestOrNull();
+        if (req == null) {
+            // Defence in depth: in production the OTT auth provider always runs
+            // inside a request, but tests that exercise the provider directly may
+            // not bind RequestContextHolder. Silently no-op so the unit test path
+            // stays usable; the integration tests cover the session-bound flow.
+            return;
+        }
+        req.getSession(true).setAttribute(ATTRIBUTE_NAME, Boolean.TRUE);
+    }
+
+    /** True iff the marker is present on the request's session. */
+    public static boolean isPresent(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        return session != null && Boolean.TRUE.equals(session.getAttribute(ATTRIBUTE_NAME));
+    }
+
+    /** Remove the marker. Safe to call when no session or no attribute exists. */
+    public static void clear(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            session.removeAttribute(ATTRIBUTE_NAME);
+        }
+    }
+
+    private static @Nullable HttpServletRequest currentRequestOrNull() {
+        var attrs = RequestContextHolder.getRequestAttributes();
+        if (attrs instanceof ServletRequestAttributes sra) {
+            return sra.getRequest();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/stucray/limen/auth/ott/TenantOttAuthenticationProvider.java
+++ b/src/main/java/com/stucray/limen/auth/ott/TenantOttAuthenticationProvider.java
@@ -36,9 +36,12 @@ import java.util.Set;
  *   <li>{@link OttIntent#VERIFY_EMAIL} — flips {@code email_verified=true} via
  *       {@link EmailVerificationService#markEmailVerified} (idempotent on a
  *       second consume).</li>
- *   <li>{@link OttIntent#PASSWORD_RESET} — left to slice #126; the principal
- *       is returned authenticated so the post-login dispatch can route to
- *       change-password.</li>
+ *   <li>{@link OttIntent#PASSWORD_RESET} — also flips {@code email_verified=true}
+ *       (clicking a link delivered to the address proves control of it, same
+ *       guarantee as the verify-email flow), and sets a session breadcrumb via
+ *       {@link PasswordResetSessionMarker} so {@code passwordChangeAfterReset()}
+ *       can route the just-authenticated user through change-password ahead of
+ *       any saved /oauth2/authorize request.</li>
  * </ul>
  */
 @Component
@@ -84,14 +87,25 @@ public class TenantOttAuthenticationProvider implements AuthenticationProvider {
             throw new BadCredentialsException("Failed to authenticate the one-time token");
         }
 
-        if (row.intent() == OttIntent.VERIFY_EMAIL) {
-            verificationService.markEmailVerified(principal.userId(), principal.tenantId());
-            // Reflect the just-applied flip on the in-memory principal so the
-            // PostLoginIntent.emailVerificationRequired() check that runs from
-            // the success handler doesn't see stale state and bounce the user
-            // back to check-inbox.
-            principal = new TenantUserDetails(
-                principal.user().withEmailVerified(true), principal.tenant());
+        // Both intents flip email_verified=true. For VERIFY_EMAIL that is the
+        // whole point of the flow; for PASSWORD_RESET it is a defensible side
+        // effect — the user just demonstrated control of the address by clicking
+        // a link delivered to it, the same proof the verify-email flow accepts.
+        // Without this an unverified user using forgot-password would be bounced
+        // to /check-inbox by emailVerificationRequired() before ever reaching
+        // change-password.
+        verificationService.markEmailVerified(principal.userId(), principal.tenantId());
+        // Reflect the just-applied flip on the in-memory principal so the
+        // PostLoginIntent.emailVerificationRequired() check that runs from
+        // the success handler doesn't see stale state and bounce the user
+        // back to check-inbox.
+        principal = new TenantUserDetails(
+            principal.user().withEmailVerified(true), principal.tenant());
+
+        if (row.intent() == OttIntent.PASSWORD_RESET) {
+            // Set the session breadcrumb that passwordChangeAfterReset() reads
+            // and TenantPasswordChangeFlow clears on successful submission.
+            PasswordResetSessionMarker.setOnCurrentRequest();
         }
 
         Set<GrantedAuthority> authorities = new HashSet<>(principal.getAuthorities());

--- a/src/main/java/com/stucray/limen/auth/ott/TenantOttRoutingFilter.java
+++ b/src/main/java/com/stucray/limen/auth/ott/TenantOttRoutingFilter.java
@@ -18,10 +18,10 @@ import java.util.regex.Pattern;
 
 /**
  * Binds {@link TenantScope} for the OTT URLs ({@code /t/{slug}/login/ott},
- * {@code /t/{slug}/check-inbox}, {@code /t/{slug}/resend-verification}) so the
- * OTT auth provider, the tenant-aware token service, and the controllers below
- * can read tenant identity from {@link TenantScope} instead of plumbing it
- * through every method signature.
+ * {@code /t/{slug}/check-inbox}, {@code /t/{slug}/resend-verification},
+ * {@code /t/{slug}/forgot-password}) so the OTT auth provider, the tenant-aware
+ * token service, and the controllers below can read tenant identity from
+ * {@link TenantScope} instead of plumbing it through every method signature.
  *
  * <p>Modelled on {@code TenantOAuth2RoutingFilter} but does <em>not</em> strip
  * the URL prefix — these endpoints are owned by Limen's own controllers and
@@ -37,7 +37,7 @@ import java.util.regex.Pattern;
 public class TenantOttRoutingFilter extends OncePerRequestFilter {
 
     private static final Pattern TENANT_OTT_PATH =
-        Pattern.compile("^/t/([^/]+)/(login/ott|check-inbox|resend-verification)(?:[/?].*)?$");
+        Pattern.compile("^/t/([^/]+)/(login/ott|check-inbox|resend-verification|forgot-password)(?:[/?].*)?$");
 
     private final TenantRepository tenantRepository;
 

--- a/src/main/java/com/stucray/limen/oauth2/OAuth2LoginSecurityConfig.java
+++ b/src/main/java/com/stucray/limen/oauth2/OAuth2LoginSecurityConfig.java
@@ -74,6 +74,7 @@ public class OAuth2LoginSecurityConfig {
                 .requestMatchers("/t/*/login/ott").permitAll()
                 .requestMatchers("/t/*/check-inbox").permitAll()
                 .requestMatchers("/t/*/resend-verification").permitAll()
+                .requestMatchers("/t/*/forgot-password").permitAll()
                 .anyRequest().authenticated()
             )
             .requestCache(rc -> rc.requestCache(requestCache))

--- a/src/main/resources/templates/check-inbox.html
+++ b/src/main/resources/templates/check-inbox.html
@@ -8,7 +8,15 @@
             <h1>Check your inbox</h1>
             <p th:if="${tenantName}" th:text="${tenantName}">Tenant</p>
         </hgroup>
-        <p>
+        <p th:if="${flow == 'password-reset'}">
+            If an account exists for
+            <span th:if="${email != null and !email.isEmpty()}">
+                <strong th:text="${email}" data-test-action="reset-email">you@example.com</strong>,
+            </span>
+            <span th:unless="${email != null and !email.isEmpty()}">that address,</span>
+            we've sent a password-reset link. Click it to set a new password.
+        </p>
+        <p th:if="${flow != 'password-reset'}">
             We've sent a verification link
             <span th:if="${email != null and !email.isEmpty()}">
                 to <strong th:text="${email}" data-test-action="verification-email">you@example.com</strong>
@@ -17,10 +25,15 @@
         </p>
         <p class="muted">The link is single-use and expires in 60 minutes.</p>
         <hr/>
-        <p>
+        <p th:if="${flow != 'password-reset'}">
             Didn't receive the email?
             <a th:href="@{/t/{slug}/resend-verification(slug=${slug}, email=${email})}"
                data-test-action="resend-verification-link">Resend it</a>.
+        </p>
+        <p th:if="${flow == 'password-reset'}">
+            Didn't receive the email?
+            <a th:href="@{/t/{slug}/forgot-password(slug=${slug}, email=${email})}"
+               data-test-action="resend-reset-link">Request a new link</a>.
         </p>
         <p>
             <a th:href="@{/t/{slug}/login(slug=${slug})}" data-test-action="back-to-login">Back to sign in</a>

--- a/src/main/resources/templates/forgot-password.html
+++ b/src/main/resources/templates/forgot-password.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{fragments/layout :: layout(~{::title}, ~{::main})}">
+<head><title>Reset your password — Limen</title></head>
+<body>
+<main>
+    <article class="card card--auth">
+        <hgroup>
+            <h1>Reset your password</h1>
+            <p th:if="${tenantName}" th:text="${tenantName}">Tenant</p>
+        </hgroup>
+        <p>Enter your email address and we'll send you a link to set a new password.</p>
+        <form method="post" th:action="@{/t/{slug}/forgot-password(slug=${slug})}" class="stack">
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+            <label>
+                Email
+                <input type="email" name="email" th:value="${email}" autofocus required/>
+            </label>
+            <button type="submit" class="btn--block" data-test-action="forgot-password-submit">Send reset link</button>
+        </form>
+        <hr/>
+        <p>
+            <a th:href="@{/t/{slug}/login(slug=${slug})}" data-test-action="back-to-login">Back to sign in</a>
+        </p>
+    </article>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -24,6 +24,10 @@
             </label>
             <button type="submit" class="btn--block" data-test-action="login-submit">Sign in</button>
         </form>
+        <p>
+            <a th:href="@{/t/{slug}/forgot-password(slug=${tenantSlug})}"
+               data-test-action="forgot-password-link">Forgot your password?</a>
+        </p>
     </article>
 </main>
 </body>

--- a/src/test/java/com/stucray/limen/auth/login/PostLoginIntentsUnitTest.java
+++ b/src/test/java/com/stucray/limen/auth/login/PostLoginIntentsUnitTest.java
@@ -1,6 +1,7 @@
 package com.stucray.limen.auth.login;
 
 import com.stucray.limen.auth.TenantUserDetails;
+import com.stucray.limen.auth.ott.PasswordResetSessionMarker;
 import com.stucray.limen.tenant.Tenant;
 import com.stucray.limen.tenant.TenantStatus;
 import com.stucray.limen.user.User;
@@ -119,6 +120,38 @@ class PostLoginIntentsUnitTest {
 
         assertThat(url).isNull();
         verify(requestCache, never()).removeRequest(req, res);
+    }
+
+    @Test
+    @DisplayName("passwordChangeAfterReset: redirects to change-password when the password-reset session marker is present")
+    void passwordChangeAfterResetRedirectsWhenMarkerPresent() {
+        req.getSession(true).setAttribute(PasswordResetSessionMarker.ATTRIBUTE_NAME, Boolean.TRUE);
+        PostLoginIntent intent = PostLoginIntents.passwordChangeAfterReset();
+
+        String url = intent.resolve(req, res, freshPrincipal, OAUTH2);
+
+        assertThat(url).isEqualTo("/t/alpha/change-password");
+    }
+
+    @Test
+    @DisplayName("passwordChangeAfterReset: returns null (falls through) when no session exists")
+    void passwordChangeAfterResetFallsThroughWhenNoSession() {
+        PostLoginIntent intent = PostLoginIntents.passwordChangeAfterReset();
+
+        String url = intent.resolve(req, res, freshPrincipal, OAUTH2);
+
+        assertThat(url).isNull();
+    }
+
+    @Test
+    @DisplayName("passwordChangeAfterReset: returns null when session exists but marker is unset")
+    void passwordChangeAfterResetFallsThroughWhenMarkerAbsent() {
+        req.getSession(true);
+        PostLoginIntent intent = PostLoginIntents.passwordChangeAfterReset();
+
+        String url = intent.resolve(req, res, freshPrincipal, OAUTH2);
+
+        assertThat(url).isNull();
     }
 
     @Test

--- a/src/test/java/com/stucray/limen/auth/ott/PasswordResetFlowIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/auth/ott/PasswordResetFlowIntegrationTest.java
@@ -1,0 +1,328 @@
+package com.stucray.limen.auth.ott;
+
+import com.stucray.limen.TestcontainersConfiguration;
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantProvisioningService;
+import com.stucray.limen.tenant.TenantScope;
+import com.stucray.limen.user.User;
+import com.stucray.limen.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * End-to-end coverage of the OTT-driven password-reset flow at the HTTP layer:
+ *
+ * <ul>
+ *   <li>The unauthenticated forgot-password POST returns the same redirect for
+ *       known and unknown emails — the form is not a user-existence oracle.</li>
+ *   <li>Magic-link consume (POST /t/&#123;slug&#125;/login/ott with a reset
+ *       token) authenticates and routes to /change-password ahead of any saved
+ *       /oauth2/authorize, via {@code passwordChangeAfterReset()}.</li>
+ *   <li>Submitting the new password runs the existing change-password flow,
+ *       clears the session marker, and emits {@code PasswordResetCompletedEvent}
+ *       and {@code PasswordChangedEvent} (the latter as {@code SELF_SERVICE},
+ *       because {@code mustChangePassword} is unset on a normal account).</li>
+ *   <li>Single-use: a consumed reset OTT cannot be reused. Storage-side delete
+ *       is shared with verify-email, but covered here against the reset-specific
+ *       flow.</li>
+ *   <li>Expiry: a token whose {@code expires_at} is in the past is rejected
+ *       even before its single-use deletion fires.</li>
+ *   <li>Audit: rows for {@code password_reset_ott_issued} (with
+ *       {@code delivered=true} for known emails and {@code delivered=false} for
+ *       unknown) and {@code password_reset_completed} appear after the matching
+ *       events. The {@code password_changed} row from
+ *       {@code UserManagementService.changePassword} also lands.</li>
+ * </ul>
+ */
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@DisplayName("Password reset: forgot-password is no oracle; magic-link routes through change-password; reset completion + audit rows land")
+class PasswordResetFlowIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired TenantProvisioningService tenantProvisioningService;
+    @Autowired UserRepository userRepository;
+    @Autowired PasswordEncoder passwordEncoder;
+    @Autowired TenantAwareOneTimeTokenService tokenService;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanAudit() {
+        jdbcTemplate.execute("DELETE FROM audit_event WHERE event_type IN "
+            + "('password_reset_ott_issued', 'password_reset_completed', 'password_changed')");
+    }
+
+    @Nested
+    @DisplayName("Forgot-password is not a user-existence oracle")
+    class NoOracle {
+
+        @Test
+        @DisplayName("Known email returns the same redirect target as unknown email — same status, same Location")
+        void identicalResponseForKnownAndUnknownEmail() throws Exception {
+            String suffix = uniqueSuffix();
+            String slug = "noracle-" + suffix;
+            String knownEmail = "known-" + suffix + "@example.test";
+            String unknownEmail = "ghost-" + suffix + "@example.test";
+            Tenant tenant = tenantProvisioningService.createTenant(slug, "NoOracle " + suffix);
+            userRepository.save(activeUser(tenant.id(), knownEmail));
+
+            MvcResult known = mockMvc.perform(post("/t/" + slug + "/forgot-password")
+                    .param("email", knownEmail).with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andReturn();
+
+            MvcResult unknown = mockMvc.perform(post("/t/" + slug + "/forgot-password")
+                    .param("email", unknownEmail).with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andReturn();
+
+            assertThat(known.getResponse().getStatus()).isEqualTo(unknown.getResponse().getStatus());
+            // The Location query parameter encodes the email — so the two URLs
+            // differ in that field, but both point at the same path with the
+            // same flow=password-reset marker. Check the path + flow only.
+            String knownLocation = known.getResponse().getHeader("Location");
+            String unknownLocation = unknown.getResponse().getHeader("Location");
+            assertThat(knownLocation).isNotNull();
+            assertThat(unknownLocation).isNotNull();
+            assertThat(stripEmail(knownLocation)).isEqualTo(stripEmail(unknownLocation));
+            assertThat(knownLocation).contains("flow=password-reset");
+            assertThat(unknownLocation).contains("flow=password-reset");
+        }
+    }
+
+    @Nested
+    @DisplayName("Magic-link consume routes through change-password")
+    class ResetRoutes {
+
+        @Test
+        @DisplayName("After OTT consume the post-login dispatch redirects to /t/{slug}/change-password — passwordChangeAfterReset wins ahead of tenantHome")
+        void ottConsumeRoutesToChangePassword() throws Exception {
+            String suffix = uniqueSuffix();
+            String slug = "rst-" + suffix;
+            String email = "owner-" + suffix + "@example.test";
+            Tenant tenant = tenantProvisioningService.createTenant(slug, "Reset " + suffix);
+            userRepository.save(activeUser(tenant.id(), email));
+
+            TenantOneTimeToken issued = TenantScope.call(tenant.slug(), tenant.id(), () ->
+                tokenService.generateForIntent(email, OttIntent.PASSWORD_RESET));
+
+            MockHttpSession session = new MockHttpSession();
+            MvcResult ottResult = mockMvc.perform(post("/t/" + slug + "/login/ott")
+                    .param("token", issued.tokenValue())
+                    .session(session).with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andReturn();
+
+            String location = ottResult.getResponse().getHeader("Location");
+            assertThat(location).endsWith("/t/" + slug + "/change-password");
+            // The session marker survived the redirect — the change-password
+            // POST step will read it and emit the completed event.
+            assertThat(session.getAttribute(PasswordResetSessionMarker.ATTRIBUTE_NAME))
+                .isEqualTo(Boolean.TRUE);
+        }
+
+        @Test
+        @DisplayName("Submitting the new password clears the marker and emits password_reset_completed + password_changed audit rows")
+        void submittingNewPasswordCompletesResetAndAuditsBothEvents() throws Exception {
+            String suffix = uniqueSuffix();
+            String slug = "rst2-" + suffix;
+            String email = "owner-" + suffix + "@example.test";
+            String newPassword = "new-secret-" + suffix;
+            Tenant tenant = tenantProvisioningService.createTenant(slug, "Reset2 " + suffix);
+            User user = userRepository.save(activeUser(tenant.id(), email));
+
+            TenantOneTimeToken issued = TenantScope.call(tenant.slug(), tenant.id(), () ->
+                tokenService.generateForIntent(email, OttIntent.PASSWORD_RESET));
+
+            MockHttpSession session = new MockHttpSession();
+            mockMvc.perform(post("/t/" + slug + "/login/ott")
+                    .param("token", issued.tokenValue())
+                    .session(session).with(csrf()))
+                .andExpect(status().is3xxRedirection());
+
+            mockMvc.perform(post("/t/" + slug + "/change-password")
+                    .param("newPassword", newPassword)
+                    .param("confirmPassword", newPassword)
+                    .session(session).with(csrf()))
+                .andExpect(status().is3xxRedirection());
+
+            assertThat(session.getAttribute(PasswordResetSessionMarker.ATTRIBUTE_NAME)).isNull();
+
+            Map<String, Object> resetCompleted = jdbcTemplate.queryForMap(
+                "SELECT actor_user_id, target_id FROM audit_event "
+                    + "WHERE event_type = 'password_reset_completed' AND tenant_id = ? "
+                    + "ORDER BY occurred_at DESC LIMIT 1",
+                tenant.id());
+            assertThat(resetCompleted.get("actor_user_id")).isEqualTo(user.id());
+            assertThat(resetCompleted.get("target_id")).isEqualTo(String.valueOf(user.id()));
+
+            Map<String, Object> passwordChanged = jdbcTemplate.queryForMap(
+                "SELECT details::text AS details FROM audit_event "
+                    + "WHERE event_type = 'password_changed' AND tenant_id = ? "
+                    + "ORDER BY occurred_at DESC LIMIT 1",
+                tenant.id());
+            assertThat(passwordChanged.get("details").toString()).contains("self_service");
+        }
+    }
+
+    @Nested
+    @DisplayName("Reset OTT lifecycle")
+    class TokenLifecycle {
+
+        @Test
+        @DisplayName("A consumed reset OTT cannot be reused — second consume returns 401-equivalent (no auth, no redirect to change-password)")
+        void consumedResetTokenCannotBeReused() throws Exception {
+            String suffix = uniqueSuffix();
+            String slug = "single-" + suffix;
+            String email = "owner-" + suffix + "@example.test";
+            Tenant tenant = tenantProvisioningService.createTenant(slug, "Single " + suffix);
+            userRepository.save(activeUser(tenant.id(), email));
+            TenantOneTimeToken issued = TenantScope.call(tenant.slug(), tenant.id(), () ->
+                tokenService.generateForIntent(email, OttIntent.PASSWORD_RESET));
+
+            // First consume — succeeds.
+            mockMvc.perform(post("/t/" + slug + "/login/ott")
+                    .param("token", issued.tokenValue()).with(csrf()))
+                .andExpect(status().is3xxRedirection());
+
+            // Second consume — token row is gone, Spring's OTT filter falls
+            // through to its failure handler (?error) rather than authenticating.
+            // The exact redirect target is Spring Security's default OTT
+            // failure URL ({@code /login?error}); what matters here is that the
+            // user is not routed into the change-password form, since that
+            // would mean a stale magic link still grants password-reset access.
+            MvcResult second = mockMvc.perform(post("/t/" + slug + "/login/ott")
+                    .param("token", issued.tokenValue()).with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andReturn();
+            String secondLocation = second.getResponse().getHeader("Location");
+            assertThat(secondLocation).isNotNull();
+            assertThat(secondLocation).doesNotContain("/change-password");
+            assertThat(secondLocation).contains("error");
+        }
+
+        @Test
+        @DisplayName("A reset OTT past expiry is rejected — TenantAwareOneTimeTokenService.consume returns null and the user is not authenticated")
+        void expiredResetTokenIsRejected() throws Exception {
+            String suffix = uniqueSuffix();
+            String slug = "expiry-" + suffix;
+            String email = "owner-" + suffix + "@example.test";
+            Tenant tenant = tenantProvisioningService.createTenant(slug, "Expiry " + suffix);
+            userRepository.save(activeUser(tenant.id(), email));
+            TenantOneTimeToken issued = TenantScope.call(tenant.slug(), tenant.id(), () ->
+                tokenService.generateForIntent(email, OttIntent.PASSWORD_RESET));
+
+            // Move the row's expires_at into the past so consume() picks it up
+            // but rejects on the clock check. Mirrors how
+            // TenantAwareOneTimeTokenServiceIntegrationTest exercises expiry.
+            jdbcTemplate.update(
+                "UPDATE one_time_tokens SET expires_at = ? WHERE token_value = ?",
+                Timestamp.from(Instant.now().minusSeconds(3600)), issued.tokenValue());
+
+            MvcResult result = mockMvc.perform(post("/t/" + slug + "/login/ott")
+                    .param("token", issued.tokenValue()).with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andReturn();
+            String location = result.getResponse().getHeader("Location");
+            assertThat(location).isNotNull();
+            assertThat(location).doesNotContain("/change-password");
+            assertThat(location).contains("error");
+        }
+    }
+
+    @Nested
+    @DisplayName("Audit rows for forgot-password attempts")
+    class AuditRows {
+
+        @Test
+        @DisplayName("Forgot-password for a known email writes password_reset_ott_issued with delivered=true and a non-null actor")
+        void knownEmailAuditsAsDelivered() throws Exception {
+            String suffix = uniqueSuffix();
+            String slug = "auditok-" + suffix;
+            String email = "owner-" + suffix + "@example.test";
+            Tenant tenant = tenantProvisioningService.createTenant(slug, "AuditOK " + suffix);
+            User user = userRepository.save(activeUser(tenant.id(), email));
+
+            mockMvc.perform(post("/t/" + slug + "/forgot-password")
+                    .param("email", email).with(csrf()))
+                .andExpect(status().is3xxRedirection());
+
+            Map<String, Object> row = jdbcTemplate.queryForMap(
+                "SELECT actor_user_id, target_id, details::text AS details FROM audit_event "
+                    + "WHERE event_type = 'password_reset_ott_issued' AND tenant_id = ? "
+                    + "ORDER BY occurred_at DESC LIMIT 1",
+                tenant.id());
+            assertThat(row.get("actor_user_id")).isEqualTo(user.id());
+            assertThat(row.get("target_id")).isEqualTo(String.valueOf(user.id()));
+            String details = row.get("details").toString().replace(" ", "");
+            assertThat(details).contains("\"delivered\":true");
+            assertThat(details).contains(email);
+        }
+
+        @Test
+        @DisplayName("Forgot-password for an unknown email writes password_reset_ott_issued with delivered=false and null actor")
+        void unknownEmailAuditsAsUndelivered() throws Exception {
+            String suffix = uniqueSuffix();
+            String slug = "auditx-" + suffix;
+            Tenant tenant = tenantProvisioningService.createTenant(slug, "AuditX " + suffix);
+
+            mockMvc.perform(post("/t/" + slug + "/forgot-password")
+                    .param("email", "ghost-" + suffix + "@example.test").with(csrf()))
+                .andExpect(status().is3xxRedirection());
+
+            Map<String, Object> row = jdbcTemplate.queryForMap(
+                "SELECT actor_user_id, target_id, details::text AS details FROM audit_event "
+                    + "WHERE event_type = 'password_reset_ott_issued' AND tenant_id = ? "
+                    + "ORDER BY occurred_at DESC LIMIT 1",
+                tenant.id());
+            assertThat(row.get("actor_user_id")).isNull();
+            assertThat(row.get("target_id")).isNull();
+            assertThat(row.get("details").toString().replace(" ", ""))
+                .contains("\"delivered\":false");
+        }
+    }
+
+    // --- helpers ---
+
+    private static String uniqueSuffix() {
+        return UUID.randomUUID().toString().substring(0, 8);
+    }
+
+    private User activeUser(Long tenantId, String email) {
+        // (id, tenantId, email, passwordHash, enabled, mustChangePassword,
+        //  emailVerified, tenantOwner, createdAt). Verified=true here so the
+        //  reset-flow tests focus on the reset path itself, not the verify-email
+        //  side effect (covered separately in TenantOttAuthenticationProviderTest).
+        return new User(
+            null, tenantId, email,
+            passwordEncoder.encode("old-secret"),
+            true, false, true, false, LocalDateTime.now());
+    }
+
+    private static String stripEmail(String url) {
+        return url.replaceAll("(\\?|&)email=[^&]*", "");
+    }
+}

--- a/src/test/java/com/stucray/limen/ui/journey/PasswordResetJourneyUiIT.java
+++ b/src/test/java/com/stucray/limen/ui/journey/PasswordResetJourneyUiIT.java
@@ -1,0 +1,149 @@
+package com.stucray.limen.ui.journey;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.playwright.Page;
+import com.stucray.limen.TestcontainersConfiguration;
+import com.stucray.limen.email.MailpitContainer;
+import com.stucray.limen.email.MailpitTestConfiguration;
+import com.stucray.limen.ui.pages.ForgotPasswordPage;
+import com.stucray.limen.ui.support.PlaywrightExtension;
+import com.stucray.limen.ui.support.TestTenantFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.client.RestClient;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Playwright UI journey for slice 5: an existing tenant admin clicks "Forgot
+ * password?", asks for a reset, retrieves the magic link from Mailpit, sets a
+ * new password, and verifies the new password works.
+ *
+ * <p>Activates the {@code test} profile so {@code limen.email.driver=smtp}
+ * routes mail through {@link com.stucray.limen.email.SmtpEmailSender} into
+ * Mailpit, mirroring {@link EmailVerificationJourneyUiIT}.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import({TestcontainersConfiguration.class, MailpitTestConfiguration.class})
+@ActiveProfiles("test")
+@ExtendWith(PlaywrightExtension.class)
+@DisplayName("Forgot-password journey: existing user requests reset, retrieves Mailpit link, sets a new password, signs in with it")
+class PasswordResetJourneyUiIT {
+
+    private static final Pattern MAGIC_LINK_PATTERN =
+        Pattern.compile("(/t/[^/]+/login/ott\\?token=[A-Fa-f0-9-]+)");
+
+    @LocalServerPort int port;
+    @Autowired MailpitContainer mailpit;
+    @Autowired JdbcTemplate jdbcTemplate;
+    @Autowired TestTenantFactory tenantFactory;
+    @Autowired PasswordEncoder passwordEncoder;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("happy path: login → forgot-password → Mailpit reset link → change-password → re-login with new password")
+    void happyPath(Page page) throws Exception {
+        TestTenantFactory.SeededTenant tenant = tenantFactory.createTenant();
+        String slug = tenant.slug();
+        String email = tenant.adminEmail();
+        String oldPassword = tenant.adminPassword();
+        String newPassword = "fresh-secret-" + System.nanoTime();
+
+        // Land on the login page and click the new "Forgot your password?" link.
+        page.navigate(baseUrl() + "/t/" + slug + "/login");
+        page.getByTestId("forgot-password-link").click();
+        page.waitForURL(baseUrl() + "/t/" + slug + "/forgot-password");
+
+        new ForgotPasswordPage(page, baseUrl(), slug)
+            .assertHeading()
+            .fillEmail(email)
+            .submit();
+
+        // Mailpit catches the reset email; pull the magic link.
+        String magicPath = waitForResetLink(email);
+        assertThat(magicPath).startsWith("/t/" + slug + "/login/ott?token=");
+
+        // Click the link → ott-submit page → POST → routed through change-password.
+        page.navigate(baseUrl() + magicPath);
+        page.getByTestId("ott-submit").click();
+        page.waitForURL(baseUrl() + "/t/" + slug + "/change-password");
+
+        // Set the new password.
+        page.getByLabel("New password").fill(newPassword);
+        page.getByLabel("Confirm password").fill(newPassword);
+        page.getByTestId("change-password-submit").click();
+        page.waitForURL(baseUrl() + "/t/" + slug + "/");
+
+        // Sanity: the stored hash matches the new password, not the old one.
+        String storedHash = jdbcTemplate.queryForObject(
+            "SELECT password_hash FROM users WHERE email = ?",
+            String.class, email);
+        assertThat(passwordEncoder.matches(newPassword, storedHash)).isTrue();
+        assertThat(passwordEncoder.matches(oldPassword, storedHash)).isFalse();
+
+        // Sign back in with the new password — log out first to clear the
+        // post-OTT session before exercising form login.
+        page.context().clearCookies();
+        page.navigate(baseUrl() + "/t/" + slug + "/login");
+        page.getByLabel("Email").fill(email);
+        page.getByLabel("Password").fill(newPassword);
+        page.getByTestId("login-submit").click();
+        page.waitForURL(baseUrl() + "/t/" + slug + "/");
+
+        // The completed reset emitted password_reset_completed; confirm the
+        // audit row landed alongside the password_changed row.
+        Long count = jdbcTemplate.queryForObject(
+            "SELECT count(*) FROM audit_event "
+                + "WHERE event_type = 'password_reset_completed' "
+                + "AND tenant_id = ?",
+            Long.class, tenant.tenantId());
+        assertThat(count).isEqualTo(1L);
+    }
+
+    private String waitForResetLink(String recipientEmail) throws Exception {
+        RestClient restClient = RestClient.create(mailpit.httpApiBaseUrl());
+        long deadline = System.currentTimeMillis() + 15_000;
+        while (System.currentTimeMillis() < deadline) {
+            JsonNode messages = objectMapper.readTree(
+                restClient.get().uri("/api/v1/messages?limit=50").retrieve().body(String.class));
+            for (JsonNode m : messages.path("messages")) {
+                JsonNode toArray = m.path("To");
+                if (toArray.isArray() && toArray.size() > 0
+                    && recipientEmail.equals(toArray.get(0).path("Address").asText())) {
+                    String id = m.get("ID").asText();
+                    JsonNode full = objectMapper.readTree(
+                        restClient.get().uri("/api/v1/message/{id}", id).retrieve().body(String.class));
+                    String text = full.path("Text").asText();
+                    // The reset email body is distinctive; double-check we
+                    // didn't pick up a verify-email message left over from a
+                    // previous test in the same Mailpit container.
+                    if (!text.contains("password-reset request")) {
+                        continue;
+                    }
+                    Matcher matcher = MAGIC_LINK_PATTERN.matcher(text);
+                    if (matcher.find()) {
+                        return matcher.group(1);
+                    }
+                }
+            }
+            Thread.sleep(150);
+        }
+        throw new AssertionError("Timed out waiting for password-reset email to " + recipientEmail);
+    }
+
+    private String baseUrl() {
+        return "http://localhost:" + port;
+    }
+}

--- a/src/test/java/com/stucray/limen/ui/pages/ForgotPasswordPage.java
+++ b/src/test/java/com/stucray/limen/ui/pages/ForgotPasswordPage.java
@@ -1,0 +1,36 @@
+package com.stucray.limen.ui.pages;
+
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.assertions.PlaywrightAssertions;
+import com.microsoft.playwright.options.AriaRole;
+
+public final class ForgotPasswordPage {
+
+    private final Page page;
+    private final String baseUrl;
+    private final String slug;
+
+    public ForgotPasswordPage(Page page, String baseUrl, String slug) {
+        this.page = page;
+        this.baseUrl = baseUrl;
+        this.slug = slug;
+    }
+
+    public ForgotPasswordPage assertHeading() {
+        PlaywrightAssertions.assertThat(
+            page.getByRole(AriaRole.HEADING, new Page.GetByRoleOptions().setName("Reset your password"))
+        ).isVisible();
+        return this;
+    }
+
+    public ForgotPasswordPage fillEmail(String email) {
+        page.getByLabel("Email").fill(email);
+        return this;
+    }
+
+    public CheckInboxPage submit() {
+        page.getByTestId("forgot-password-submit").click();
+        page.waitForURL("**/t/" + slug + "/check-inbox**");
+        return new CheckInboxPage(page, baseUrl, slug);
+    }
+}


### PR DESCRIPTION
Closes #126 (slice 5 of PRD #120).

## Summary

- New `/t/{slug}/forgot-password` form (GET + POST). The submit response is identical for known and unknown emails — same redirect path, same `flow=password-reset` query parameter — so the form is not a user-existence oracle (PRD #120 user story 14). The shared `/t/{slug}/check-inbox` page now branches its copy on `flow`.
- `PasswordResetService` issues a `password-reset` OTT and dispatches via the existing `OttEmailNotifier.sendPasswordReset`. The OTT substrate, schema, and email pipeline are reused verbatim from slice 4.
- `TenantOttAuthenticationProvider` on a `password-reset` consume now also flips `email_verified=true` (clicking a link delivered to the address proves control of it, the same proof the verify-email flow accepts) and sets a session breadcrumb (`PasswordResetSessionMarker`).
- New `PostLoginIntent.passwordChangeAfterReset()` reads the marker and routes to `/t/{slug}/change-password` ahead of `resumeOAuth2Authorize()`. `TenantPasswordChangeFlow` clears the marker on a successful submission and emits `PasswordResetCompletedEvent` so a vanilla self-service password change does not masquerade as a reset.
- Audit gains `password_reset_ott_issued` (with `delivered` + nullable user, mirroring `verification_resent`) and `password_reset_completed` listeners.
- Login template gains a "Forgot your password?" link.

## Test plan

- [x] `PasswordResetFlowIntegrationTest` — known-vs-unknown identical response (no oracle), OTT consume routes through change-password, marker cleared + completion event emitted, single-use enforcement, expiry rejection, audit-row shape for both delivered/undelivered cases
- [x] `PasswordResetJourneyUiIT` (Playwright + Mailpit) — end-to-end: forgot-password → reset email → magic link → change-password → re-login with new password
- [x] `PostLoginIntentsUnitTest` — three new cases for `passwordChangeAfterReset` (marker present / no session / session without marker)
- [x] `mvn verify` — all 104 surefire + 27 failsafe suites green

🤖 Generated with [Claude Code](https://claude.com/claude-code)