### PR TITLE
feat: auto-activate mailpit profile on mvn spring-boot:run

### DIFF
--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -369,7 +369,7 @@ Properties:
 | Driver | Implementation | When |
 |---|---|---|
 | `logging` (default) | `LoggingEmailSender` | Dev: writes the rendered message to slf4j; click the magic link straight from the log. No outbound network. |
-| `smtp` | `SmtpEmailSender` | Test profile (Mailpit Testcontainer), local dev via the `mailpit` profile (Mailpit in `docker-compose.yml`, web inbox at http://localhost:8025), and production (real SMTP host). |
+| `smtp` | `SmtpEmailSender` | Test profile (Mailpit Testcontainer), local dev (the `mailpit` profile is auto-activated by `mvn spring-boot:run` via the spring-boot-maven-plugin's `<profiles>` config in `pom.xml`; Mailpit lives in `docker-compose.yml`, web inbox at http://localhost:8025), and production (real SMTP host). |
 
 There is intentionally no third "real provider" implementation in v3 — Resend / Brevo / SendGrid wiring is a deferred config swap on top of this abstraction (see §6 v4). All callers are OTT generation success handlers and audit-driven notifications; the rest of the codebase never names a concrete sender.
 

--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,20 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<!--
+						Auto-activate the `mailpit` Spring profile when running
+						the app via `mvn spring-boot:run` so emails are
+						captured by the Mailpit container declared in
+						docker-compose.yml (web inbox at http://localhost:8025).
+						Scoped to the run goal — `mvn test`/`verify` and the
+						`build-image` goal are unaffected, so the test suite
+						and production image keep the `logging` default.
+					-->
+					<profiles>
+						<profile>mailpit</profile>
+					</profiles>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/src/main/resources/application-mailpit.yaml
+++ b/src/main/resources/application-mailpit.yaml
@@ -1,7 +1,8 @@
-# Activate with `--spring.profiles.active=mailpit` (or
-# `SPRING_PROFILES_ACTIVE=mailpit`) to deliver outbound email through the
-# Mailpit container declared in docker-compose.yml. Inspect captured
-# messages at http://localhost:8025.
+# Auto-activated by `mvn spring-boot:run` via spring-boot-maven-plugin's
+# <profiles> configuration in pom.xml. Also activates manually via
+# `--spring.profiles.active=mailpit` or `SPRING_PROFILES_ACTIVE=mailpit`.
+# Delivers outbound email through the Mailpit container in
+# docker-compose.yml; inspect captured messages at http://localhost:8025.
 limen:
   email:
     driver: smtp

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,12 +5,13 @@ limen:
     # 14 days
     remember-me-validity-seconds: 1209600
   email:
-    # logging | smtp. Default writes outbound emails to slf4j INFO so a developer
-    # can read magic links from the application log without running mail
-    # infrastructure. Set to `smtp` (and configure spring.mail.*) in any
-    # deployment that should actually deliver mail. For local dev with the
-    # Mailpit container, run with `--spring.profiles.active=mailpit` — see
-    # application-mailpit.yaml.
+    # logging | smtp. Base default is `logging` — outbound emails land at
+    # slf4j INFO. The spring-boot-maven-plugin is configured to auto-activate
+    # the `mailpit` profile on `mvn spring-boot:run`, which flips this to
+    # `smtp` and points spring.mail at the Mailpit container in
+    # docker-compose.yml (web inbox at http://localhost:8025). The base
+    # default still applies to `mvn test`/`verify` and the production image,
+    # which override via env vars in real deployments.
     driver: logging
   lockout:
     # Consecutive failed-login attempts before the account is locked. Small


### PR DESCRIPTION
## Summary
- Configures `spring-boot-maven-plugin`'s `<profiles>` so `mvn spring-boot:run` auto-activates the `mailpit` profile. Outbound emails go to the Mailpit inbox at http://localhost:8025 out of the box — no `--spring.profiles.active` flag needed.
- Scoped to the `run` goal: `mvn test`/`verify` and the `build-image` goal are untouched. Test suite (e.g. `LoggingEmailSenderIntegrationTest` which asserts the LoggingEmailSender default) and the production container image both keep `limen.email.driver: logging` as the base default; production overrides via env vars at deploy time.
- Inline comments in `application.yaml` and `application-mailpit.yaml` updated to reflect the new auto-activation. Architecture.md §4.7 likewise.

## Why this and not `spring.profiles.default: mailpit`
The simpler option, suggested earlier, would activate the profile during any `@SpringBootTest` with no `@ActiveProfiles` set — breaking `LoggingEmailSenderIntegrationTest` (which asserts `emailSender instanceof LoggingEmailSender` based on the default config) and potentially leaking Mailpit-pointing config into other tests that don't expect it. The maven-plugin scoping keeps the test boundary clean while still delivering the dev-experience win.

## Validation
- `./mvnw validate` exits 0; `./mvnw help:effective-pom` shows the `<profiles><profile>mailpit</profile></profiles>` block in `spring-boot-maven-plugin`'s configuration.

## Test plan
- [ ] `./mvnw spring-boot:run` (no profile flag) — startup log should show `The following 1 profile is active: "mailpit"`. Trigger signup/forgot-password; email should appear in the Mailpit inbox at http://localhost:8025.
- [ ] `./mvnw verify` — full test suite still green; `LoggingEmailSenderIntegrationTest` still passes (it inherits the base `logging` default, no profile activation).
- [ ] To override (use logging in dev anyway): `./mvnw spring-boot:run -Dspring-boot.run.profiles=` (empty profiles) or set `LIMEN_EMAIL_DRIVER=logging` via env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)