### PR TITLE
feat: empty-state hint on /manage/system/tenants when only system tenant exists

### DIFF
--- a/src/main/resources/templates/manage/system/tenants.html
+++ b/src/main/resources/templates/manage/system/tenants.html
@@ -20,6 +20,10 @@
     <p class="form-error" th:if="${errorMessage}" th:text="${errorMessage}"></p>
     <p class="form-info" th:if="${successMessage}" th:text="${successMessage}"></p>
 
+    <p class="empty-state" th:if="${#lists.size(tenants) == 1 && tenants[0].isSystem()}">
+        Tenants self-register at <code>/signup</code>. Once another tenant exists, lifecycle actions (suspend, delete) will appear here.
+    </p>
+
     <table>
         <thead>
             <tr>


### PR DESCRIPTION
## Summary
- A fresh Limen install shows `/manage/system/tenants` with one row (the system tenant) and `—` in the actions column, which reads as broken/incomplete.
- Renders a one-line `.empty-state` hint above the table — only when the list contains a single tenant and that tenant is the system tenant — pointing system admins at `/signup` and noting that lifecycle actions surface once another tenant exists.
- Disappears automatically as soon as any non-system tenant exists.

## Test plan
- [ ] Sign in as system admin on a fresh install (only the system tenant present) and confirm the hint renders directly above the tenants table.
- [ ] Create or self-register another tenant; reload `/manage/system/tenants` and confirm the hint no longer renders.
- [ ] Existing `SystemAdminIntegrationTest` + `SystemAdminTenantCreateIntegrationTest` continue to pass (verified locally, 14/14 green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)