### PR TITLE
refactor: at-least-once audit delivery via Spring Modulith publication registry

### DIFF
--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -381,13 +381,17 @@ flowchart LR
     subgraph "Emit sites"
       AS[Spring Security<br/>AuthenticationSuccessEvent]
       AF[Spring Security<br/>AuthenticationFailureEvent]
-      DOM["Domain events<br/>(TenantCreatedEvent,<br/>EmailVerifiedEvent,<br/>AccountLockedEvent,<br/>UserCreatedEvent,<br/>RateLimitHitEvent, ...)"]
+      RL[RateLimitHitEvent]
+      DOM["Domain events<br/>(TenantCreatedEvent,<br/>EmailVerifiedEvent,<br/>AccountLockedEvent,<br/>UserCreatedEvent, ...)"]
     end
     AR[("AuditRegistry<br/>declarative rules<br/>(event class → projection,<br/>binding)")]
     AD[AuditDispatcher]
+    EPR[("event_publication<br/>(Modulith JDBC<br/>publication registry)")]
     AS -->|@EventListener| AD
     AF -->|@EventListener| AD
-    DOM -->|@TransactionalEventListener<br/>AFTER_COMMIT| AD
+    RL -->|@EventListener| AD
+    DOM -->|@ApplicationModuleListener<br/>via publication registry| EPR
+    EPR -->|async after commit| AD
     AD -->|lookup matching rule| AR
     AD --> AEW[AuditEventWriter] --> DB[(audit_event<br/>jsonb details)]
 ```
@@ -395,10 +399,13 @@ flowchart LR
 Properties:
 
 - **Declarative rule registry.** `AuditRegistry` holds one `AuditRule` per audit-bearing event class (event type, projection lambda, binding kind). Adding a new audit row is one entry in the registry, not three places. `AuditDispatcher`'s two listener methods (one per binding) look up the matching rule, apply the projection, and call the writer. Subclass-aware lookup (with per-class cache) honours Spring's listener-subtype contract — the `AbstractAuthenticationFailureEvent` rule still matches `BadCredentialsException`, etc. Ambient context (event id, timestamp, IP / user-agent) and writer-failure swallowing live in one place rather than repeating per emit site.
-- **Two listener bindings.** Spring Security's auth events fire synchronously (no enclosing transaction), so the `@EventListener` method is used. Custom domain events use `@TransactionalEventListener(phase = AFTER_COMMIT)` so a failed audit write never rolls back the user-facing action, and a rolled-back domain action never produces a misleading audit row. The binding for each rule is encoded as data on `AuditRule.binding` rather than picked by the listener annotation.
+- **Two listener bindings.** Spring Security's auth events and `RateLimitHitEvent` fire synchronously and outside any transaction, so the `@EventListener` method handles them. Custom transactionally-sourced domain events flow through `@ApplicationModuleListener` (Spring Modulith): the publication registry persists each event in `event_publication` at publish time, the listener runs asynchronously after the publishing transaction commits, and the registry stamps `completion_date` once the listener returns. The binding for each rule is encoded as data on `AuditRule.binding` rather than picked by the listener annotation. The `@ApplicationModuleListener` parameter is typed as the `AuditedDomainEvent` marker interface (which every transactionally-sourced audit event record implements) rather than `Object`, so the publication registry only persists events the registry has rules for — a bare `Object` parameter would catch every Spring framework startup event and try to JSON-serialize the source.
+- **At-least-once for transactional events; best-effort for the rest.** A JVM crash between commit and listener execution leaves the `event_publication` row uncompleted; on the next startup Modulith replays the event and re-invokes the listener. Two scope notes follow from this:
+  - **Duplicates are possible** on rare restart-after-failure (no idempotency key on `audit_event` in this slice — adding one is a follow-up if duplicates are observed).
+  - **The guarantee is bounded.** It applies only to the `@ApplicationModuleListener` path. Audit rows derived from Spring Security auth events and `RateLimitHitEvent` go through the IMMEDIATE `@EventListener` path because those events fire outside any transaction; closing the gap for them needs an outbox-style approach (synchronous insert inside the publishing filter, async drain) and is out of scope here.
+- **Application-level write failures are still swallowed.** If the listener runs but the writer throws, the dispatcher logs and returns normally — the publication record is marked complete and not retried. The at-least-once guarantee here is specifically about *delivery* (the listener was invoked), not about *eventual write success*.
 - **Event types currently emitted:** `login_success`, `login_failure`, `tenant_created` / `tenant_suspended` / `tenant_unsuspended` / `tenant_deleted`, `client_secret_rotated`, `verification_ott_issued` / `email_verified` / `verification_resent`, `account_locked` / `account_unlocked`, `password_reset_ott_issued` / `password_reset_completed` / `password_changed`, `user_created` / `user_enabled` / `user_disabled` / `user_deleted`, `tenant_ownership_granted` / `tenant_ownership_revoked`, `rate_limit_hit`.
-- **Schema-shaped for forward compatibility.** `audit_event` carries `tenant_id` (nullable, `ON DELETE SET NULL` so deleting a Tenant does not delete its history), `actor_user_id` (same nullability rule), `event_type`, optional `target_type` / `target_id`, request context (`ip_address`, `user_agent`), `occurred_at`, and a `jsonb details` payload for event-specific fields. Indexed by `(tenant_id, occurred_at DESC)` for the per-tenant timeline view.
-- **Best-effort delivery.** A JVM crash between transaction commit and listener execution loses that one event. At-least-once is the Spring Modulith adoption story — the publication registry persists events before listener execution and replays on restart. Switching to it is an annotation swap on the listener; emit sites are unchanged. (See §6 v3.5.)
+- **Schema-shaped for forward compatibility.** `audit_event` carries `tenant_id` (nullable, `ON DELETE SET NULL` so deleting a Tenant does not delete its history), `actor_user_id` (same nullability rule), `event_type`, optional `target_type` / `target_id`, request context (`ip_address`, `user_agent`), `occurred_at`, and a `jsonb details` payload for event-specific fields. Indexed by `(tenant_id, occurred_at DESC)` for the per-tenant timeline view. The Modulith publication registry's own `event_publication` table is created by Flyway V10 (the framework's own initializer is left disabled; default `spring.modulith.events.jdbc.schema-initialization.enabled=false`).
 
 ### 4.9 Rate limiting
 
@@ -598,7 +605,7 @@ Other sub-packages (e.g. `audit.dispatch`, `auth.lockout`, `security.ratelimit`)
 
 **Cross-module dependency policy.** Modulith's open default: any module may depend on any other module's top-level package or its named interfaces. There are no `@ApplicationModule(allowedDependencies = ...)` whitelists. The verifier still enforces no cycles and no sub-package leaks; tightening to per-module allowed-dependency declarations is a future option if evidence warrants it.
 
-**Build dependencies.** `spring-modulith-api` (compile scope) provides `@NamedInterface` for the `package-info.java` annotations; `spring-modulith-starter-test` (test scope) provides `ApplicationModules.verify()` for the verifier test. No runtime Modulith behaviour is wired in this slice — that lands in v3.5 item 10's at-least-once audit work, which adds `spring-modulith-starter-jdbc` and the publication registry.
+**Build dependencies.** `spring-modulith-api` (compile scope) provides `@NamedInterface` for the `package-info.java` annotations; `spring-modulith-starter-test` (test scope) provides `ApplicationModules.verify()` for the verifier test; `spring-modulith-starter-jdbc` (runtime scope) wires the JDBC publication registry that backs `@ApplicationModuleListener` (used by `AuditDispatcher.onAfterCommit`). The `event_publication` table is owned by Flyway V10, not the framework's own initializer.
 
 ## 5. Current Gaps and Shortcomings
 
@@ -615,7 +622,7 @@ These are known limitations of the current surface. None of them block the produ
 - **No signing-key rotation job.** The schema supports it; nothing schedules it.
 - **No consent revocation UI.** Consents are persisted per Tenant but end-users have no way to view or revoke them; only direct DB or admin action would clear them.
 - **Rate-limit state is per-process.** Bucket4j in-memory is the right call for a single-container deployment; horizontal scaling will need the Postgres-backed swap (§6 v3.5).
-- **Audit delivery is best-effort.** A JVM crash between transaction commit and listener execution loses that one event. Spring Modulith's publication registry will close this to at-least-once (§6 v3.5); the listener annotation swap is the only audit-side change required.
+- **Audit delivery is at-least-once for transactional events only.** Domain events emitted from inside a transaction (every `tenant_*`, `user_*`, `client_*`, `password_*`, `email_*`, `account_*`, etc.) survive a JVM crash between commit and listener execution via the Modulith publication registry. Spring-Security-derived audit rows (`login_success`, `login_failure`) and `rate_limit_hit` still fire synchronously through `@EventListener` and remain best-effort — those events have no enclosing transaction the registry can attach to. Closing this last gap needs an outbox-style approach and is out of scope. (See §4.8.)
 - **No real email provider wired.** `EmailSender` has `logging` (default) and `smtp` drivers. Resend / Brevo / SendGrid / SES is a config swap deferred to v4.
 
 ### Code-level
@@ -649,7 +656,7 @@ A single PRD covering five gaps that blocked Limen being credible as a hosted Id
 
 ### v3.5 — operational hardening (post-PRD-#120)
 
-10. **Spring Modulith adoption.** Tracked in PRD #151. **Slice 1 (boundary enforcement) shipped 2026-05-06 (#152).** 19 application modules at `com.stucray.limen.*`, verified by `LimenModuleArchitectureTest` calling `ApplicationModules.verify()` — see §4.15. Three named interfaces (`audit.events`, `auth.login`, `auth.ott`) demarcate published API; cycles at `auth ↔ tenant`, `auth ↔ oauth2`, `audit ↔ auth`, and `oauth2 ↔ security` were broken by mechanical re-homing (provisioning promoted to its own module, `TenantAccessFilter` → `auth`, `TenantUserDetails` → `user`, `SasConfig` → `oauth2`). **Slice 2 (#153) — at-least-once audit delivery — pending.** Adds `spring-modulith-starter-jdbc`, Flyway V10 for `event_publication`, and swaps the audit dispatcher's `@TransactionalEventListener(AFTER_COMMIT)` for `@ApplicationModuleListener`. Closes the at-least-once gap for *transactional* domain events; audit rows derived from Spring Security auth events (which fire outside a transaction) remain best-effort.
+10. ~~**Spring Modulith adoption.**~~ Tracked in PRD #151; both slices shipped. **Slice 1 (boundary enforcement) shipped 2026-05-06 (#152).** 19 application modules at `com.stucray.limen.*`, verified by `LimenModuleArchitectureTest` calling `ApplicationModules.verify()` — see §4.15. Three named interfaces (`audit.events`, `auth.login`, `auth.ott`) demarcate published API; cycles at `auth ↔ tenant`, `auth ↔ oauth2`, `audit ↔ auth`, and `oauth2 ↔ security` were broken by mechanical re-homing (provisioning promoted to its own module, `TenantAccessFilter` → `auth`, `TenantUserDetails` → `user`, `SasConfig` → `oauth2`). **Slice 2 (at-least-once audit delivery) shipped 2026-05-06 (#153).** Adds `spring-modulith-starter-jdbc` (runtime) + Flyway V10 for `event_publication`; the audit dispatcher's AFTER_COMMIT listener swaps from `@TransactionalEventListener` to `@ApplicationModuleListener`, so transactionally-sourced domain events survive a JVM crash between commit and listener execution. Auth-event-derived audit rows and `rate_limit_hit` (no enclosing transaction) remain best-effort. See §4.8 for the bounded-guarantee framing and the duplicate-on-replay caveat.
 11. **Audit admin UI.** List + filter views under `/manage/t/{slug}/audit` (Tenant-scoped) and `/manage/system/audit` (cross-tenant). CSV export. Pure-additive on top of the v3 schema.
 12. **Metrics.** Micrometer counters for login success / failure, token issuance, key rotation; latency histograms on the token endpoint.
 13. **Signing-key rotation job.** Scheduled, with overlap window so old tokens validate against the retired key during a grace period.

--- a/pom.xml
+++ b/pom.xml
@@ -152,18 +152,33 @@
 		</dependency>
 
 		<!--
-			Spring Modulith — application-modules verifier.
-			Slice 1 (#152): `spring-modulith-api` is compile-scope so
-			`@NamedInterface` annotations on `package-info.java` resolve in
-			main sources; `spring-modulith-starter-test` is test-scope and
-			brings the `ApplicationModules` verifier API. No auto-config or
-			runtime behaviour added in this slice. The runtime publication-
-			registry starter (`spring-modulith-starter-jdbc`) lands in slice 2
-			(#153) when we close the audit at-least-once gap.
+			Spring Modulith — application-modules verifier (slice 1) plus the
+			JDBC publication registry that backs at-least-once delivery for
+			`@ApplicationModuleListener`-annotated handlers (slice 2).
+			`spring-modulith-api` is compile-scope so `@NamedInterface`
+			annotations on `package-info.java` resolve in main sources;
+			`spring-modulith-events-api` (compile) is needed for the
+			`@ApplicationModuleListener` annotation on `AuditDispatcher`
+			(2.0.x split it out of `spring-modulith-api`).
+			`spring-modulith-starter-test` is test-scope and brings the
+			`ApplicationModules` verifier API plus `Scenario`/`PublishedEvents`
+			helpers. `spring-modulith-starter-jdbc` is runtime-scope and wires
+			the JDBC `EventPublicationRegistry` against our existing
+			`spring-boot-starter-data-jdbc` DataSource — Flyway V10 creates the
+			`event_publication` table to the schema the registry expects.
 		-->
 		<dependency>
 			<groupId>org.springframework.modulith</groupId>
 			<artifactId>spring-modulith-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.modulith</groupId>
+			<artifactId>spring-modulith-events-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.modulith</groupId>
+			<artifactId>spring-modulith-starter-jdbc</artifactId>
+			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.modulith</groupId>

--- a/src/main/java/com/stucray/limen/audit/dispatch/AuditDispatcher.java
+++ b/src/main/java/com/stucray/limen/audit/dispatch/AuditDispatcher.java
@@ -2,14 +2,14 @@ package com.stucray.limen.audit.dispatch;
 
 import com.stucray.limen.audit.AuditEvent;
 import com.stucray.limen.audit.AuditEventWriter;
+import com.stucray.limen.audit.events.AuditedDomainEvent;
 import jakarta.servlet.http.HttpServletRequest;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.event.EventListener;
+import org.springframework.modulith.events.ApplicationModuleListener;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
@@ -25,18 +25,23 @@ import java.util.Map;
  *
  * <p>Two listener methods, one per binding:
  * <ul>
- *   <li>{@link AuditBinding#AFTER_COMMIT} for events emitted from inside a
- *       {@code @Transactional} method — the row writes after commit so a
- *       write failure cannot roll back the user-facing action.</li>
+ *   <li>{@link AuditBinding#AFTER_COMMIT} via
+ *       {@link ApplicationModuleListener @ApplicationModuleListener} for events
+ *       emitted from inside a {@code @Transactional} method. The Modulith JDBC
+ *       publication registry persists a row at publish time and clears it once
+ *       the listener completes, giving at-least-once delivery: a JVM crash
+ *       between commit and listener execution is replayed on the next startup.
+ *       Duplicates are therefore possible on rare restart-after-failure (no
+ *       idempotency key in this slice).</li>
  *   <li>{@link AuditBinding#IMMEDIATE} for pre-transaction events
- *       (rate-limit hits, Spring Security auth events).</li>
+ *       (rate-limit hits, Spring Security auth events). These fire outside any
+ *       transaction so the publication registry can't engage; delivery is
+ *       best-effort.</li>
  * </ul>
  *
- * <p>Best-effort delivery — write failures are logged and swallowed.
- * At-least-once arrives with Spring Modulith adoption (architecture doc
- * §6 v3.5): the AFTER_COMMIT listener swaps to {@code @ApplicationModuleListener},
- * and event records gain ip / user-agent fields (since async listeners run
- * off-thread and {@link RequestContextHolder} is thread-local).
+ * <p>Write failures are logged and swallowed; for AFTER_COMMIT events Modulith
+ * still records the publication so a stuck listener can be inspected and
+ * resubmitted via the registry.
  */
 @Component
 public class AuditDispatcher {
@@ -51,8 +56,18 @@ public class AuditDispatcher {
         this.registry = registry;
     }
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void onAfterCommit(Object event) {
+    /**
+     * The parameter type is the {@link AuditedDomainEvent} marker rather than
+     * {@code Object}: Modulith's {@code PersistentApplicationEventMulticaster}
+     * persists every published event whose runtime type is assignable to the
+     * declared listener parameter. A bare {@code Object} would catch every
+     * Spring framework startup event ({@code ContextRefreshedEvent}, etc.) and
+     * try to JSON-serialize the source — which is the entire application
+     * context — into {@code event_publication}. Narrowing here scopes
+     * persistence to the events the registry actually has rules for.
+     */
+    @ApplicationModuleListener
+    public void onAfterCommit(AuditedDomainEvent event) {
         dispatch(event, AuditBinding.AFTER_COMMIT);
     }
 

--- a/src/main/java/com/stucray/limen/audit/events/AccountLockedEvent.java
+++ b/src/main/java/com/stucray/limen/audit/events/AccountLockedEvent.java
@@ -14,4 +14,4 @@ public record AccountLockedEvent(
     Long userId,
     String email,
     LocalDateTime lockedUntil
-) {}
+) implements AuditedDomainEvent {}

--- a/src/main/java/com/stucray/limen/audit/events/AccountUnlockedEvent.java
+++ b/src/main/java/com/stucray/limen/audit/events/AccountUnlockedEvent.java
@@ -11,4 +11,4 @@ public record AccountUnlockedEvent(
     Long actorUserId,
     Long userId,
     String email
-) {}
+) implements AuditedDomainEvent {}

--- a/src/main/java/com/stucray/limen/audit/events/AuditedDomainEvent.java
+++ b/src/main/java/com/stucray/limen/audit/events/AuditedDomainEvent.java
@@ -1,0 +1,31 @@
+package com.stucray.limen.audit.events;
+
+/**
+ * Marker for transactionally-emitted domain events that an audit listener
+ * should record. Every concrete implementor is a {@code record} living in
+ * this package, so the set is enumerable here and via {@link AuditRegistry}.
+ *
+ * <p>Two reasons this exists:
+ * <ul>
+ *   <li><b>Type-narrows the AFTER_COMMIT audit listener.</b>
+ *       {@code AuditDispatcher.onAfterCommit} is annotated
+ *       {@code @ApplicationModuleListener}, which delegates through
+ *       Modulith's {@code PersistentApplicationEventMulticaster}. The
+ *       multicaster persists every published event whose declared listener
+ *       parameter type is assignable from the event's runtime type. A bare
+ *       {@code Object} parameter would catch every framework startup event
+ *       ({@code ContextRefreshedEvent}, {@code ApplicationReadyEvent}, ...)
+ *       and try to JSON-serialize the source — which is the entire
+ *       application context — into {@code event_publication}. This marker
+ *       confines persistence to events we actually care about.</li>
+ *   <li><b>Documents intent.</b> If a future contributor adds a domain event
+ *       and wants it audited, the type system points at the marker.</li>
+ * </ul>
+ *
+ * <p>{@code RateLimitHitEvent} and the Spring Security auth events
+ * deliberately do <em>not</em> implement this marker — they fire outside any
+ * transaction and run through the IMMEDIATE {@code @EventListener} branch,
+ * which never touches the publication registry.
+ */
+public interface AuditedDomainEvent {
+}

--- a/src/main/java/com/stucray/limen/audit/events/ClientSecretRotatedEvent.java
+++ b/src/main/java/com/stucray/limen/audit/events/ClientSecretRotatedEvent.java
@@ -4,4 +4,4 @@ public record ClientSecretRotatedEvent(
     Long tenantId,
     String registeredClientId,
     Long actorUserId
-) {}
+) implements AuditedDomainEvent {}

--- a/src/main/java/com/stucray/limen/audit/events/EmailVerifiedEvent.java
+++ b/src/main/java/com/stucray/limen/audit/events/EmailVerifiedEvent.java
@@ -8,4 +8,4 @@ public record EmailVerifiedEvent(
     Long tenantId,
     Long userId,
     String email
-) {}
+) implements AuditedDomainEvent {}

--- a/src/main/java/com/stucray/limen/audit/events/PasswordChangedEvent.java
+++ b/src/main/java/com/stucray/limen/audit/events/PasswordChangedEvent.java
@@ -10,6 +10,6 @@ public record PasswordChangedEvent(
     Long tenantId,
     Long userId,
     Trigger trigger
-) {
+) implements AuditedDomainEvent {
     public enum Trigger { FORCED, SELF_SERVICE, ADMIN_RESET }
 }

--- a/src/main/java/com/stucray/limen/audit/events/PasswordResetCompletedEvent.java
+++ b/src/main/java/com/stucray/limen/audit/events/PasswordResetCompletedEvent.java
@@ -10,4 +10,4 @@ package com.stucray.limen.audit.events;
 public record PasswordResetCompletedEvent(
     Long tenantId,
     Long userId
-) {}
+) implements AuditedDomainEvent {}

--- a/src/main/java/com/stucray/limen/audit/events/PasswordResetOttIssuedEvent.java
+++ b/src/main/java/com/stucray/limen/audit/events/PasswordResetOttIssuedEvent.java
@@ -15,4 +15,4 @@ public record PasswordResetOttIssuedEvent(
     @Nullable Long userId,
     String email,
     boolean delivered
-) {}
+) implements AuditedDomainEvent {}

--- a/src/main/java/com/stucray/limen/audit/events/TenantCreatedEvent.java
+++ b/src/main/java/com/stucray/limen/audit/events/TenantCreatedEvent.java
@@ -15,4 +15,4 @@ public record TenantCreatedEvent(
     String slug,
     String displayName,
     @Nullable Long actorUserId
-) {}
+) implements AuditedDomainEvent {}

--- a/src/main/java/com/stucray/limen/audit/events/TenantDeletedEvent.java
+++ b/src/main/java/com/stucray/limen/audit/events/TenantDeletedEvent.java
@@ -9,4 +9,4 @@ public record TenantDeletedEvent(
     Long tenantId,
     String slug,
     Long actorUserId
-) {}
+) implements AuditedDomainEvent {}

--- a/src/main/java/com/stucray/limen/audit/events/TenantOwnershipGrantedEvent.java
+++ b/src/main/java/com/stucray/limen/audit/events/TenantOwnershipGrantedEvent.java
@@ -13,4 +13,4 @@ public record TenantOwnershipGrantedEvent(
     Long actorUserId,
     Long userId,
     String email
-) {}
+) implements AuditedDomainEvent {}

--- a/src/main/java/com/stucray/limen/audit/events/TenantOwnershipRevokedEvent.java
+++ b/src/main/java/com/stucray/limen/audit/events/TenantOwnershipRevokedEvent.java
@@ -12,4 +12,4 @@ public record TenantOwnershipRevokedEvent(
     Long actorUserId,
     Long userId,
     String email
-) {}
+) implements AuditedDomainEvent {}

--- a/src/main/java/com/stucray/limen/audit/events/TenantSuspendedEvent.java
+++ b/src/main/java/com/stucray/limen/audit/events/TenantSuspendedEvent.java
@@ -4,4 +4,4 @@ public record TenantSuspendedEvent(
     Long tenantId,
     String slug,
     Long actorUserId
-) {}
+) implements AuditedDomainEvent {}

--- a/src/main/java/com/stucray/limen/audit/events/TenantUnsuspendedEvent.java
+++ b/src/main/java/com/stucray/limen/audit/events/TenantUnsuspendedEvent.java
@@ -4,4 +4,4 @@ public record TenantUnsuspendedEvent(
     Long tenantId,
     String slug,
     Long actorUserId
-) {}
+) implements AuditedDomainEvent {}

--- a/src/main/java/com/stucray/limen/audit/events/UserCreatedEvent.java
+++ b/src/main/java/com/stucray/limen/audit/events/UserCreatedEvent.java
@@ -11,4 +11,4 @@ public record UserCreatedEvent(
     Long actorUserId,
     Long userId,
     String email
-) {}
+) implements AuditedDomainEvent {}

--- a/src/main/java/com/stucray/limen/audit/events/UserDeletedEvent.java
+++ b/src/main/java/com/stucray/limen/audit/events/UserDeletedEvent.java
@@ -12,4 +12,4 @@ public record UserDeletedEvent(
     Long actorUserId,
     Long userId,
     String email
-) {}
+) implements AuditedDomainEvent {}

--- a/src/main/java/com/stucray/limen/audit/events/UserDisabledEvent.java
+++ b/src/main/java/com/stucray/limen/audit/events/UserDisabledEvent.java
@@ -13,4 +13,4 @@ public record UserDisabledEvent(
     Long actorUserId,
     Long userId,
     String email
-) {}
+) implements AuditedDomainEvent {}

--- a/src/main/java/com/stucray/limen/audit/events/UserEnabledEvent.java
+++ b/src/main/java/com/stucray/limen/audit/events/UserEnabledEvent.java
@@ -11,4 +11,4 @@ public record UserEnabledEvent(
     Long actorUserId,
     Long userId,
     String email
-) {}
+) implements AuditedDomainEvent {}

--- a/src/main/java/com/stucray/limen/audit/events/VerificationOttIssuedEvent.java
+++ b/src/main/java/com/stucray/limen/audit/events/VerificationOttIssuedEvent.java
@@ -10,4 +10,4 @@ public record VerificationOttIssuedEvent(
     Long tenantId,
     Long userId,
     String email
-) {}
+) implements AuditedDomainEvent {}

--- a/src/main/java/com/stucray/limen/audit/events/VerificationResentEvent.java
+++ b/src/main/java/com/stucray/limen/audit/events/VerificationResentEvent.java
@@ -12,4 +12,4 @@ public record VerificationResentEvent(
     @Nullable Long userId,
     String email,
     boolean delivered
-) {}
+) implements AuditedDomainEvent {}

--- a/src/main/resources/db/migration/V10__event_publication.sql
+++ b/src/main/resources/db/migration/V10__event_publication.sql
@@ -1,0 +1,39 @@
+-- Spring Modulith JDBC publication registry — backing table for at-least-once
+-- delivery of `@ApplicationModuleListener`-annotated handlers (currently just
+-- AuditDispatcher.onAfterCommit). Schema mirrors the v2 PostgreSQL DDL bundled
+-- with spring-modulith-events-jdbc 2.0.x; we manage it via Flyway rather than
+-- the framework's own initializer (`spring.modulith.events.jdbc.schema-
+-- initialization.enabled` stays at its default of false).
+--
+-- A row lands here transactionally with the publishing event. If the JVM
+-- crashes after commit but before the listener completes, the row's
+-- completion_date stays null; on next startup Modulith replays the event,
+-- re-invokes the listener, and stamps completion. That gives at-least-once
+-- semantics for transactionally-published events. Duplicate audit_event rows
+-- are possible on rare restart-after-failure (no idempotency key in this
+-- slice — see architecture.md §4.8).
+--
+-- Scope of the guarantee: this only engages for the AFTER_COMMIT-bound
+-- AuditDispatcher.onAfterCommit listener. The IMMEDIATE-bound listener for
+-- Spring Security auth events and rate-limit hits stays best-effort: those
+-- events fire outside any transaction, so there's nothing for the publication
+-- registry to attach to.
+
+CREATE TABLE event_publication (
+    id                     uuid                     NOT NULL,
+    listener_id            text                     NOT NULL,
+    event_type             text                     NOT NULL,
+    serialized_event       text                     NOT NULL,
+    publication_date       timestamp with time zone NOT NULL,
+    completion_date        timestamp with time zone,
+    status                 text,
+    completion_attempts    int,
+    last_resubmission_date timestamp with time zone,
+    PRIMARY KEY (id)
+);
+
+CREATE INDEX event_publication_serialized_event_hash_idx
+    ON event_publication USING hash (serialized_event);
+
+CREATE INDEX event_publication_by_completion_date_idx
+    ON event_publication (completion_date);

--- a/src/test/java/com/stucray/limen/audit/AuditEventEmitIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/audit/AuditEventEmitIntegrationTest.java
@@ -21,18 +21,26 @@ import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 /**
  * One assertion per emit source: the user-facing action triggers a row in
  * {@code audit_event} with the right shape, tenant_id, actor and target.
  * The {@code listenerFailureDoesNotRollBackParent} test pins the AFTER_COMMIT
  * contract — a thrown listener must not roll back the parent transaction.
+ *
+ * <p>Audit row reads are wrapped in Awaitility polling: under the Modulith
+ * publication registry the AFTER_COMMIT-bound listener runs asynchronously,
+ * so a {@code SELECT} immediately after the publishing call can race the
+ * dispatcher.
  */
 @SpringBootTest
 @Import(TestcontainersConfiguration.class)
@@ -54,11 +62,12 @@ class AuditEventEmitIntegrationTest {
         String slug = uniqueSlug();
         Tenant tenant = tenantProvisioningService.createTenant(slug, "Display " + slug);
 
-        Map<String, Object> row = latestEventForTenant(tenant.id());
-        assertThat(row).isNotNull();
-        assertThat(row.get("event_type")).isEqualTo("tenant_created");
-        assertThat(row.get("target_type")).isEqualTo("tenant");
-        assertThat(row.get("target_id")).isEqualTo(String.valueOf(tenant.id()));
+        awaitAuditRow(() -> latestEventForTenant(tenant.id()), row -> {
+            assertThat(row).isNotNull();
+            assertThat(row.get("event_type")).isEqualTo("tenant_created");
+            assertThat(row.get("target_type")).isEqualTo("tenant");
+            assertThat(row.get("target_id")).isEqualTo(String.valueOf(tenant.id()));
+        });
     }
 
     @Test
@@ -69,9 +78,10 @@ class AuditEventEmitIntegrationTest {
 
         tenantProvisioningService.suspend(tenant, admin);
 
-        Map<String, Object> row = latestEventForTenantOfType(tenant.id(), "tenant_suspended");
-        assertThat(row).isNotNull();
-        assertThat(row.get("actor_user_id")).isEqualTo(admin);
+        awaitAuditRow(() -> latestEventForTenantOfType(tenant.id(), "tenant_suspended"), row -> {
+            assertThat(row).isNotNull();
+            assertThat(row.get("actor_user_id")).isEqualTo(admin);
+        });
         assertThat(tenantRepository.findById(tenant.id()).orElseThrow().status())
             .isEqualTo(TenantStatus.SUSPENDED);
     }
@@ -86,7 +96,8 @@ class AuditEventEmitIntegrationTest {
 
         tenantProvisioningService.unsuspend(suspended, admin);
 
-        assertThat(latestEventForTenantOfType(tenant.id(), "tenant_unsuspended")).isNotNull();
+        awaitAuditRow(() -> latestEventForTenantOfType(tenant.id(), "tenant_unsuspended"),
+            row -> assertThat(row).isNotNull());
         assertThat(tenantRepository.findById(tenant.id()).orElseThrow().status())
             .isEqualTo(TenantStatus.ACTIVE);
     }
@@ -101,13 +112,15 @@ class AuditEventEmitIntegrationTest {
         tenantProvisioningService.delete(tenant, admin);
 
         // tenant_id on the row is null (FK SET NULL); look up by event_type + target_id
-        Map<String, Object> row = jdbcTemplate.queryForMap(
-            "SELECT event_type, tenant_id, target_id, details::text AS details FROM audit_event "
-                + "WHERE event_type = 'tenant_deleted' AND target_id = ? ORDER BY occurred_at DESC LIMIT 1",
-            String.valueOf(originalId));
-        assertThat(row.get("tenant_id")).isNull();
-        assertThat(row.get("details").toString().replace(" ", ""))
-            .contains("\"originalTenantId\":" + originalId);
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            Map<String, Object> row = jdbcTemplate.queryForMap(
+                "SELECT event_type, tenant_id, target_id, details::text AS details FROM audit_event "
+                    + "WHERE event_type = 'tenant_deleted' AND target_id = ? ORDER BY occurred_at DESC LIMIT 1",
+                String.valueOf(originalId));
+            assertThat(row.get("tenant_id")).isNull();
+            assertThat(row.get("details").toString().replace(" ", ""))
+                .contains("\"originalTenantId\":" + originalId);
+        });
     }
 
     @Test
@@ -126,10 +139,11 @@ class AuditEventEmitIntegrationTest {
 
         clientManagementService.rotateSecret(registeredClientId, tenant.id(), actor);
 
-        Map<String, Object> row = latestEventForTenantOfType(tenant.id(), "client_secret_rotated");
-        assertThat(row).isNotNull();
-        assertThat(row.get("target_type")).isEqualTo("registered_client");
-        assertThat(row.get("target_id")).isEqualTo(registeredClientId);
+        awaitAuditRow(() -> latestEventForTenantOfType(tenant.id(), "client_secret_rotated"), row -> {
+            assertThat(row).isNotNull();
+            assertThat(row.get("target_type")).isEqualTo("registered_client");
+            assertThat(row.get("target_id")).isEqualTo(registeredClientId);
+        });
     }
 
     @Test
@@ -141,9 +155,9 @@ class AuditEventEmitIntegrationTest {
 
         userAdministration.resetPassword(user.id(), tenant.id(), admin, "tempPass1234");
 
-        Map<String, Object> row = latestEventForTenantOfType(tenant.id(), "password_changed");
-        assertThat(row.get("details").toString().replace(" ", ""))
-            .contains("\"trigger\":\"admin_reset\"");
+        awaitAuditRow(() -> latestEventForTenantOfType(tenant.id(), "password_changed"),
+            row -> assertThat(row.get("details").toString().replace(" ", ""))
+                .contains("\"trigger\":\"admin_reset\""));
     }
 
     @Nested
@@ -213,10 +227,21 @@ class AuditEventEmitIntegrationTest {
         return rows.isEmpty() ? null : rows.get(0);
     }
 
-    private Map<String, Object> latestEventForTenantOfType(Long tenantId, String eventType) {
-        return jdbcTemplate.queryForMap(
+    private @org.jspecify.annotations.Nullable Map<String, Object> latestEventForTenantOfType(Long tenantId, String eventType) {
+        var rows = jdbcTemplate.queryForList(
             "SELECT event_type, tenant_id, actor_user_id, target_type, target_id, details::text AS details "
                 + "FROM audit_event WHERE tenant_id = ? AND event_type = ? ORDER BY occurred_at DESC LIMIT 1",
             tenantId, eventType);
+        return rows.isEmpty() ? null : rows.get(0);
+    }
+
+    private static void awaitAuditRow(
+            java.util.function.Supplier<Map<String, Object>> rowSupplier,
+            Consumer<Map<String, Object>> assertion) {
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            Map<String, Object> row = rowSupplier.get();
+            assertThat(row).isNotNull();
+            assertion.accept(row);
+        });
     }
 }

--- a/src/test/java/com/stucray/limen/audit/dispatch/AuditDispatcherTest.java
+++ b/src/test/java/com/stucray/limen/audit/dispatch/AuditDispatcherTest.java
@@ -2,6 +2,7 @@ package com.stucray.limen.audit.dispatch;
 
 import com.stucray.limen.audit.AuditEvent;
 import com.stucray.limen.audit.AuditEventWriter;
+import com.stucray.limen.audit.events.AuditedDomainEvent;
 import com.stucray.limen.audit.events.RateLimitHitEvent;
 import com.stucray.limen.audit.events.TenantCreatedEvent;
 import org.junit.jupiter.api.DisplayName;
@@ -95,8 +96,11 @@ class AuditDispatcherTest {
         AuditDispatcher dispatcher = new AuditDispatcher(writer, registry);
 
         dispatcher.onImmediate("some random event");
-        dispatcher.onAfterCommit(123);
+        dispatcher.onAfterCommit(new UnregisteredDomainEvent());
 
         verify(writer, never()).write(any());
     }
+
+    /** Implements the marker but has no rule in {@link AuditRegistry} — exercises the no-match path. */
+    private record UnregisteredDomainEvent() implements AuditedDomainEvent {}
 }

--- a/src/test/java/com/stucray/limen/auth/lockout/AccountLockoutFlowIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/auth/lockout/AccountLockoutFlowIntegrationTest.java
@@ -19,11 +19,14 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 import java.sql.Timestamp;
+import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -286,16 +289,20 @@ class AccountLockoutFlowIntegrationTest {
                     .andExpect(status().is3xxRedirection());
             }
 
-            Map<String, Object> row = jdbcTemplate.queryForMap(
-                "SELECT actor_user_id, target_id, details::text AS details FROM audit_event "
-                    + "WHERE event_type = 'account_locked' AND tenant_id = ? "
-                    + "ORDER BY occurred_at DESC LIMIT 1",
-                tenant.id());
-            assertThat(row.get("actor_user_id")).isEqualTo(user.id());
-            assertThat(row.get("target_id")).isEqualTo(String.valueOf(user.id()));
-            String details = row.get("details").toString();
-            assertThat(details).contains(email);
-            assertThat(details).contains("lockedUntil");
+            await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+                List<Map<String, Object>> rows = jdbcTemplate.queryForList(
+                    "SELECT actor_user_id, target_id, details::text AS details FROM audit_event "
+                        + "WHERE event_type = 'account_locked' AND tenant_id = ? "
+                        + "ORDER BY occurred_at DESC LIMIT 1",
+                    tenant.id());
+                assertThat(rows).isNotEmpty();
+                Map<String, Object> row = rows.get(0);
+                assertThat(row.get("actor_user_id")).isEqualTo(user.id());
+                assertThat(row.get("target_id")).isEqualTo(String.valueOf(user.id()));
+                String details = row.get("details").toString();
+                assertThat(details).contains(email);
+                assertThat(details).contains("lockedUntil");
+            });
         }
     }
 

--- a/src/test/java/com/stucray/limen/auth/ott/EmailVerificationFlowIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/auth/ott/EmailVerificationFlowIntegrationTest.java
@@ -39,13 +39,16 @@ import org.springframework.web.util.UriComponentsBuilder;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.SecureRandom;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Base64;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -194,14 +197,18 @@ class EmailVerificationFlowIntegrationTest {
                 signupService.signup(new SignupForm("Audit " + suffix, slug, email, "password"));
 
             assertThat(result).isInstanceOf(SignupService.SignupResult.Success.class);
-            Map<String, Object> row = jdbcTemplate.queryForMap(
-                "SELECT event_type, target_type, details::text AS details FROM audit_event "
-                    + "WHERE event_type = 'verification_ott_issued' "
-                    + "AND tenant_id = (SELECT id FROM tenants WHERE slug = ?) "
-                    + "ORDER BY occurred_at DESC LIMIT 1",
-                slug);
-            assertThat(row.get("target_type")).isEqualTo("user");
-            assertThat(row.get("details").toString()).contains(email);
+            await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+                List<Map<String, Object>> rows = jdbcTemplate.queryForList(
+                    "SELECT event_type, target_type, details::text AS details FROM audit_event "
+                        + "WHERE event_type = 'verification_ott_issued' "
+                        + "AND tenant_id = (SELECT id FROM tenants WHERE slug = ?) "
+                        + "ORDER BY occurred_at DESC LIMIT 1",
+                    slug);
+                assertThat(rows).isNotEmpty();
+                Map<String, Object> row = rows.get(0);
+                assertThat(row.get("target_type")).isEqualTo("user");
+                assertThat(row.get("details").toString()).contains(email);
+            });
         }
 
         @Test
@@ -223,14 +230,18 @@ class EmailVerificationFlowIntegrationTest {
                     .with(csrf()))
                 .andExpect(status().is3xxRedirection());
 
-            Map<String, Object> row = jdbcTemplate.queryForMap(
-                "SELECT actor_user_id, target_id, details::text AS details FROM audit_event "
-                    + "WHERE event_type = 'email_verified' AND tenant_id = ? "
-                    + "ORDER BY occurred_at DESC LIMIT 1",
-                tenant.id());
-            assertThat(row.get("actor_user_id")).isEqualTo(user.id());
-            assertThat(row.get("target_id")).isEqualTo(String.valueOf(user.id()));
-            assertThat(row.get("details").toString()).contains(email);
+            await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+                List<Map<String, Object>> rows = jdbcTemplate.queryForList(
+                    "SELECT actor_user_id, target_id, details::text AS details FROM audit_event "
+                        + "WHERE event_type = 'email_verified' AND tenant_id = ? "
+                        + "ORDER BY occurred_at DESC LIMIT 1",
+                    tenant.id());
+                assertThat(rows).isNotEmpty();
+                Map<String, Object> row = rows.get(0);
+                assertThat(row.get("actor_user_id")).isEqualTo(user.id());
+                assertThat(row.get("target_id")).isEqualTo(String.valueOf(user.id()));
+                assertThat(row.get("details").toString()).contains(email);
+            });
         }
 
         @Test
@@ -245,15 +256,19 @@ class EmailVerificationFlowIntegrationTest {
                     .with(csrf()))
                 .andExpect(status().is3xxRedirection());
 
-            Map<String, Object> row = jdbcTemplate.queryForMap(
-                "SELECT actor_user_id, target_id, details::text AS details FROM audit_event "
-                    + "WHERE event_type = 'verification_resent' AND tenant_id = ? "
-                    + "ORDER BY occurred_at DESC LIMIT 1",
-                tenant.id());
-            assertThat(row.get("actor_user_id")).isNull();
-            assertThat(row.get("target_id")).isNull();
-            assertThat(row.get("details").toString().replace(" ", ""))
-                .contains("\"delivered\":false");
+            await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+                List<Map<String, Object>> rows = jdbcTemplate.queryForList(
+                    "SELECT actor_user_id, target_id, details::text AS details FROM audit_event "
+                        + "WHERE event_type = 'verification_resent' AND tenant_id = ? "
+                        + "ORDER BY occurred_at DESC LIMIT 1",
+                    tenant.id());
+                assertThat(rows).isNotEmpty();
+                Map<String, Object> row = rows.get(0);
+                assertThat(row.get("actor_user_id")).isNull();
+                assertThat(row.get("target_id")).isNull();
+                assertThat(row.get("details").toString().replace(" ", ""))
+                    .contains("\"delivered\":false");
+            });
         }
     }
 

--- a/src/test/java/com/stucray/limen/auth/ott/PasswordResetFlowIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/auth/ott/PasswordResetFlowIntegrationTest.java
@@ -23,12 +23,15 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 import java.sql.Timestamp;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -186,20 +189,27 @@ class PasswordResetFlowIntegrationTest {
             assertThat(stored.getAuthentication()).isNotInstanceOf(TenantOttAuthentication.class);
             assertThat(stored.getAuthentication().isAuthenticated()).isTrue();
 
-            Map<String, Object> resetCompleted = jdbcTemplate.queryForMap(
-                "SELECT actor_user_id, target_id FROM audit_event "
-                    + "WHERE event_type = 'password_reset_completed' AND tenant_id = ? "
-                    + "ORDER BY occurred_at DESC LIMIT 1",
-                tenant.id());
-            assertThat(resetCompleted.get("actor_user_id")).isEqualTo(user.id());
-            assertThat(resetCompleted.get("target_id")).isEqualTo(String.valueOf(user.id()));
+            await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+                List<Map<String, Object>> rows = jdbcTemplate.queryForList(
+                    "SELECT actor_user_id, target_id FROM audit_event "
+                        + "WHERE event_type = 'password_reset_completed' AND tenant_id = ? "
+                        + "ORDER BY occurred_at DESC LIMIT 1",
+                    tenant.id());
+                assertThat(rows).isNotEmpty();
+                Map<String, Object> resetCompleted = rows.get(0);
+                assertThat(resetCompleted.get("actor_user_id")).isEqualTo(user.id());
+                assertThat(resetCompleted.get("target_id")).isEqualTo(String.valueOf(user.id()));
+            });
 
-            Map<String, Object> passwordChanged = jdbcTemplate.queryForMap(
-                "SELECT details::text AS details FROM audit_event "
-                    + "WHERE event_type = 'password_changed' AND tenant_id = ? "
-                    + "ORDER BY occurred_at DESC LIMIT 1",
-                tenant.id());
-            assertThat(passwordChanged.get("details").toString()).contains("self_service");
+            await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+                List<Map<String, Object>> rows = jdbcTemplate.queryForList(
+                    "SELECT details::text AS details FROM audit_event "
+                        + "WHERE event_type = 'password_changed' AND tenant_id = ? "
+                        + "ORDER BY occurred_at DESC LIMIT 1",
+                    tenant.id());
+                assertThat(rows).isNotEmpty();
+                assertThat(rows.get(0).get("details").toString()).contains("self_service");
+            });
         }
 
         @Test
@@ -236,11 +246,18 @@ class PasswordResetFlowIntegrationTest {
                     .session(session).with(csrf()))
                 .andExpect(status().is3xxRedirection());
 
-            Integer completedCount = jdbcTemplate.queryForObject(
+            // The first submit emits one password_reset_completed; the second must not.
+            // Wait for the first event to land, then assert the count stays at 1.
+            await().atMost(Duration.ofSeconds(5)).untilAsserted(() ->
+                assertThat(passwordResetCompletedCount(tenant.id())).isEqualTo(1));
+            assertThat(passwordResetCompletedCount(tenant.id())).isEqualTo(1);
+        }
+
+        private Integer passwordResetCompletedCount(Long tenantId) {
+            return jdbcTemplate.queryForObject(
                 "SELECT COUNT(*) FROM audit_event "
                     + "WHERE event_type = 'password_reset_completed' AND tenant_id = ?",
-                Integer.class, tenant.id());
-            assertThat(completedCount).isEqualTo(1);
+                Integer.class, tenantId);
         }
     }
 
@@ -326,16 +343,20 @@ class PasswordResetFlowIntegrationTest {
                     .param("email", email).with(csrf()))
                 .andExpect(status().is3xxRedirection());
 
-            Map<String, Object> row = jdbcTemplate.queryForMap(
-                "SELECT actor_user_id, target_id, details::text AS details FROM audit_event "
-                    + "WHERE event_type = 'password_reset_ott_issued' AND tenant_id = ? "
-                    + "ORDER BY occurred_at DESC LIMIT 1",
-                tenant.id());
-            assertThat(row.get("actor_user_id")).isEqualTo(user.id());
-            assertThat(row.get("target_id")).isEqualTo(String.valueOf(user.id()));
-            String details = row.get("details").toString().replace(" ", "");
-            assertThat(details).contains("\"delivered\":true");
-            assertThat(details).contains(email);
+            await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+                List<Map<String, Object>> rows = jdbcTemplate.queryForList(
+                    "SELECT actor_user_id, target_id, details::text AS details FROM audit_event "
+                        + "WHERE event_type = 'password_reset_ott_issued' AND tenant_id = ? "
+                        + "ORDER BY occurred_at DESC LIMIT 1",
+                    tenant.id());
+                assertThat(rows).isNotEmpty();
+                Map<String, Object> row = rows.get(0);
+                assertThat(row.get("actor_user_id")).isEqualTo(user.id());
+                assertThat(row.get("target_id")).isEqualTo(String.valueOf(user.id()));
+                String details = row.get("details").toString().replace(" ", "");
+                assertThat(details).contains("\"delivered\":true");
+                assertThat(details).contains(email);
+            });
         }
 
         @Test
@@ -349,15 +370,19 @@ class PasswordResetFlowIntegrationTest {
                     .param("email", "ghost-" + suffix + "@example.test").with(csrf()))
                 .andExpect(status().is3xxRedirection());
 
-            Map<String, Object> row = jdbcTemplate.queryForMap(
-                "SELECT actor_user_id, target_id, details::text AS details FROM audit_event "
-                    + "WHERE event_type = 'password_reset_ott_issued' AND tenant_id = ? "
-                    + "ORDER BY occurred_at DESC LIMIT 1",
-                tenant.id());
-            assertThat(row.get("actor_user_id")).isNull();
-            assertThat(row.get("target_id")).isNull();
-            assertThat(row.get("details").toString().replace(" ", ""))
-                .contains("\"delivered\":false");
+            await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+                List<Map<String, Object>> rows = jdbcTemplate.queryForList(
+                    "SELECT actor_user_id, target_id, details::text AS details FROM audit_event "
+                        + "WHERE event_type = 'password_reset_ott_issued' AND tenant_id = ? "
+                        + "ORDER BY occurred_at DESC LIMIT 1",
+                    tenant.id());
+                assertThat(rows).isNotEmpty();
+                Map<String, Object> row = rows.get(0);
+                assertThat(row.get("actor_user_id")).isNull();
+                assertThat(row.get("target_id")).isNull();
+                assertThat(row.get("details").toString().replace(" ", ""))
+                    .contains("\"delivered\":false");
+            });
         }
     }
 

--- a/src/test/java/com/stucray/limen/ui/journey/PasswordResetJourneyUiIT.java
+++ b/src/test/java/com/stucray/limen/ui/journey/PasswordResetJourneyUiIT.java
@@ -21,10 +21,12 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.client.RestClient;
 
+import java.time.Duration;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 /**
  * Playwright UI journey for slice 5: an existing tenant admin clicks "Forgot
@@ -103,13 +105,16 @@ class PasswordResetJourneyUiIT {
         page.waitForURL(baseUrl() + "/t/" + slug + "/");
 
         // The completed reset emitted password_reset_completed; confirm the
-        // audit row landed alongside the password_changed row.
-        Long count = jdbcTemplate.queryForObject(
-            "SELECT count(*) FROM audit_event "
-                + "WHERE event_type = 'password_reset_completed' "
-                + "AND tenant_id = ?",
-            Long.class, tenant.tenantId());
-        assertThat(count).isEqualTo(1L);
+        // audit row landed alongside the password_changed row. Async dispatch
+        // via the Modulith publication registry means we poll until it lands.
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            Long count = jdbcTemplate.queryForObject(
+                "SELECT count(*) FROM audit_event "
+                    + "WHERE event_type = 'password_reset_completed' "
+                    + "AND tenant_id = ?",
+                Long.class, tenant.tenantId());
+            assertThat(count).isEqualTo(1L);
+        });
     }
 
     private String waitForResetLink(String recipientEmail) throws Exception {

--- a/src/test/java/com/stucray/limen/users/UserManagementIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/users/UserManagementIntegrationTest.java
@@ -19,12 +19,14 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -188,8 +190,12 @@ class UserManagementIntegrationTest {
 
         User updated = userRepository.findById(alice.id()).orElseThrow();
         assertThat(updated.mustChangePassword()).isTrue();
-        Map<String, Object> row = latestEventOfType(tenant.id(), "password_changed");
-        assertThat(row.get("details").toString().replace(" ", "")).contains("\"trigger\":\"admin_reset\"");
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            Map<String, Object> row = latestEventOfType(tenant.id(), "password_changed");
+            assertThat(row).isNotNull();
+            assertThat(row.get("details").toString().replace(" ", ""))
+                .contains("\"trigger\":\"admin_reset\"");
+        });
     }
 
     @Test
@@ -380,8 +386,12 @@ class UserManagementIntegrationTest {
             .andExpect(status().is3xxRedirection());
 
         assertThat(userRepository.findById(newUser.id()).orElseThrow().mustChangePassword()).isFalse();
-        Map<String, Object> row = latestEventOfType(tenant.id(), "password_changed");
-        assertThat(row.get("details").toString().replace(" ", "")).contains("\"trigger\":\"forced\"");
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            Map<String, Object> row = latestEventOfType(tenant.id(), "password_changed");
+            assertThat(row).isNotNull();
+            assertThat(row.get("details").toString().replace(" ", ""))
+                .contains("\"trigger\":\"forced\"");
+        });
     }
 
     @Test
@@ -391,8 +401,12 @@ class UserManagementIntegrationTest {
                 .param("newPassword", "newpass123").param("confirmPassword", "newpass123"))
             .andExpect(status().is3xxRedirection());
 
-        Map<String, Object> row = latestEventOfType(tenant.id(), "password_changed");
-        assertThat(row.get("details").toString().replace(" ", "")).contains("\"trigger\":\"self_service\"");
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            Map<String, Object> row = latestEventOfType(tenant.id(), "password_changed");
+            assertThat(row).isNotNull();
+            assertThat(row.get("details").toString().replace(" ", ""))
+                .contains("\"trigger\":\"self_service\"");
+        });
     }
 
     @Test
@@ -452,16 +466,27 @@ class UserManagementIntegrationTest {
         return (MockHttpSession) login.getRequest().getSession(false);
     }
 
+    // The AFTER_COMMIT-bound dispatcher runs asynchronously under the Modulith
+    // publication registry, so positive audit-row checks poll until the row
+    // lands. Negative checks (assertNoAuditRow / "count is zero") follow a
+    // rejected action that never commits, so no event is ever emitted; a
+    // synchronous read is safe.
+
     private void assertAuditRow(Long tenantId, String eventType, Long actorUserId, Long targetUserId, String email) {
-        Map<String, Object> row = latestEventOfType(tenantId, eventType);
-        assertThat(row.get("actor_user_id")).isEqualTo(actorUserId);
-        assertThat(row.get("target_id")).isEqualTo(String.valueOf(targetUserId));
-        assertThat(row.get("details").toString().replace(" ", "")).contains("\"email\":\"" + email + "\"");
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            Map<String, Object> row = latestEventOfType(tenantId, eventType);
+            assertThat(row).as("expected %s row for tenant %d", eventType, tenantId).isNotNull();
+            assertThat(row.get("actor_user_id")).isEqualTo(actorUserId);
+            assertThat(row.get("target_id")).isEqualTo(String.valueOf(targetUserId));
+            assertThat(row.get("details").toString().replace(" ", "")).contains("\"email\":\"" + email + "\"");
+        });
     }
 
     private void assertAuditRowExists(Long tenantId, String eventType, Long targetUserId) {
-        long count = countAuditRows(tenantId, eventType, targetUserId);
-        assertThat(count).as("expected %s row for user %d", eventType, targetUserId).isGreaterThan(0);
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() ->
+            assertThat(countAuditRows(tenantId, eventType, targetUserId))
+                .as("expected %s row for user %d", eventType, targetUserId)
+                .isGreaterThan(0));
     }
 
     private void assertNoAuditRow(Long tenantId, String eventType) {
@@ -478,10 +503,11 @@ class UserManagementIntegrationTest {
         return count == null ? 0 : count;
     }
 
-    private Map<String, Object> latestEventOfType(Long tenantId, String eventType) {
-        return jdbcTemplate.queryForMap(
+    private @org.jspecify.annotations.Nullable Map<String, Object> latestEventOfType(Long tenantId, String eventType) {
+        List<Map<String, Object>> rows = jdbcTemplate.queryForList(
             "SELECT event_type, tenant_id, actor_user_id, target_type, target_id, details::text AS details "
                 + "FROM audit_event WHERE tenant_id = ? AND event_type = ? ORDER BY occurred_at DESC LIMIT 1",
             tenantId, eventType);
+        return rows.isEmpty() ? null : rows.get(0);
     }
 }


### PR DESCRIPTION
## Summary

Closes the audit at-least-once gap for transactionally-sourced domain events. PR A from PRD #151; closes #153.

- Adds `spring-modulith-starter-jdbc` (runtime) + Flyway V10 for `event_publication`.
- Swaps `AuditDispatcher.onAfterCommit` from `@TransactionalEventListener(AFTER_COMMIT)` to `@ApplicationModuleListener` — a JVM crash between commit and listener execution is replayed on next startup.
- Narrows the listener parameter from `Object` to a new `AuditedDomainEvent` marker that the 19 transactionally-emitted audit event records now implement. Without the narrowing, Modulith's publication registry would catch every Spring framework startup event (`ContextRefreshedEvent`, etc.) and try to JSON-serialize the source — i.e. the entire application context. The first context-load attempt blew up with a Jackson cyclic-serialization stack trace; the marker scopes persistence to events the registry actually has rules for.
- Wraps positive audit-row assertions in seven existing Testcontainers integration tests with Awaitility polling, since the AFTER_COMMIT listener now runs asynchronously. Negative ("no row") assertions stay synchronous — they follow rejected actions that never commit.
- Architecture doc updated: §4.8 (mermaid + bounded-guarantee framing + duplicate-on-replay caveat), §5 (best-effort gap reframed), §6 v3.5 item 10 marked done with PR ref.

## Honest scope

- The guarantee applies only to the `@ApplicationModuleListener` path. Audit rows derived from Spring Security auth events and `RateLimitHitEvent` go through the IMMEDIATE `@EventListener` path because those events have no enclosing transaction; closing that gap needs an outbox-style approach and is out of scope.
- Application-level write failures are still swallowed by `safeWrite`, so the publication is marked complete and not retried. The at-least-once guarantee here is about *delivery* (the listener was invoked), not eventual write success. Documented in §4.8.
- No idempotency key on `audit_event` — duplicates are possible on rare restart-after-failure. Adding one is a follow-up if duplicates are observed.

## Test plan

- [x] `./mvnw clean verify` — 393 surefire + 15 failsafe tests, all pass
- [x] V10 migration creates `event_publication` against the v2 PostgreSQL schema bundled with `spring-modulith-events-jdbc` 2.0.x
- [x] `AuditDispatcher.onAfterCommit` uses `@ApplicationModuleListener`; the sibling `@EventListener` is unchanged
- [x] Seven integration tests pass under async delivery (Awaitility-based polling, applied consistently)
- [x] `LimenModuleArchitectureTest` (slice 1's Modulith verifier) still green with the new module-level imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)