### PR TITLE
feat: system-admin tenant-create UI (#129)

### DIFF
--- a/src/main/java/com/stucray/limen/management/signup/SignupService.java
+++ b/src/main/java/com/stucray/limen/management/signup/SignupService.java
@@ -1,17 +1,11 @@
 package com.stucray.limen.management.signup;
 
-import com.stucray.limen.auth.ott.EmailVerificationService;
-import com.stucray.limen.tenant.Tenant;
-import com.stucray.limen.tenant.TenantProvisioningService;
 import com.stucray.limen.tenant.TenantRepository;
-import com.stucray.limen.user.User;
-import com.stucray.limen.user.UserRepository;
-import org.springframework.security.crypto.password.PasswordEncoder;
+import com.stucray.limen.tenant.TenantUserBootstrap;
+import com.stucray.limen.tenant.TenantUserBootstrap.OwnerCredentials;
+import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -25,23 +19,14 @@ public class SignupService {
     );
 
     private final TenantRepository tenantRepository;
-    private final TenantProvisioningService tenantProvisioningService;
-    private final UserRepository userRepository;
-    private final PasswordEncoder passwordEncoder;
-    private final EmailVerificationService emailVerificationService;
+    private final TenantUserBootstrap tenantUserBootstrap;
 
     public SignupService(
         TenantRepository tenantRepository,
-        TenantProvisioningService tenantProvisioningService,
-        UserRepository userRepository,
-        PasswordEncoder passwordEncoder,
-        EmailVerificationService emailVerificationService
+        TenantUserBootstrap tenantUserBootstrap
     ) {
         this.tenantRepository = tenantRepository;
-        this.tenantProvisioningService = tenantProvisioningService;
-        this.userRepository = userRepository;
-        this.passwordEncoder = passwordEncoder;
-        this.emailVerificationService = emailVerificationService;
+        this.tenantUserBootstrap = tenantUserBootstrap;
     }
 
     public sealed interface SignupResult {
@@ -49,11 +34,40 @@ public class SignupService {
         record Error(String field, String message) implements SignupResult {}
     }
 
-    @Transactional
-    @SuppressWarnings("NullAway") // Spring Data convention: null id on insert; populated on save
     public SignupResult signup(SignupForm form) {
         String slug = form.slug() == null ? "" : form.slug().trim();
+        SignupResult.Error slugError = validateSlug(slug, tenantRepository);
+        if (slugError != null) {
+            return slugError;
+        }
 
+        String orgName = form.organizationName() == null ? "" : form.organizationName().trim();
+        if (orgName.isBlank()) {
+            return new SignupResult.Error("organizationName", "Organization name is required");
+        }
+
+        String email = form.email() == null ? "" : form.email().trim();
+        SignupResult.Error emailError = validateEmail(email);
+        if (emailError != null) {
+            return emailError;
+        }
+
+        if (form.password() == null || form.password().isBlank()) {
+            return new SignupResult.Error("password", "Password is required");
+        }
+
+        tenantUserBootstrap.bootstrap(
+            slug, orgName, email, new OwnerCredentials.Provided(form.password()));
+        return new SignupResult.Success(slug, email);
+    }
+
+    /**
+     * Slug-validation rules, exposed as a static helper so the system-admin
+     * tenant-create form can apply identical checks (PRD #120 acceptance:
+     * "Slug validation reuses the rules from {@code SignupService}").
+     * Returns null when the slug is acceptable.
+     */
+    public static SignupResult.@Nullable Error validateSlug(String slug, TenantRepository tenantRepository) {
         if (slug.length() < 3 || slug.length() > 48) {
             return new SignupResult.Error("slug", "Slug must be between 3 and 48 characters");
         }
@@ -66,13 +80,15 @@ public class SignupService {
         if (tenantRepository.existsBySlug(slug)) {
             return new SignupResult.Error("slug", "That slug is already taken");
         }
+        return null;
+    }
 
-        String orgName = form.organizationName() == null ? "" : form.organizationName().trim();
-        if (orgName.isBlank()) {
-            return new SignupResult.Error("organizationName", "Organization name is required");
-        }
-
-        String email = form.email() == null ? "" : form.email().trim();
+    /**
+     * Email-validation rules. Mirrors {@link #validateSlug} so the sysadmin
+     * tenant-create form gets the same length / format checks. Returns null
+     * when the email is acceptable.
+     */
+    public static SignupResult.@Nullable Error validateEmail(String email) {
         if (email.isBlank()) {
             return new SignupResult.Error("email", "Email is required");
         }
@@ -82,20 +98,6 @@ public class SignupService {
         if (!EMAIL_FORMAT.matcher(email).matches()) {
             return new SignupResult.Error("email", "Email must be a valid email address");
         }
-
-        if (form.password() == null || form.password().isBlank()) {
-            return new SignupResult.Error("password", "Password is required");
-        }
-
-        Tenant tenant = tenantProvisioningService.createTenant(slug, orgName);
-        User savedOwner = userRepository.save(new User(
-            null, tenant.id(), email,
-            Objects.requireNonNull(passwordEncoder.encode(form.password())),
-            true, false, true, false, LocalDateTime.now()
-        ));
-
-        emailVerificationService.issueVerification(tenant, savedOwner);
-
-        return new SignupResult.Success(slug, email);
+        return null;
     }
 }

--- a/src/main/java/com/stucray/limen/management/system/SystemAdminController.java
+++ b/src/main/java/com/stucray/limen/management/system/SystemAdminController.java
@@ -1,16 +1,22 @@
 package com.stucray.limen.management.system;
 
 import com.stucray.limen.auth.TenantUserDetails;
+import com.stucray.limen.management.signup.SignupService;
+import com.stucray.limen.management.signup.SignupService.SignupResult;
 import com.stucray.limen.tenant.Tenant;
 import com.stucray.limen.tenant.TenantProvisioningService;
 import com.stucray.limen.tenant.TenantRepository;
-import com.stucray.limen.user.UserRepository;
-import org.springframework.jdbc.core.JdbcTemplate;
+import com.stucray.limen.tenant.TenantUserBootstrap;
+import com.stucray.limen.tenant.TenantUserBootstrap.OwnerCredentials;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Controller
@@ -20,25 +26,67 @@ public class SystemAdminController {
 
     private final TenantRepository tenantRepository;
     private final TenantProvisioningService tenantProvisioningService;
-    private final UserRepository userRepository;
-    private final JdbcTemplate jdbcTemplate;
+    private final TenantUserBootstrap tenantUserBootstrap;
 
     public SystemAdminController(
         TenantRepository tenantRepository,
         TenantProvisioningService tenantProvisioningService,
-        UserRepository userRepository,
-        JdbcTemplate jdbcTemplate
+        TenantUserBootstrap tenantUserBootstrap
     ) {
         this.tenantRepository = tenantRepository;
         this.tenantProvisioningService = tenantProvisioningService;
-        this.userRepository = userRepository;
-        this.jdbcTemplate = jdbcTemplate;
+        this.tenantUserBootstrap = tenantUserBootstrap;
     }
 
     @GetMapping("/tenants")
     public String listTenants(Model model) {
         model.addAttribute("tenants", tenantRepository.findAll());
         return "manage/system/tenants";
+    }
+
+    @GetMapping("/tenants/new")
+    public String newTenantForm(Model model) {
+        if (!model.containsAttribute("form")) {
+            model.addAttribute("form", new TenantCreateForm("", "", ""));
+        }
+        return "manage/system/tenant-new";
+    }
+
+    @PostMapping("/tenants/new")
+    public String createTenant(
+        @RequestParam String slug,
+        @RequestParam String displayName,
+        @RequestParam String ownerEmail,
+        Model model,
+        RedirectAttributes redirectAttributes
+    ) {
+        String trimmedSlug = slug == null ? "" : slug.trim();
+        String trimmedName = displayName == null ? "" : displayName.trim();
+        String trimmedEmail = ownerEmail == null ? "" : ownerEmail.trim();
+        TenantCreateForm form = new TenantCreateForm(trimmedSlug, trimmedName, trimmedEmail);
+
+        SignupResult.Error slugError = SignupService.validateSlug(trimmedSlug, tenantRepository);
+        if (slugError != null) {
+            return renderFormWithError(model, form, slugError);
+        }
+        if (trimmedName.isBlank()) {
+            return renderFormWithError(model, form,
+                new SignupResult.Error("displayName", "Display name is required"));
+        }
+        SignupResult.Error emailError = SignupService.validateEmail(trimmedEmail);
+        if (emailError != null) {
+            // Helper reports the field as "email" (what /signup uses); this form's
+            // input is named "ownerEmail" so we rebind to the matching template key.
+            return renderFormWithError(model, form,
+                new SignupResult.Error("ownerEmail", emailError.message()));
+        }
+
+        Tenant tenant = tenantUserBootstrap.bootstrap(
+            trimmedSlug, trimmedName, trimmedEmail, new OwnerCredentials.GenerateRandom());
+        redirectAttributes.addFlashAttribute("successMessage",
+            "Created tenant " + tenant.slug() + ". A verification email has been sent to "
+                + trimmedEmail + ".");
+        return "redirect:/manage/system/tenants";
     }
 
     @PostMapping("/tenants/{tenantId}/suspend")
@@ -84,4 +132,15 @@ public class SystemAdminController {
         tenantProvisioningService.delete(tenant, principal.userId());
         return "redirect:/manage/system/tenants";
     }
+
+    private static String renderFormWithError(
+        Model model, TenantCreateForm form, SignupResult.Error error
+    ) {
+        model.addAttribute("form", form);
+        model.addAttribute("errorField", error.field());
+        model.addAttribute("errorMessage", error.message());
+        return "manage/system/tenant-new";
+    }
+
+    public record TenantCreateForm(String slug, String displayName, String ownerEmail) {}
 }

--- a/src/main/java/com/stucray/limen/tenant/TenantUserBootstrap.java
+++ b/src/main/java/com/stucray/limen/tenant/TenantUserBootstrap.java
@@ -1,0 +1,101 @@
+package com.stucray.limen.tenant;
+
+import com.stucray.limen.auth.ott.EmailVerificationService;
+import com.stucray.limen.user.User;
+import com.stucray.limen.user.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Single transactional entry point for "new tenant + new owner user + send
+ * verification email". Wraps the three steps so a failure in any of them
+ * rolls back the whole bootstrap — no orphan {@code tenants} row when OTT
+ * delivery throws, no orphan {@code users} row when seed-key generation does.
+ *
+ * <p>Two callers, one shape:
+ *
+ * <ul>
+ *   <li>{@code SignupService} — public {@code /signup} form. Owner picks
+ *       their own password; {@code mustChangePassword=false}.</li>
+ *   <li>{@code SystemAdminController} — sysadmin {@code /manage/system/tenants/new}
+ *       form. Owner is provisioned without a password they know; we generate
+ *       a high-entropy placeholder, set {@code mustChangePassword=true}, and
+ *       rely on the verification email + forced-change interceptor to walk
+ *       the new owner through setting one.</li>
+ * </ul>
+ *
+ * <p>Both paths produce the same downstream effects: {@code TenantCreatedEvent}
+ * (emitted by {@link TenantProvisioningService#createTenant}), an unverified
+ * owner user row, and a {@code VerificationOttIssuedEvent} (emitted by
+ * {@link EmailVerificationService#issueVerification}).
+ */
+@Service
+@Transactional
+public class TenantUserBootstrap {
+
+    private final TenantProvisioningService tenantProvisioningService;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final EmailVerificationService emailVerificationService;
+
+    public TenantUserBootstrap(
+        TenantProvisioningService tenantProvisioningService,
+        UserRepository userRepository,
+        PasswordEncoder passwordEncoder,
+        EmailVerificationService emailVerificationService
+    ) {
+        this.tenantProvisioningService = tenantProvisioningService;
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.emailVerificationService = emailVerificationService;
+    }
+
+    /**
+     * The owner credential supplied by the caller. Sealed so the bootstrap
+     * can pattern-match exhaustively on the two known modes; widening to a
+     * third (e.g. SSO-only owners) is a deliberate shape change at the call
+     * sites rather than a silent default.
+     */
+    public sealed interface OwnerCredentials {
+        /** Owner provided their own password (signup form). */
+        record Provided(String rawPassword) implements OwnerCredentials {}
+
+        /** Server generates a placeholder; owner sets a real one after verifying email. */
+        record GenerateRandom() implements OwnerCredentials {}
+    }
+
+    @SuppressWarnings("NullAway") // Spring Data convention: null id on insert; populated on save
+    public Tenant bootstrap(
+        String slug, String displayName, String ownerEmail, OwnerCredentials credentials
+    ) {
+        Tenant tenant = tenantProvisioningService.createTenant(slug, displayName);
+
+        String rawPassword = switch (credentials) {
+            case OwnerCredentials.Provided p -> p.rawPassword();
+            case OwnerCredentials.GenerateRandom g -> randomPlaceholderPassword();
+        };
+        boolean mustChangePassword = credentials instanceof OwnerCredentials.GenerateRandom;
+
+        User owner = userRepository.save(new User(
+            null, tenant.id(), ownerEmail,
+            Objects.requireNonNull(passwordEncoder.encode(rawPassword)),
+            true, mustChangePassword, true, false, LocalDateTime.now()
+        ));
+
+        emailVerificationService.issueVerification(tenant, owner);
+
+        return tenant;
+    }
+
+    private static String randomPlaceholderPassword() {
+        // Two concatenated UUIDs = ~256 bits of entropy. The owner never sees
+        // this — the verification flow + mustChangePassword interceptor force
+        // them through change-password before they can use the account.
+        return UUID.randomUUID() + UUID.randomUUID().toString();
+    }
+}

--- a/src/main/resources/templates/manage/system/tenant-new.html
+++ b/src/main/resources/templates/manage/system/tenant-new.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{fragments/layout-authed :: layout(~{::title}, ~{::main})}">
+<head><title>New tenant — System Admin</title></head>
+<body>
+<main class="container">
+    <ol class="breadcrumb" aria-label="breadcrumb">
+        <li><a th:href="@{/manage/t/system/}">Home</a></li>
+        <li><a th:href="@{/manage/system/tenants}">Tenants</a></li>
+        <li>New</li>
+    </ol>
+
+    <article class="card card--auth">
+        <hgroup>
+            <h1>Create a tenant</h1>
+            <p>Provisions a new tenant and sends a verification email to the owner. They set their own password after clicking the link.</p>
+        </hgroup>
+        <form method="post" th:action="@{/manage/system/tenants/new}" class="stack">
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+
+            <label>
+                Slug
+                <input type="text" name="slug" th:value="${form.slug()}"
+                       pattern="[a-z0-9][a-z0-9\-]{1,46}[a-z0-9]"
+                       autofocus required
+                       data-test-field="slug"/>
+                <small class="muted">Their management URL will be <code>/manage/t/{slug}/</code></small>
+                <span class="form-error" th:if="${errorField == 'slug'}" th:text="${errorMessage}"></span>
+            </label>
+
+            <label>
+                Display name
+                <input type="text" name="displayName" th:value="${form.displayName()}" required
+                       data-test-field="displayName"/>
+                <span class="form-error" th:if="${errorField == 'displayName'}" th:text="${errorMessage}"></span>
+            </label>
+
+            <label>
+                Owner email
+                <input type="email" name="ownerEmail" th:value="${form.ownerEmail()}" required
+                       data-test-field="ownerEmail"/>
+                <small class="muted">A verification link will be sent here. The owner sets a password after clicking it.</small>
+                <span class="form-error" th:if="${errorField == 'ownerEmail'}" th:text="${errorMessage}"></span>
+            </label>
+
+            <button type="submit" class="btn--block" data-test-action="tenant-create-submit">Create tenant</button>
+        </form>
+    </article>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/manage/system/tenants.html
+++ b/src/main/resources/templates/manage/system/tenants.html
@@ -13,6 +13,10 @@
         <p>Manage tenants across the system.</p>
     </hgroup>
 
+    <p class="actions">
+        <a class="btn--primary" th:href="@{/manage/system/tenants/new}" data-test-action="new-tenant">New tenant</a>
+    </p>
+
     <p class="form-error" th:if="${errorMessage}" th:text="${errorMessage}"></p>
     <p class="form-info" th:if="${successMessage}" th:text="${successMessage}"></p>
 

--- a/src/test/java/com/stucray/limen/management/system/SystemAdminTenantCreateIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/management/system/SystemAdminTenantCreateIntegrationTest.java
@@ -1,0 +1,165 @@
+package com.stucray.limen.management.system;
+
+import com.stucray.limen.TestcontainersConfiguration;
+import com.stucray.limen.tenant.Tenant;
+import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.tenant.TenantStatus;
+import com.stucray.limen.user.User;
+import com.stucray.limen.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@DisplayName("System admin: /manage/system/tenants/new — provision tenant + owner + verification email")
+class SystemAdminTenantCreateIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired TenantRepository tenantRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired PasswordEncoder passwordEncoder;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    MockHttpSession sysadminSession;
+    Tenant customerTenant;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        jdbcTemplate.execute("DELETE FROM client_membership");
+        jdbcTemplate.execute("DELETE FROM application_membership_role");
+        jdbcTemplate.execute("DELETE FROM application_membership");
+        jdbcTemplate.execute("DELETE FROM role");
+        jdbcTemplate.execute("DELETE FROM applications");
+        jdbcTemplate.execute(
+            "DELETE FROM users WHERE tenant_id IN (SELECT id FROM tenants WHERE slug != 'system')");
+        jdbcTemplate.execute("DELETE FROM tenants WHERE slug != 'system'");
+        jdbcTemplate.execute(
+            "DELETE FROM users WHERE tenant_id = (SELECT id FROM tenants WHERE slug = 'system')");
+
+        Tenant systemTenant = tenantRepository.findBySlug("system").orElseThrow();
+        userRepository.save(new User(
+            null, systemTenant.id(), "sysadmin@example.test",
+            passwordEncoder.encode("syspass"),
+            true, false, false, true, LocalDateTime.now()));
+
+        MvcResult login = mockMvc.perform(post("/manage/t/system/login")
+                .param("email", "sysadmin@example.test")
+                .param("password", "syspass")
+                .with(csrf()))
+            .andReturn();
+        sysadminSession = (MockHttpSession) login.getRequest().getSession(false);
+
+        customerTenant = tenantRepository.save(new Tenant(
+            null, "customer", "Customer", TenantStatus.ACTIVE, LocalDateTime.now()));
+    }
+
+    @Test
+    @DisplayName("GET /manage/system/tenants/new renders the form for a system admin")
+    void formRendersForSystemAdmin() throws Exception {
+        mockMvc.perform(get("/manage/system/tenants/new").session(sysadminSession))
+            .andExpect(status().isOk())
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("Create a tenant")));
+    }
+
+    @Test
+    @DisplayName("Successful POST creates the tenant + owner user (emailVerified=false, mustChangePassword=true) and redirects to the tenants list")
+    void successfulPostCreatesTenantAndOwner() throws Exception {
+        mockMvc.perform(post("/manage/system/tenants/new").session(sysadminSession)
+                .param("slug", "newco")
+                .param("displayName", "Newco Inc.")
+                .param("ownerEmail", "owner@newco.test")
+                .with(csrf()))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/manage/system/tenants"));
+
+        Tenant created = tenantRepository.findBySlug("newco").orElseThrow();
+        assertThat(created.displayName()).isEqualTo("Newco Inc.");
+        assertThat(created.status()).isEqualTo(TenantStatus.ACTIVE);
+
+        User owner = userRepository.findByEmailAndTenantId("owner@newco.test", created.id()).orElseThrow();
+        assertThat(owner.tenantOwner()).isTrue();
+        assertThat(owner.emailVerified()).isFalse();
+        assertThat(owner.mustChangePassword()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Reserved slug ('system') is rejected and the form re-renders with the reserved-slug message")
+    void reservedSlugReturnsFormError() throws Exception {
+        mockMvc.perform(post("/manage/system/tenants/new").session(sysadminSession)
+                .param("slug", "system")
+                .param("displayName", "X")
+                .param("ownerEmail", "x@example.test")
+                .with(csrf()))
+            .andExpect(status().isOk())
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("reserved")));
+    }
+
+    @Test
+    @DisplayName("Duplicate slug is rejected and the form re-renders with the already-taken message")
+    void duplicateSlugReturnsFormError() throws Exception {
+        mockMvc.perform(post("/manage/system/tenants/new").session(sysadminSession)
+                .param("slug", "customer")
+                .param("displayName", "X")
+                .param("ownerEmail", "x@example.test")
+                .with(csrf()))
+            .andExpect(status().isOk())
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("already taken")));
+    }
+
+    @Test
+    @DisplayName("Invalid email format is rejected")
+    void invalidEmailReturnsFormError() throws Exception {
+        mockMvc.perform(post("/manage/system/tenants/new").session(sysadminSession)
+                .param("slug", "fresh")
+                .param("displayName", "Fresh")
+                .param("ownerEmail", "not-an-email")
+                .with(csrf()))
+            .andExpect(status().isOk())
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("valid email address")));
+    }
+
+    @Test
+    @DisplayName("Tenant Owner (non-system-admin) gets 403 when accessing the form (read or write)")
+    void tenantOwnerIsForbidden() throws Exception {
+        userRepository.save(new User(
+            null, customerTenant.id(), "owner@customer.test",
+            passwordEncoder.encode("ownerpass"),
+            true, false, true, true, LocalDateTime.now()));
+
+        MvcResult ownerLogin = mockMvc.perform(post("/manage/t/customer/login")
+                .param("email", "owner@customer.test")
+                .param("password", "ownerpass")
+                .with(csrf()))
+            .andReturn();
+        MockHttpSession ownerSession = (MockHttpSession) ownerLogin.getRequest().getSession(false);
+
+        mockMvc.perform(get("/manage/system/tenants/new").session(ownerSession))
+            .andExpect(status().isForbidden());
+
+        mockMvc.perform(post("/manage/system/tenants/new").session(ownerSession)
+                .param("slug", "x").param("displayName", "X").param("ownerEmail", "x@example.test")
+                .with(csrf()))
+            .andExpect(status().isForbidden());
+    }
+}

--- a/src/test/java/com/stucray/limen/tenant/TenantUserBootstrapIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/tenant/TenantUserBootstrapIntegrationTest.java
@@ -1,0 +1,103 @@
+package com.stucray.limen.tenant;
+
+import com.stucray.limen.TestcontainersConfiguration;
+import com.stucray.limen.auth.ott.OttIntent;
+import com.stucray.limen.auth.ott.TenantAwareOneTimeTokenService;
+import com.stucray.limen.tenant.TenantUserBootstrap.OwnerCredentials;
+import com.stucray.limen.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.reset;
+
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest
+@DisplayName("TenantUserBootstrap atomicity + happy path")
+class TenantUserBootstrapIntegrationTest {
+
+    @Autowired TenantUserBootstrap bootstrap;
+    @Autowired TenantRepository tenantRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    @MockitoSpyBean TenantAwareOneTimeTokenService tokenService;
+
+    @BeforeEach
+    void cleanCustomerData() {
+        jdbcTemplate.execute(
+            "DELETE FROM users WHERE tenant_id IN (SELECT id FROM tenants WHERE slug != 'system')");
+        jdbcTemplate.execute("DELETE FROM tenants WHERE slug != 'system'");
+        reset(tokenService);
+    }
+
+    @Test
+    @DisplayName("Provided-credentials path creates tenant + owner, owner has the supplied password and emailVerified=false")
+    void providedPasswordHappyPath() {
+        String slug = uniqueSlug();
+        Tenant tenant = bootstrap.bootstrap(
+            slug, "Acme " + slug, "owner-" + slug + "@example.test",
+            new OwnerCredentials.Provided("secret123"));
+
+        assertThat(tenantRepository.findBySlug(slug)).contains(tenant);
+        var owner = userRepository.findByEmailAndTenantId("owner-" + slug + "@example.test", tenant.id())
+            .orElseThrow();
+        assertThat(owner.tenantOwner()).isTrue();
+        assertThat(owner.emailVerified()).isFalse();
+        assertThat(owner.mustChangePassword()).isFalse();
+    }
+
+    @Test
+    @DisplayName("GenerateRandom path creates tenant + owner with mustChangePassword=true and emailVerified=false")
+    void generateRandomHappyPath() {
+        String slug = uniqueSlug();
+        bootstrap.bootstrap(
+            slug, "Acme " + slug, "owner-" + slug + "@example.test",
+            new OwnerCredentials.GenerateRandom());
+
+        var owner = userRepository.findByEmailAndTenantId(
+                "owner-" + slug + "@example.test",
+                tenantRepository.findBySlug(slug).orElseThrow().id())
+            .orElseThrow();
+        assertThat(owner.mustChangePassword()).isTrue();
+        assertThat(owner.tenantOwner()).isTrue();
+        assertThat(owner.emailVerified()).isFalse();
+    }
+
+    @Test
+    @DisplayName("If OTT generation throws, the bootstrap rolls back: no orphan tenant or owner row")
+    void ottFailureRollsBackTenantAndOwner() {
+        String slug = uniqueSlug();
+        String email = "owner-" + slug + "@example.test";
+
+        doThrow(new IllegalStateException("simulated OTT outage"))
+            .when(tokenService)
+            .generateForIntent(eq(email), any(OttIntent.class));
+
+        assertThatThrownBy(() -> bootstrap.bootstrap(
+            slug, "Acme " + slug, email, new OwnerCredentials.GenerateRandom()))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("simulated OTT outage");
+
+        assertThat(tenantRepository.findBySlug(slug)).isEmpty();
+        Integer userCount = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM users WHERE email = ?", Integer.class, email);
+        assertThat(userCount).isZero();
+    }
+
+    private static String uniqueSlug() {
+        return "boot-" + UUID.randomUUID().toString().substring(0, 8);
+    }
+}

--- a/src/test/java/com/stucray/limen/tenant/TenantUserBootstrapIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/tenant/TenantUserBootstrapIntegrationTest.java
@@ -51,7 +51,13 @@ class TenantUserBootstrapIntegrationTest {
             slug, "Acme " + slug, "owner-" + slug + "@example.test",
             new OwnerCredentials.Provided("secret123"));
 
-        assertThat(tenantRepository.findBySlug(slug)).contains(tenant);
+        // Compare by id rather than full equality: Linux LocalDateTime.now() is
+        // nanosecond-precision in memory, Postgres timestamp truncates to micros
+        // on persistence (memory note 2026-05-03 / slice-6).
+        Tenant reloaded = tenantRepository.findBySlug(slug).orElseThrow();
+        assertThat(reloaded.id()).isEqualTo(tenant.id());
+        assertThat(reloaded.slug()).isEqualTo(slug);
+
         var owner = userRepository.findByEmailAndTenantId("owner-" + slug + "@example.test", tenant.id())
             .orElseThrow();
         assertThat(owner.tenantOwner()).isTrue();

--- a/src/test/java/com/stucray/limen/ui/journey/SystemAdminTenantCreateJourneyUiIT.java
+++ b/src/test/java/com/stucray/limen/ui/journey/SystemAdminTenantCreateJourneyUiIT.java
@@ -1,0 +1,39 @@
+package com.stucray.limen.ui.journey;
+
+import com.microsoft.playwright.Page;
+import com.stucray.limen.ui.pages.manage.system.SystemTenantCreatePage;
+import com.stucray.limen.ui.pages.manage.system.SystemTenantsListPage;
+import com.stucray.limen.ui.support.BaseUiIT;
+import com.stucray.limen.ui.support.LoginPageObject;
+import com.stucray.limen.ui.support.TestTenantFactory.SeededSystemAdmin;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+@DisplayName("A system administrator can provision a new tenant via the manage console")
+class SystemAdminTenantCreateJourneyUiIT extends BaseUiIT {
+
+    @Test
+    @DisplayName("happy path: sysadmin signs in, opens New tenant, fills form, lands back on the tenants list with the new slug visible")
+    void happyPath(Page page) {
+        SeededSystemAdmin admin = tenants.createSystemAdmin();
+        String suffix = UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+        String slug = "newco-" + suffix;
+
+        new LoginPageObject(page, baseUrl())
+            .loginAsSystemAdmin(admin.email(), admin.password());
+
+        new SystemTenantsListPage(page, baseUrl())
+            .visit()
+            .assertOnTenantsList();
+
+        new SystemTenantCreatePage(page, baseUrl())
+            .visitFromTenantsList()
+            .assertOnForm()
+            .fillForm(slug, "Newco " + suffix, "owner-" + suffix + "@example.test")
+            .submit()
+            .assertOnTenantsList()
+            .assertTenantSlugVisible(slug);
+    }
+}

--- a/src/test/java/com/stucray/limen/ui/pages/manage/system/SystemTenantCreatePage.java
+++ b/src/test/java/com/stucray/limen/ui/pages/manage/system/SystemTenantCreatePage.java
@@ -1,0 +1,42 @@
+package com.stucray.limen.ui.pages.manage.system;
+
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.assertions.PlaywrightAssertions;
+import com.microsoft.playwright.options.AriaRole;
+
+public final class SystemTenantCreatePage {
+
+    private final Page page;
+    private final String baseUrl;
+
+    public SystemTenantCreatePage(Page page, String baseUrl) {
+        this.page = page;
+        this.baseUrl = baseUrl;
+    }
+
+    public SystemTenantCreatePage visitFromTenantsList() {
+        page.getByTestId("new-tenant").click();
+        page.waitForURL(baseUrl + "/manage/system/tenants/new");
+        return this;
+    }
+
+    public SystemTenantCreatePage assertOnForm() {
+        PlaywrightAssertions.assertThat(
+            page.getByRole(AriaRole.HEADING, new Page.GetByRoleOptions().setName("Create a tenant"))
+        ).isVisible();
+        return this;
+    }
+
+    public SystemTenantCreatePage fillForm(String slug, String displayName, String ownerEmail) {
+        page.locator("[data-test-field='slug']").fill(slug);
+        page.locator("[data-test-field='displayName']").fill(displayName);
+        page.locator("[data-test-field='ownerEmail']").fill(ownerEmail);
+        return this;
+    }
+
+    public SystemTenantsListPage submit() {
+        page.getByTestId("tenant-create-submit").click();
+        page.waitForURL(baseUrl + "/manage/system/tenants");
+        return new SystemTenantsListPage(page, baseUrl);
+    }
+}

--- a/src/test/java/com/stucray/limen/ui/pages/manage/system/SystemTenantsListPage.java
+++ b/src/test/java/com/stucray/limen/ui/pages/manage/system/SystemTenantsListPage.java
@@ -27,7 +27,12 @@ public final class SystemTenantsListPage {
     }
 
     public SystemTenantsListPage assertTenantSlugVisible(String slug) {
-        PlaywrightAssertions.assertThat(page.getByText(slug)).isVisible();
+        // setExact(true) targets the <code>{slug}</code> cell directly. The
+        // post-create flash message ("Created tenant {slug}.") would otherwise
+        // also match and trip Playwright's strict-mode duplicate guard.
+        PlaywrightAssertions.assertThat(
+            page.getByText(slug, new Page.GetByTextOptions().setExact(true))
+        ).isVisible();
         return this;
     }
 }


### PR DESCRIPTION
Closes #129 — PRD #120 slice 8 (the last one).

## Summary

- New `TenantUserBootstrap` service wraps Tenant create + Owner User insert + verification-OTT send into a single `@Transactional` flow. A failure in any step rolls back the whole bootstrap — no orphan `tenants` row when OTT delivery throws, no orphan `users` row when seed-key generation does.
- `SignupService` refactored to delegate to `TenantUserBootstrap` so both bootstrap paths stay consistent (validation + bootstrap split cleanly).
- New `GET/POST /manage/system/tenants/new` (`@PreAuthorize("hasRole('SYSTEM_ADMIN')")`) takes slug + display name + owner email, calls bootstrap with `OwnerCredentials.GenerateRandom`, redirects to the tenants list with a flash message. The new owner gets a verification email and walks through the existing forced-password-change flow on first sign-in.
- Slug + email validation extracted into two static helpers on `SignupService` (`validateSlug`, `validateEmail`) so both forms apply identical rules including the reserved-slug blocklist (`system`, `admin`, `manage`, `api`, `www`, `static`, `health`, `limen`).
- `TenantCreatedEvent` already fires from `TenantProvisioningService.createTenant` regardless of caller, so the sysadmin path produces a `tenant_created` audit row with no new event type needed.
- "New tenant" link added to `/manage/system/tenants` so the form is reachable from the existing tenants listing.

## Test plan
- [x] `TenantUserBootstrapIntegrationTest` — 3 tests: provided-credentials happy path (mustChangePassword=false), generate-random happy path (mustChangePassword=true, emailVerified=false), and the rollback assertion (mocked-spy on `TenantAwareOneTimeTokenService#generateForIntent` throws → no orphan tenant or owner row).
- [x] `SystemAdminTenantCreateIntegrationTest` — 6 tests: form GET, successful POST, reserved-slug error, duplicate-slug error, invalid-email error, and Tenant-Owner-gets-403 (both GET and POST).
- [x] `SystemAdminTenantCreateJourneyUiIT` — Playwright happy path: sysadmin signs in, opens "New tenant", fills form, lands back on the tenants list with the new slug visible.
- [x] `SignupIntegrationTest` (12 tests) still green — the refactor preserved every existing behavior.
- [x] Full `mvn verify` green: 351 unit/integration tests + 15 UI tests, 0 failures.

## Wraps PRD #120
This is the last of the eight production-credibility slices. After merge: PRD #120 closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)