### PR TITLE
ci: auto-close parent issue when all sub-issues are closed

### DIFF
--- a/.github/workflows/close-prd.yml
+++ b/.github/workflows/close-prd.yml
@@ -1,0 +1,84 @@
+# Auto-closes a parent issue (typically a PRD) when its last open sub-issue
+# is closed. Uses GitHub's native sub-issue feature, not title-trailer parsing.
+#
+# Trigger: any issue close. The workflow looks up the closed issue's parent
+# (via GraphQL `parent` field), lists the parent's sub-issues, and if every
+# one is closed, closes the parent with a summary comment. No-op if the
+# closed issue has no parent or the parent is already closed.
+#
+# Idempotency / concurrency: a workflow-level concurrency group serialises
+# runs across the repo, and the parent-state check before closing means a
+# second concurrent close attempt is a no-op rather than a duplicate comment.
+
+name: Auto-close PRD when all sub-issues are closed
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  issues: write
+
+concurrency:
+  group: close-prd
+  cancel-in-progress: false
+
+jobs:
+  close-parent-if-children-done:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Close parent if all sub-issues are closed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          OWNER="${REPO%/*}"
+          NAME="${REPO#*/}"
+
+          # Find the parent issue (if any).
+          PARENT=$(gh api graphql -f query="
+            query { repository(owner: \"$OWNER\", name: \"$NAME\") {
+                issue(number: $ISSUE_NUMBER) { parent { number state } }
+            } }" --jq '.data.repository.issue.parent')
+
+          if [ -z "$PARENT" ] || [ "$PARENT" = "null" ]; then
+            echo "::notice::Issue #$ISSUE_NUMBER has no parent; nothing to do."
+            exit 0
+          fi
+
+          PARENT_NUMBER=$(echo "$PARENT" | jq -r '.number')
+          PARENT_STATE=$(echo "$PARENT" | jq -r '.state')
+
+          if [ "$PARENT_STATE" = "CLOSED" ]; then
+            echo "::notice::Parent #$PARENT_NUMBER is already closed; nothing to do."
+            exit 0
+          fi
+
+          # All open sub-issues must be empty for us to close the parent.
+          OPEN_COUNT=$(gh api "repos/$REPO/issues/$PARENT_NUMBER/sub_issues" \
+            --jq '[.[] | select(.state == "open")] | length')
+
+          if [ "$OPEN_COUNT" -gt 0 ]; then
+            echo "::notice::Parent #$PARENT_NUMBER still has $OPEN_COUNT open sub-issue(s); not closing."
+            exit 0
+          fi
+
+          # Build a child summary for the closing comment.
+          CHILDREN=$(gh api "repos/$REPO/issues/$PARENT_NUMBER/sub_issues" \
+            --jq 'map("- #\(.number) — \(.title)") | join("\n")')
+
+          {
+            echo "All sub-issues are closed; auto-closing this issue."
+            echo
+            echo "Closed sub-issues:"
+            echo
+            echo "$CHILDREN"
+            echo
+            echo "_Triggered by the close of #$ISSUE_NUMBER. Auto-closed by \`.github/workflows/close-prd.yml\`._"
+          } > /tmp/close-comment.md
+
+          gh issue close "$PARENT_NUMBER" --repo "$REPO" --comment "$(cat /tmp/close-comment.md)"
+          echo "::notice::Closed parent #$PARENT_NUMBER."


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/close-prd.yml` — triggers on `issues.closed`, looks up the parent via GitHub's native sub-issue link (GraphQL `parent` field), and closes it with a summary comment if every sub-issue is now closed. No-op when no parent or parent already closed.
- Concurrency group serialises runs across the repo; the parent-state guard makes a second concurrent run idempotent (no duplicate close, no duplicate comment).
- Workflow is repo-agnostic — any issue with sub-issues benefits, not just title-prefixed PRDs.
- Companion change (already applied, outside this PR): updated user-level `prd-to-issues` skill so future PRDs link slices as native sub-issues at creation time.

## Pre-merge cleanup already done
- PRD #151 had its two slices (#152, #153) back-linked as sub-issues and was manually closed with a summary comment, so we have a known-good linked PRD on file even before the automation goes live.

## Test plan
- [ ] After merge, verify the workflow appears at `.github/workflows/close-prd.yml` and is enabled in Actions.
- [ ] First validation will happen organically: when the next PRD's last slice closes, the workflow should auto-close the PRD with a summary comment.
- [ ] Negative test: closing a regular issue (no parent) should produce a `::notice::` log line and exit 0 with no side-effects.
- [ ] Confirm the GraphQL `parent` lookup uses the same auth as `gh api` — `secrets.GITHUB_TOKEN` with `permissions: issues: write` should be sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)