### PR TITLE
fix: explicit OTLP endpoints for tracing and logging exporters

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -104,3 +104,16 @@ management:
       # `service.name` defaults to spring.application.name (`limen`).
       # `deployment.environment` is overridable via env at deploy time.
       deployment.environment: dev
+    tracing:
+      export:
+        otlp:
+          # Trace export endpoint. Micrometer's OtlpMeterRegistry has a
+          # baked-in default for metrics, but tracing requires this
+          # explicitly. Override per env via OTEL_EXPORTER_OTLP_ENDPOINT
+          # (which sets the base URL; the SDK appends /v1/traces).
+          endpoint: http://localhost:4318/v1/traces
+    logging:
+      export:
+        otlp:
+          # Same reasoning as tracing above. SDK appends /v1/logs.
+          endpoint: http://localhost:4318/v1/logs


### PR DESCRIPTION
## Summary

- Sets `management.tracing.export.otlp.endpoint` and `management.logging.export.otlp.endpoint` to `http://localhost:4318/v1/{traces,logs}` so traces and logs export correctly when the LGTM container is started outside of `docker compose` (i.e. when Spring Boot's DockerCompose auto-wiring isn't engaged).
- Mirrors the metrics path: Micrometer's `OtlpMeterRegistry` already ships with a baked-in default of `http://localhost:4318/v1/metrics`, so metrics work out of the box but traces/logs silently dropped.
- Production still overrides via the standard `OTEL_EXPORTER_OTLP_ENDPOINT` env var (which sets the base URL; the SDK appends the per-signal suffix).

## Test plan

- [x] `mvn verify` — full suite passes (no behaviour change in tests; `OTEL_SDK_DISABLED=true` keeps the surefire/failsafe runs from exporting)
- [ ] Smoke check in dev: start LGTM standalone (not via compose), `mvn spring-boot:run`, hit `/oauth2/token` once, and confirm a trace appears in Tempo and the corresponding log line in Loki

🤖 Generated with [Claude Code](https://claude.com/claude-code)