### PR TITLE
feat: Bucket4j in-memory rate limiting (RateLimitFilter) (#128)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,19 @@
 			<artifactId>spring-boot-starter-mail</artifactId>
 		</dependency>
 
+		<!--
+			In-memory token-bucket rate limiting for pre-auth endpoints
+			(/oauth2/token, /signup, /forgot-password). Pure bucket4j-core only
+			— not the spring-boot-starter (we wire the filter ourselves) and not
+			bucket4j-postgresql (state lives in a per-process ConcurrentHashMap;
+			a Postgres-backed swap is the v3.5 horizontal-scale story).
+		-->
+		<dependency>
+			<groupId>com.bucket4j</groupId>
+			<artifactId>bucket4j-core</artifactId>
+			<version>8.10.1</version>
+		</dependency>
+
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
@@ -190,6 +203,16 @@
 					<environmentVariables>
 						<LIMEN_SECURITY_KEK>dGVzdC1rZWstdGVzdC1rZWstdGVzdC1rZWstdGVzdC0=</LIMEN_SECURITY_KEK>
 					</environmentVariables>
+					<!--
+						Default-off: every unit/integration test shares the
+						127.0.0.1 client IP, so production-shaped buckets
+						(capacity 10/hour for /signup) would 429-out other
+						tests. RateLimitFilterIntegrationTest re-enables via
+						@TestPropertySource with shrunken limits.
+					-->
+					<systemPropertyVariables>
+						<limen.rate-limit.enabled>false</limen.rate-limit.enabled>
+					</systemPropertyVariables>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -203,6 +226,10 @@
 					<environmentVariables>
 						<LIMEN_SECURITY_KEK>dGVzdC1rZWstdGVzdC1rZWstdGVzdC1rZWstdGVzdC0=</LIMEN_SECURITY_KEK>
 					</environmentVariables>
+					<!-- Same rationale as surefire above. -->
+					<systemPropertyVariables>
+						<limen.rate-limit.enabled>false</limen.rate-limit.enabled>
+					</systemPropertyVariables>
 				</configuration>
 				<executions>
 					<execution>

--- a/src/main/java/com/stucray/limen/audit/AuditEventListener.java
+++ b/src/main/java/com/stucray/limen/audit/AuditEventListener.java
@@ -7,6 +7,7 @@ import com.stucray.limen.audit.events.EmailVerifiedEvent;
 import com.stucray.limen.audit.events.PasswordChangedEvent;
 import com.stucray.limen.audit.events.PasswordResetCompletedEvent;
 import com.stucray.limen.audit.events.PasswordResetOttIssuedEvent;
+import com.stucray.limen.audit.events.RateLimitHitEvent;
 import com.stucray.limen.audit.events.TenantCreatedEvent;
 import com.stucray.limen.audit.events.TenantDeletedEvent;
 import com.stucray.limen.audit.events.TenantSuspendedEvent;
@@ -252,6 +253,25 @@ public class AuditEventListener {
             currentIp(), currentUserAgent(),
             LocalDateTime.now(ZoneId.systemDefault()),
             Map.of()));
+    }
+
+    @EventListener
+    public void onRateLimitHit(RateLimitHitEvent event) {
+        Map<String, Object> details = new HashMap<>();
+        details.put("ruleId", event.ruleId());
+        if (event.key() != null) {
+            details.put("key", event.key());
+        }
+        details.put("path", event.path());
+        details.put("method", event.method());
+        details.put("retryAfterSeconds", event.retryAfterSeconds());
+        safeWrite(new AuditEvent(
+            null, null, null,
+            "rate_limit_hit",
+            null, null,
+            event.ip(), currentUserAgent(),
+            LocalDateTime.now(ZoneId.systemDefault()),
+            details));
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)

--- a/src/main/java/com/stucray/limen/audit/events/RateLimitHitEvent.java
+++ b/src/main/java/com/stucray/limen/audit/events/RateLimitHitEvent.java
@@ -1,0 +1,26 @@
+package com.stucray.limen.audit.events;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A pre-auth request was rejected with HTTP 429 because its bucket was empty.
+ * Emitted by {@code RateLimitFilter} immediately before writing the response.
+ *
+ * <p>Pre-auth means the rate-limited request never reaches a controller and
+ * never opens a database transaction — emit uses a plain
+ * {@link org.springframework.context.event.EventListener} (the audit listener
+ * picks the matching annotation automatically), not a transactional one.
+ *
+ * <p>{@code key} is the value the filter rule extracted from the request
+ * (an IP address, an OAuth client_id, or {@code "anonymous"} when a per-client
+ * rule fired on a request without identifiable client credentials). It is
+ * captured for diagnostic value, not joined back to any other table.
+ */
+public record RateLimitHitEvent(
+    String ruleId,
+    @Nullable String key,
+    String path,
+    String method,
+    @Nullable String ip,
+    long retryAfterSeconds
+) {}

--- a/src/main/java/com/stucray/limen/security/ratelimit/RateLimitFilter.java
+++ b/src/main/java/com/stucray/limen/security/ratelimit/RateLimitFilter.java
@@ -1,0 +1,195 @@
+package com.stucray.limen.security.ratelimit;
+
+import com.stucray.limen.audit.events.RateLimitHitEvent;
+import com.stucray.limen.security.ratelimit.RateLimitProperties.KeyType;
+import com.stucray.limen.security.ratelimit.RateLimitProperties.RuleSpec;
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.ConsumptionProbe;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.jspecify.annotations.Nullable;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+
+/**
+ * High-precedence servlet filter that token-bucket-limits pre-auth surfaces
+ * (see {@link RateLimitProperties} for the configured rules). On bucket-empty
+ * the response is HTTP 429 with a {@code Retry-After} header (seconds until
+ * the next refill) and a {@link RateLimitHitEvent} is published so the audit
+ * module records the event.
+ *
+ * <p>Order is {@link Ordered#HIGHEST_PRECEDENCE} so that throttled requests
+ * never reach the routing or security filter chains — there is no point doing
+ * tenant resolution or session lookup for a request we are about to reject.
+ *
+ * <p>Bucket state is a {@link ConcurrentHashMap} keyed on {@code (ruleId,
+ * extractedKey)} — see class javadoc on {@link RateLimitProperties} for the
+ * scaling story. {@link OncePerRequestFilter} guarantees we evaluate each
+ * rule exactly once per request even if the request is forwarded.
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class RateLimitFilter extends OncePerRequestFilter {
+
+    private final RateLimitProperties properties;
+    private final ApplicationEventPublisher publisher;
+    private final List<CompiledRule> compiledRules;
+    private final ConcurrentHashMap<RuleKey, Bucket> buckets = new ConcurrentHashMap<>();
+
+    public RateLimitFilter(RateLimitProperties properties, ApplicationEventPublisher publisher) {
+        this.properties = properties;
+        this.publisher = publisher;
+        this.compiledRules = properties.rules().entrySet().stream()
+            .map(e -> CompiledRule.of(e.getKey(), e.getValue()))
+            .toList();
+    }
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request, HttpServletResponse response, FilterChain chain
+    ) throws ServletException, IOException {
+        if (!properties.enabled() || compiledRules.isEmpty()) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        String path = request.getRequestURI();
+        for (CompiledRule rule : compiledRules) {
+            if (!rule.matches(path)) {
+                continue;
+            }
+            String key = rule.extractKey(request);
+            Bucket bucket = buckets.computeIfAbsent(
+                new RuleKey(rule.id(), key),
+                k -> rule.newBucket()
+            );
+            ConsumptionProbe probe = bucket.tryConsumeAndReturnRemaining(1);
+            if (!probe.isConsumed()) {
+                long retryAfter = retryAfterSeconds(probe.getNanosToWaitForRefill());
+                response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+                response.setHeader(HttpHeaders.RETRY_AFTER, Long.toString(retryAfter));
+                publisher.publishEvent(new RateLimitHitEvent(
+                    rule.id(), key, path, request.getMethod(),
+                    request.getRemoteAddr(), retryAfter));
+                return;
+            }
+        }
+        chain.doFilter(request, response);
+    }
+
+    /**
+     * Visible for tests: drop all per-key bucket state. Production callers
+     * should never invoke this — it would let throttled clients bypass the
+     * remaining wait of any in-flight bucket. Tests use it to keep one
+     * scenario from polluting the next within a single Spring context.
+     */
+    public void resetBucketsForTesting() {
+        buckets.clear();
+    }
+
+    private static long retryAfterSeconds(long nanosToWait) {
+        // Round up so a probe of "wait 1.2 seconds" yields Retry-After: 2;
+        // returning 1 would tell the client to retry before the next refill.
+        long whole = nanosToWait / 1_000_000_000L;
+        return nanosToWait % 1_000_000_000L == 0 ? whole : whole + 1;
+    }
+
+    private record RuleKey(String ruleId, String extractedKey) {}
+
+    private record CompiledRule(
+        String id,
+        Pattern pathPattern,
+        KeyType keyType,
+        long capacity,
+        long refillTokens,
+        java.time.Duration refillPeriod
+    ) {
+        static CompiledRule of(String id, RuleSpec spec) {
+            return new CompiledRule(
+                id,
+                Pattern.compile(spec.pathPattern()),
+                spec.key(),
+                spec.capacity(),
+                spec.refillTokens(),
+                spec.refillPeriod()
+            );
+        }
+
+        boolean matches(String path) {
+            return pathPattern.matcher(path).matches();
+        }
+
+        String extractKey(HttpServletRequest request) {
+            return switch (keyType) {
+                case IP -> nullToFallback(request.getRemoteAddr(), "unknown-ip");
+                case CLIENT_ID -> extractClientId(request);
+            };
+        }
+
+        Bucket newBucket() {
+            Bandwidth limit = Bandwidth.builder()
+                .capacity(capacity)
+                .refillGreedy(refillTokens, refillPeriod)
+                .build();
+            return Bucket.builder().addLimit(limit).build();
+        }
+
+        private static String extractClientId(HttpServletRequest request) {
+            // Form-post client auth (client_secret_post) carries client_id as a
+            // form parameter; servlet container parses + caches it on first
+            // read, so SAS still sees the same value downstream.
+            String fromForm = request.getParameter("client_id");
+            if (fromForm != null && !fromForm.isBlank()) {
+                return fromForm;
+            }
+            // HTTP Basic client auth (client_secret_basic) carries client_id as
+            // the basic-auth username.
+            String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+            String fromBasic = clientIdFromBasicAuth(authHeader);
+            if (fromBasic != null) {
+                return fromBasic;
+            }
+            // No identifiable client — bucket all anonymous attempts together
+            // so a flood of unauthenticated token-endpoint hits still trips
+            // the per-client rule (in addition to the per-IP rule).
+            return "anonymous";
+        }
+
+        private static @Nullable String clientIdFromBasicAuth(@Nullable String authHeader) {
+            if (authHeader == null || !authHeader.regionMatches(true, 0, "Basic ", 0, 6)) {
+                return null;
+            }
+            try {
+                byte[] decoded = Base64.getDecoder().decode(authHeader.substring(6).trim());
+                String credentials = new String(decoded, java.nio.charset.StandardCharsets.UTF_8);
+                int colon = credentials.indexOf(':');
+                if (colon <= 0) {
+                    return null;
+                }
+                String clientId = credentials.substring(0, colon);
+                return clientId.isBlank() ? null : clientId;
+            } catch (IllegalArgumentException malformedBase64) {
+                return null;
+            }
+        }
+
+        private static String nullToFallback(@Nullable String value, String fallback) {
+            return value == null ? fallback : value;
+        }
+    }
+}

--- a/src/main/java/com/stucray/limen/security/ratelimit/RateLimitProperties.java
+++ b/src/main/java/com/stucray/limen/security/ratelimit/RateLimitProperties.java
@@ -1,0 +1,51 @@
+package com.stucray.limen.security.ratelimit;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import java.time.Duration;
+import java.util.Map;
+
+/**
+ * Configuration shape for {@link RateLimitFilter}. Each entry in {@code rules}
+ * is one (path-matcher, key-extractor, bucket-spec) tuple. Multiple rules can
+ * target the same path — the filter consumes a token from each matching
+ * bucket, so a request must pass them all.
+ *
+ * <p>State is per-process (a {@link java.util.concurrent.ConcurrentHashMap} of
+ * buckets keyed on rule-id + extracted key). Postgres-backed shared state is
+ * the v3.5 horizontal-scale story.
+ */
+@ConfigurationProperties("limen.rate-limit")
+@Validated
+public record RateLimitProperties(
+    boolean enabled,
+    @Valid Map<String, RuleSpec> rules
+) {
+
+    public RateLimitProperties {
+        rules = rules == null ? Map.of() : Map.copyOf(rules);
+    }
+
+    /**
+     * One rate-limit rule. {@code pathPattern} is a Java regex matched against
+     * the raw request URI (see {@link jakarta.servlet.http.HttpServletRequest#getRequestURI()}),
+     * so tenant-prefixed routes need an optional {@code (/t/[^/]+)?} segment.
+     * {@code capacity} is the bucket depth; {@code refillTokens} per
+     * {@code refillPeriod} sets the steady-state allowance via Bucket4j's
+     * {@code Refill.greedy} (continuous, fractional refill).
+     */
+    public record RuleSpec(
+        @NotBlank String pathPattern,
+        @NotNull KeyType key,
+        @Positive long capacity,
+        @Positive long refillTokens,
+        @NotNull Duration refillPeriod
+    ) {}
+
+    public enum KeyType { IP, CLIENT_ID }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -17,6 +17,45 @@ limen:
     # How long the lock holds; admins can short-circuit via the user-detail
     # "Unlock account" button on /manage/t/{slug}/users/{userId}.
     window: 15m
+  rate-limit:
+    # Token-bucket throttling on pre-auth endpoints (RateLimitFilter). Disable
+    # in test profiles that load the full context but want to exercise floods
+    # without 429s by setting enabled=false.
+    enabled: true
+    rules:
+      # /oauth2/token, both bare and tenant-prefixed forms. Per-client and
+      # per-IP rules both fire — a request must pass both. Capacity 60 /
+      # 1-min refill ≈ 1 req/sec sustained, 60-burst absorbed.
+      oauth2-token-per-client:
+        path-pattern: "(/t/[^/]+)?/oauth2/token"
+        key: client-id
+        capacity: 60
+        refill-tokens: 60
+        refill-period: 1m
+      oauth2-token-per-ip:
+        path-pattern: "(/t/[^/]+)?/oauth2/token"
+        key: ip
+        capacity: 60
+        refill-tokens: 60
+        refill-period: 1m
+      # Public signup. Generous enough that a real user reloading the form a
+      # few times before submit has headroom; tight enough that scripted
+      # tenant-creation abuse trips fast.
+      signup-per-ip:
+        path-pattern: "/signup"
+        key: ip
+        capacity: 10
+        refill-tokens: 10
+        refill-period: 1h
+      # Forgot-password is tenant-scoped (/t/{slug}/forgot-password). Per-IP
+      # ceiling is the abuse-defence anchor; per-email rate-limiting is
+      # already handled by the OTT-issuance debounce in slice 5.
+      forgot-password-per-ip:
+        path-pattern: "/t/[^/]+/forgot-password"
+        key: ip
+        capacity: 10
+        refill-tokens: 10
+        refill-period: 1h
 spring:
   application:
     name: limen

--- a/src/test/java/com/stucray/limen/security/ratelimit/RateLimitFilterIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/security/ratelimit/RateLimitFilterIntegrationTest.java
@@ -1,0 +1,224 @@
+package com.stucray.limen.security.ratelimit;
+
+import com.stucray.limen.TestcontainersConfiguration;
+import com.stucray.limen.tenant.TenantProvisioningService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration tests for {@link RateLimitFilter}. Each rule under test is
+ * shrunk via {@link TestPropertySource} to a 2-token bucket with a 1-minute
+ * refill, so the third hit in a tight loop is the one we assert against.
+ *
+ * <p>{@link RateLimitFilter#resetBucketsForTesting()} is invoked in
+ * {@code @BeforeEach} so a leak from one test method does not preload the
+ * bucket for the next.
+ */
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+    "limen.rate-limit.enabled=true",
+    "limen.rate-limit.rules.signup-per-ip.path-pattern=/signup",
+    "limen.rate-limit.rules.signup-per-ip.key=ip",
+    "limen.rate-limit.rules.signup-per-ip.capacity=2",
+    "limen.rate-limit.rules.signup-per-ip.refill-tokens=2",
+    "limen.rate-limit.rules.signup-per-ip.refill-period=1m",
+    "limen.rate-limit.rules.forgot-password-per-ip.path-pattern=/t/[^/]+/forgot-password",
+    "limen.rate-limit.rules.forgot-password-per-ip.key=ip",
+    "limen.rate-limit.rules.forgot-password-per-ip.capacity=2",
+    "limen.rate-limit.rules.forgot-password-per-ip.refill-tokens=2",
+    "limen.rate-limit.rules.forgot-password-per-ip.refill-period=1m",
+    "limen.rate-limit.rules.oauth2-token-per-ip.path-pattern=(/t/[^/]+)?/oauth2/token",
+    "limen.rate-limit.rules.oauth2-token-per-ip.key=ip",
+    "limen.rate-limit.rules.oauth2-token-per-ip.capacity=2",
+    "limen.rate-limit.rules.oauth2-token-per-ip.refill-tokens=2",
+    "limen.rate-limit.rules.oauth2-token-per-ip.refill-period=1m",
+    "limen.rate-limit.rules.oauth2-token-per-client.path-pattern=(/t/[^/]+)?/oauth2/token",
+    "limen.rate-limit.rules.oauth2-token-per-client.key=client-id",
+    "limen.rate-limit.rules.oauth2-token-per-client.capacity=2",
+    "limen.rate-limit.rules.oauth2-token-per-client.refill-tokens=2",
+    "limen.rate-limit.rules.oauth2-token-per-client.refill-period=1m"
+})
+@DisplayName("RateLimitFilter throttles pre-auth surfaces and audits 429s")
+class RateLimitFilterIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired RateLimitFilter rateLimitFilter;
+    @Autowired JdbcTemplate jdbcTemplate;
+    @Autowired TenantProvisioningService tenantProvisioningService;
+
+    @BeforeEach
+    void resetBucketsAndAudit() {
+        rateLimitFilter.resetBucketsForTesting();
+        jdbcTemplate.execute("DELETE FROM audit_event WHERE event_type = 'rate_limit_hit'");
+        jdbcTemplate.execute(
+            "DELETE FROM users WHERE tenant_id IN (SELECT id FROM tenants WHERE slug != 'system')");
+        jdbcTemplate.execute("DELETE FROM tenants WHERE slug != 'system'");
+    }
+
+    @Nested
+    @DisplayName("/signup")
+    class Signup {
+
+        @Test
+        @DisplayName("Third POST exceeds capacity=2 and is rejected with 429 + Retry-After")
+        void thirdSignupHits429() throws Exception {
+            postSignup("acme-1").andExpect(noThrottle());
+            postSignup("acme-2").andExpect(noThrottle());
+
+            postSignup("acme-3")
+                .andExpect(status().isTooManyRequests())
+                .andExpect(header().exists(HttpHeaders.RETRY_AFTER))
+                .andExpect(result -> assertThat(
+                    Long.parseLong(result.getResponse().getHeader(HttpHeaders.RETRY_AFTER)))
+                    .isPositive());
+        }
+
+        @Test
+        @DisplayName("Sub-limit traffic (two POSTs) is not throttled")
+        void belowLimitIsNotThrottled() throws Exception {
+            postSignup("acme-a").andExpect(noThrottle());
+            postSignup("acme-b").andExpect(noThrottle());
+        }
+
+        private org.springframework.test.web.servlet.ResultActions postSignup(String slug) throws Exception {
+            return mockMvc.perform(post("/signup")
+                .param("organizationName", "Acme " + slug)
+                .param("slug", slug)
+                .param("email", slug + "@example.test")
+                .param("password", "secret123")
+                .with(csrf()));
+        }
+    }
+
+    @Nested
+    @DisplayName("/t/{slug}/forgot-password")
+    class ForgotPassword {
+
+        @Test
+        @DisplayName("Third POST exceeds capacity=2 and is rejected with 429 + Retry-After")
+        void thirdForgotPasswordHits429() throws Exception {
+            postForgotPassword().andExpect(noThrottle());
+            postForgotPassword().andExpect(noThrottle());
+
+            postForgotPassword()
+                .andExpect(status().isTooManyRequests())
+                .andExpect(header().exists(HttpHeaders.RETRY_AFTER));
+        }
+
+        private org.springframework.test.web.servlet.ResultActions postForgotPassword() throws Exception {
+            return mockMvc.perform(post("/t/" + uniqueSlug() + "/forgot-password")
+                .param("email", "user@example.test")
+                .with(csrf()));
+        }
+    }
+
+    @Nested
+    @DisplayName("/oauth2/token")
+    class OAuth2Token {
+
+        @Test
+        @DisplayName("Third POST per IP exceeds capacity=2 and is rejected with 429")
+        void thirdTokenRequestHits429() throws Exception {
+            postToken().andExpect(noThrottle());
+            postToken().andExpect(noThrottle());
+
+            postToken()
+                .andExpect(status().isTooManyRequests())
+                .andExpect(header().exists(HttpHeaders.RETRY_AFTER));
+        }
+
+        private org.springframework.test.web.servlet.ResultActions postToken() throws Exception {
+            return mockMvc.perform(post("/oauth2/token")
+                .param("grant_type", "client_credentials")
+                .with(csrf()));
+        }
+    }
+
+    @Nested
+    @DisplayName("audit emit")
+    class Audit {
+
+        @Test
+        @DisplayName("A 429 hit publishes RateLimitHitEvent and writes exactly one audit_event row")
+        void rateLimitHitProducesExactlyOneAuditRow() throws Exception {
+            // Burn the bucket and capture the rejection.
+            mockMvc.perform(post("/signup")
+                .param("organizationName", "X").param("slug", "x-1")
+                .param("email", "x1@example.test").param("password", "secret123")
+                .with(csrf()));
+            mockMvc.perform(post("/signup")
+                .param("organizationName", "X").param("slug", "x-2")
+                .param("email", "x2@example.test").param("password", "secret123")
+                .with(csrf()));
+            mockMvc.perform(post("/signup")
+                .param("organizationName", "X").param("slug", "x-3")
+                .param("email", "x3@example.test").param("password", "secret123")
+                .with(csrf()))
+                .andExpect(status().isTooManyRequests());
+
+            Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM audit_event WHERE event_type = 'rate_limit_hit'",
+                Integer.class);
+            assertThat(count).isEqualTo(1);
+
+            // Postgres jsonb text-rendering inserts a space after ':' on read,
+            // so we cast to ->>'<key>' for an unambiguous string comparison.
+            String ruleId = jdbcTemplate.queryForObject(
+                "SELECT details->>'ruleId' FROM audit_event WHERE event_type = 'rate_limit_hit'",
+                String.class);
+            String path = jdbcTemplate.queryForObject(
+                "SELECT details->>'path' FROM audit_event WHERE event_type = 'rate_limit_hit'",
+                String.class);
+            String method = jdbcTemplate.queryForObject(
+                "SELECT details->>'method' FROM audit_event WHERE event_type = 'rate_limit_hit'",
+                String.class);
+            assertThat(ruleId).isEqualTo("signup-per-ip");
+            assertThat(path).isEqualTo("/signup");
+            assertThat(method).isEqualTo("POST");
+        }
+
+        @Test
+        @DisplayName("Sub-limit traffic writes no rate_limit_hit rows")
+        void belowLimitProducesNoAuditRows() throws Exception {
+            mockMvc.perform(post("/signup")
+                .param("organizationName", "Y").param("slug", "y-1")
+                .param("email", "y1@example.test").param("password", "secret123")
+                .with(csrf()));
+
+            Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM audit_event WHERE event_type = 'rate_limit_hit'",
+                Integer.class);
+            assertThat(count).isZero();
+        }
+    }
+
+    private static String uniqueSlug() {
+        return "fp-" + UUID.randomUUID().toString().substring(0, 8);
+    }
+
+    private static org.springframework.test.web.servlet.ResultMatcher noThrottle() {
+        return result -> assertThat(result.getResponse().getStatus())
+            .as("should not be throttled (got %d)", result.getResponse().getStatus())
+            .isNotEqualTo(429);
+    }
+}


### PR DESCRIPTION
Closes #128 — PRD #120 slice 7.

## Summary

- High-precedence servlet filter `RateLimitFilter` token-buckets the three pre-auth endpoints account-lockout doesn't cover: `/oauth2/token` (per-client + per-IP), `/signup` (per-IP), `/forgot-password` (per-IP).
- Empty bucket → HTTP 429 + `Retry-After` (seconds until next refill) + `RateLimitHitEvent` published through `ApplicationEventPublisher`; the audit module already holds the listener wiring pattern, so a new `@EventListener` in `AuditEventListener` writes a `rate_limit_hit` row.
- Pure `bucket4j-core` 8.10.1 — not the spring-boot starter and not `bucket4j-postgresql`. State is a per-process `ConcurrentHashMap<RuleKey, Bucket>`. Postgres-backed shared state stays a v3.5 horizontal-scale deferred (architecture doc §6).
- Rules are configuration-shaped (`limen.rate-limit.rules.<id>` with `path-pattern`, `key`, `capacity`, `refill-tokens`, `refill-period`) so operators can tune or add buckets without code changes.

## Production defaults

| Rule | Path | Key | Capacity | Refill |
|---|---|---|---|---|
| oauth2-token-per-client | `(/t/[^/]+)?/oauth2/token` | client-id (form param or basic-auth username, falls back to `anonymous`) | 60 | 60 / 1m |
| oauth2-token-per-ip | `(/t/[^/]+)?/oauth2/token` | ip | 60 | 60 / 1m |
| signup-per-ip | `/signup` | ip | 10 | 10 / 1h |
| forgot-password-per-ip | `/t/[^/]+/forgot-password` | ip | 10 | 10 / 1h |

## Test infrastructure

`limen.rate-limit.enabled` is forced **off** in surefire/failsafe — every Spring Boot integration test shares `127.0.0.1` against the same in-process buckets, so production-shaped limits would 429-out unrelated tests in long-running classes (`SignupIntegrationTest` proved this). `RateLimitFilterIntegrationTest` re-enables via `@TestPropertySource` with `capacity=2` so each scenario asserts on the third request.

## Test plan
- [x] All 6 `RateLimitFilterIntegrationTest` cases green: 429 on third hit + `Retry-After` for `/signup`, `/t/{slug}/forgot-password`, `/oauth2/token`; sub-limit traffic not throttled; 429 emits exactly one `audit_event` row with `rule_id`/`path`/`method` populated; sub-limit traffic emits zero audit rows.
- [x] Full `mvn verify` green: 342 unit/integration tests + 14 UI tests, 0 failures.
- [x] No regressions in pre-existing `SignupIntegrationTest`, `LoginIntegrationTest`, OAuth2 / OTT / lockout flows after disabling-by-default the filter in tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)