### PR TITLE
feat: add mailpit to docker-compose for dev email capture

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,5 +15,23 @@ services:
       timeout: 5s
       retries: 5
 
+  # Mailpit captures every outbound email (SMTP on 1025) and exposes a web
+  # inbox at http://localhost:8025. Lightweight (~25MB image, single Go
+  # binary) so it's always-on alongside Postgres. Captured messages live in
+  # memory only — restart wipes the inbox, which matches the dev workflow.
+  # To deliver to it, run with `--spring.profiles.active=mailpit` (see
+  # src/main/resources/application-mailpit.yaml). Default profile keeps
+  # `limen.email.driver: logging` so emails go to the application log.
+  mailpit:
+    image: axllent/mailpit:latest
+    ports:
+      - "1025:1025"  # SMTP
+      - "8025:8025"  # web UI / API
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8025/api/v1/info"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
 volumes:
   auth_postgres_data:

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -369,7 +369,7 @@ Properties:
 | Driver | Implementation | When |
 |---|---|---|
 | `logging` (default) | `LoggingEmailSender` | Dev: writes the rendered message to slf4j; click the magic link straight from the log. No outbound network. |
-| `smtp` | `SmtpEmailSender` | Test profile (Mailpit Testcontainer) and production (real SMTP host). |
+| `smtp` | `SmtpEmailSender` | Test profile (Mailpit Testcontainer), local dev via the `mailpit` profile (Mailpit in `docker-compose.yml`, web inbox at http://localhost:8025), and production (real SMTP host). |
 
 There is intentionally no third "real provider" implementation in v3 — Resend / Brevo / SendGrid wiring is a deferred config swap on top of this abstraction (see §6 v4). All callers are OTT generation success handlers and audit-driven notifications; the rest of the codebase never names a concrete sender.
 

--- a/src/main/resources/application-mailpit.yaml
+++ b/src/main/resources/application-mailpit.yaml
@@ -1,0 +1,11 @@
+# Activate with `--spring.profiles.active=mailpit` (or
+# `SPRING_PROFILES_ACTIVE=mailpit`) to deliver outbound email through the
+# Mailpit container declared in docker-compose.yml. Inspect captured
+# messages at http://localhost:8025.
+limen:
+  email:
+    driver: smtp
+spring:
+  mail:
+    host: localhost
+    port: 1025

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,7 +8,9 @@ limen:
     # logging | smtp. Default writes outbound emails to slf4j INFO so a developer
     # can read magic links from the application log without running mail
     # infrastructure. Set to `smtp` (and configure spring.mail.*) in any
-    # deployment that should actually deliver mail.
+    # deployment that should actually deliver mail. For local dev with the
+    # Mailpit container, run with `--spring.profiles.active=mailpit` — see
+    # application-mailpit.yaml.
     driver: logging
   lockout:
     # Consecutive failed-login attempts before the account is locked. Small


### PR DESCRIPTION
## Summary
- Adds the Mailpit (`axllent/mailpit`) container to `docker-compose.yml` so `spring-boot-docker-compose` brings it up alongside Postgres in dev. SMTP on `1025`, web inbox at http://localhost:8025.
- Adds `src/main/resources/application-mailpit.yaml` — activate with `--spring.profiles.active=mailpit` to flip `limen.email.driver` to `smtp` and point `spring.mail` at the container.
- Default behaviour unchanged: `limen.email.driver: logging` stays the default, so no-profile `mvn spring-boot:run` still writes emails to the application log (current dev habit).
- Updates the inline comment in `application.yaml` and architecture.md §4.7 to mention the dev-mode Mailpit option.

## Why a profile and not always-on
Keeping `limen.email.driver=logging` as the default preserves the lean dev workflow ("read magic links from the log without any infra"). Mailpit is opt-in for the cases where you want to inspect rendered HTML, headers, or multiple recipients in a captured-inbox UI.

## Validation
- Locally: `docker compose config` parses; `docker compose up -d mailpit` brings the container up to `healthy`; `curl http://localhost:8025/api/v1/info` returns Mailpit v1.29.7 metadata; tear-down is clean.

## Test plan
- [ ] Pull the branch, `mvn spring-boot:run --spring.profiles.active=mailpit`. Trigger signup or forgot-password. Email should appear in the Mailpit inbox at http://localhost:8025.
- [ ] Pull the branch, `mvn spring-boot:run` (no profile). Trigger signup. Email should still appear in the log (LoggingEmailSender) — Mailpit is up but unused.
- [ ] Confirm no port clash: 1025 / 8025 must be free locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)