### PR TITLE
feat: per-tenant signing-key rotation core (slice 1 of #173)

### DIFF
--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -281,7 +281,8 @@ Properties:
 - **Per-key random salt** stored in the `iv` column. The column is named `iv` for historical reasons; it is the salt passed to `Encryptors.stronger`, not an AES IV.
 - **Public key stored as a JWK in plaintext** (`public_key_jwk`) so that the JWKS endpoint can be served without decrypting anything.
 - **Keys are created during Tenant provisioning** by `TenantProvisioningService` calling `SigningKeyStore.createForTenant(tenantId)`. The System Tenant does not get a signing key — it never issues tokens.
-- **Rotation is supported by the schema but not yet automated.** The `status` column (`ACTIVE` / `RETIRED`) plus the partial unique index allows multiple keys per Tenant with one ACTIVE; no scheduled job currently performs rotation.
+- **Per-tenant rotation is supported by `SigningKeyStore.rotateForTenant`** (and orchestrated by `SigningKeyRotator`, which publishes a `SigningKeyRotatedEvent` consumed by the audit dispatcher and `AuditMetricsListener`'s `limen.security.signing_key.rotated` counter). Storage swap is one transaction: the existing `ACTIVE` row is updated to `RETIRED` with `retired_at = now()`, then the new `ACTIVE` row is inserted — order forced by the partial unique index. A scheduled batch driver and prune of grace-expired `RETIRED` keys are tracked separately under §6 v3.5 #13.
+- **The JWKS endpoint advertises both `ACTIVE` and `RETIRED` keys for a tenant.** `TenantJwkSource` branches on selector intent: SAS's signing path (selector constrained by keyType + keyUse + algorithm) returns the `ACTIVE` key only with private material decrypted, so `NimbusJwtEncoder`'s strict single-match contract is satisfied. The JWKS-endpoint path (match-all selector) returns every key for the tenant, public-only. This means resource servers caching the JWKS can validate tokens signed by either the current `ACTIVE` or a recently-`RETIRED` key throughout a rotation grace window.
 
 ### 4.5 Authentication flows
 

--- a/src/main/java/com/stucray/limen/audit/dispatch/AuditRegistry.java
+++ b/src/main/java/com/stucray/limen/audit/dispatch/AuditRegistry.java
@@ -8,6 +8,7 @@ import com.stucray.limen.audit.events.PasswordChangedEvent;
 import com.stucray.limen.audit.events.PasswordResetCompletedEvent;
 import com.stucray.limen.audit.events.PasswordResetOttIssuedEvent;
 import com.stucray.limen.audit.events.RateLimitHitEvent;
+import com.stucray.limen.audit.events.SigningKeyRotatedEvent;
 import com.stucray.limen.audit.events.TenantCreatedEvent;
 import com.stucray.limen.audit.events.TenantDeletedEvent;
 import com.stucray.limen.audit.events.TenantOwnershipGrantedEvent;
@@ -104,6 +105,14 @@ public class AuditRegistry {
                 event.tenantId(), event.actorUserId(),
                 "registered_client", event.registeredClientId(),
                 Map.of())),
+
+        // No actor — rotation is system-driven. Target is the kid (the new
+        // ACTIVE one); both kids land in details so the trail is reconstructable.
+        new AuditRule<>(SigningKeyRotatedEvent.class, "signing_key_rotated", AFTER_COMMIT,
+            event -> AuditRule.Projection.of(
+                event.tenantId(), null,
+                "signing_key", event.newKid(),
+                Map.of("oldKid", event.oldKid(), "newKid", event.newKid()))),
 
         new AuditRule<>(VerificationOttIssuedEvent.class, "verification_ott_issued", AFTER_COMMIT,
             event -> AuditRule.Projection.ofUser(

--- a/src/main/java/com/stucray/limen/audit/events/SigningKeyRotatedEvent.java
+++ b/src/main/java/com/stucray/limen/audit/events/SigningKeyRotatedEvent.java
@@ -1,0 +1,7 @@
+package com.stucray.limen.audit.events;
+
+public record SigningKeyRotatedEvent(
+    Long tenantId,
+    String oldKid,
+    String newKid
+) implements AuditedDomainEvent {}

--- a/src/main/java/com/stucray/limen/oauth2/TenantJwkSource.java
+++ b/src/main/java/com/stucray/limen/oauth2/TenantJwkSource.java
@@ -17,6 +17,26 @@ import org.springframework.security.oauth2.server.authorization.context.Authoriz
 
 import java.util.List;
 
+/**
+ * Branches by selector intent. SAS uses this {@link JWKSource} for two
+ * distinct callers:
+ *
+ * <ul>
+ *   <li><b>Signing</b> ({@code NimbusJwtEncoder.selectJwk}): the selector
+ *       constrains keyType/keyUse/algorithm. The encoder throws if the source
+ *       returns more than one match, so we return only the ACTIVE key (with
+ *       private material decrypted by {@link SigningKeyStore#getActiveSigningKey}).</li>
+ *   <li><b>JWKS endpoint</b> ({@code NimbusJwkSetEndpointFilter}): the selector
+ *       has an empty matcher (match-all). We return every key for the tenant
+ *       (ACTIVE + any RETIRED still inside the grace window), public-only via
+ *       {@link SigningKeyStore#getJwkSet}, so resource servers can validate
+ *       tokens signed by either key throughout a rotation overlap.</li>
+ * </ul>
+ *
+ * <p>Distinguishing intent by inspecting the selector's matcher is brittle if
+ * a third caller appears, but SAS only invokes this source via those two paths
+ * today and the dispatch is asserted by unit tests.
+ */
 public class TenantJwkSource implements JWKSource<SecurityContext> {
 
     private static final String TENANT_PATH_SEGMENT = "/t/";
@@ -37,11 +57,29 @@ public class TenantJwkSource implements JWKSource<SecurityContext> {
                 "TenantJwkSource invoked with no tenant context — no AuthorizationServerContext issuer and no TenantScope"
             );
         }
+        if (isMatchAllSelector(selector)) {
+            JWKSet allPublic = signingKeyStore.getJwkSet(tenantId);
+            if (allPublic.getKeys().isEmpty()) {
+                throw new IllegalStateException("No signing keys for tenant " + tenantId);
+            }
+            return selector.select(allPublic);
+        }
         RSAKey activeKey = signingKeyStore.getActiveSigningKey(tenantId);
         if (activeKey == null) {
             throw new IllegalStateException("No active signing key for tenant " + tenantId);
         }
         return selector.select(new JWKSet(activeKey));
+    }
+
+    private static boolean isMatchAllSelector(JWKSelector selector) {
+        // SAS's JWKS-endpoint filter passes `new JWKSelector(new JWKMatcher.Builder().build())`,
+        // i.e. a matcher with no constraints. The signing path constrains at least keyType,
+        // keyUse, and algorithm.
+        var m = selector.getMatcher();
+        return m.getKeyTypes() == null
+            && m.getKeyUses() == null
+            && m.getAlgorithms() == null
+            && m.getKeyIDs() == null;
     }
 
     private @Nullable Long resolveTenantId() {

--- a/src/main/java/com/stucray/limen/observability/AuditMetricsListener.java
+++ b/src/main/java/com/stucray/limen/observability/AuditMetricsListener.java
@@ -1,6 +1,7 @@
 package com.stucray.limen.observability;
 
 import com.stucray.limen.audit.events.ClientSecretRotatedEvent;
+import com.stucray.limen.audit.events.SigningKeyRotatedEvent;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.context.event.EventListener;
@@ -34,10 +35,12 @@ public class AuditMetricsListener {
     static final String LOGIN_SUCCESS = "limen.auth.login.success";
     static final String LOGIN_FAILURE = "limen.auth.login.failure";
     static final String CLIENT_SECRET_ROTATED = "limen.oauth2.client.secret.rotated";
+    static final String SIGNING_KEY_ROTATED = "limen.security.signing_key.rotated";
 
     private final MeterRegistry registry;
     private final Counter loginSuccess;
     private final Counter clientSecretRotated;
+    private final Counter signingKeyRotated;
 
     public AuditMetricsListener(MeterRegistry registry) {
         this.registry = registry;
@@ -47,6 +50,10 @@ public class AuditMetricsListener {
             .register(registry);
         this.clientSecretRotated = Counter.builder(CLIENT_SECRET_ROTATED)
             .description("OAuth2 client secret rotations.")
+            .baseUnit("events")
+            .register(registry);
+        this.signingKeyRotated = Counter.builder(SIGNING_KEY_ROTATED)
+            .description("Per-tenant JWT signing-key rotations.")
             .baseUnit("events")
             .register(registry);
     }
@@ -69,5 +76,10 @@ public class AuditMetricsListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onClientSecretRotated(ClientSecretRotatedEvent event) {
         clientSecretRotated.increment();
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onSigningKeyRotated(SigningKeyRotatedEvent event) {
+        signingKeyRotated.increment();
     }
 }

--- a/src/main/java/com/stucray/limen/security/JdbcSigningKeyStore.java
+++ b/src/main/java/com/stucray/limen/security/JdbcSigningKeyStore.java
@@ -5,10 +5,12 @@ import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
 import org.jspecify.annotations.Nullable;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.crypto.encrypt.BytesEncryptor;
 import org.springframework.security.crypto.encrypt.Encryptors;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
@@ -18,6 +20,7 @@ import java.sql.SQLException;
 import java.text.ParseException;
 import java.util.HexFormat;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 @Component
@@ -43,7 +46,7 @@ public class JdbcSigningKeyStore implements SigningKeyStore {
         });
     }
 
-    private static void insertActiveSigningKey(Connection conn, long tenantId, String kekPassword) throws SQLException {
+    private static String insertActiveSigningKey(Connection conn, long tenantId, String kekPassword) throws SQLException {
         RSAKey rsaKey;
         try {
             rsaKey = new RSAKeyGenerator(RSA_KEY_SIZE)
@@ -71,6 +74,7 @@ public class JdbcSigningKeyStore implements SigningKeyStore {
             ps.setString(6, publicJwk);
             ps.executeUpdate();
         }
+        return rsaKey.getKeyID();
     }
 
     @Override
@@ -100,7 +104,8 @@ public class JdbcSigningKeyStore implements SigningKeyStore {
     @Override
     public JWKSet getJwkSet(long tenantId) {
         List<JWK> jwks = jdbcTemplate.query(
-            "SELECT public_key_jwk FROM tenant_signing_key WHERE tenant_id = ?",
+            "SELECT public_key_jwk FROM tenant_signing_key WHERE tenant_id = ? " +
+                "ORDER BY (status = 'ACTIVE') DESC, created_at DESC",
             (rs, rowNum) -> {
                 try {
                     return JWK.parse(rs.getString("public_key_jwk"));
@@ -118,6 +123,30 @@ public class JdbcSigningKeyStore implements SigningKeyStore {
     @Override
     public void deleteForTenant(long tenantId) {
         jdbcTemplate.update("DELETE FROM tenant_signing_key WHERE tenant_id = ?", tenantId);
+    }
+
+    @Override
+    @Transactional
+    public RotationOutcome rotateForTenant(long tenantId) {
+        // Order is forced: the partial unique index allows only one ACTIVE row
+        // per tenant, so we must vacate ACTIVE before inserting a new one.
+        String oldKid;
+        try {
+            oldKid = jdbcTemplate.queryForObject(
+                "UPDATE tenant_signing_key SET status = 'RETIRED', retired_at = CURRENT_TIMESTAMP " +
+                    "WHERE tenant_id = ? AND status = 'ACTIVE' RETURNING kid",
+                String.class,
+                tenantId
+            );
+        } catch (EmptyResultDataAccessException e) {
+            throw new IllegalStateException(
+                "Cannot rotate: tenant " + tenantId + " has no ACTIVE signing key", e);
+        }
+        String newKid = jdbcTemplate.execute((Connection conn) ->
+            insertActiveSigningKey(conn, tenantId, kekPassword));
+        return new RotationOutcome(
+            Objects.requireNonNull(oldKid, "RETURNING kid must be non-null after non-empty UPDATE"),
+            Objects.requireNonNull(newKid, "insertActiveSigningKey returned a non-null kid"));
     }
 
     private BytesEncryptor encryptor(byte[] salt) {

--- a/src/main/java/com/stucray/limen/security/SigningKeyRotator.java
+++ b/src/main/java/com/stucray/limen/security/SigningKeyRotator.java
@@ -1,0 +1,52 @@
+package com.stucray.limen.security;
+
+import com.stucray.limen.audit.events.SigningKeyRotatedEvent;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+
+/**
+ * Orchestrates per-tenant signing-key rotation: delegates the storage swap to
+ * {@link SigningKeyStore#rotateForTenant(long)} and publishes a
+ * {@link SigningKeyRotatedEvent} for downstream audit + metrics.
+ *
+ * <p>Slice 1 ships the per-tenant {@link #rotate(long)} entry point used by
+ * the storage and end-to-end tests; the scheduled batch entry point and prune
+ * path arrive in slices 2 and 3 respectively (PRD #173). The {@link Clock}
+ * field is unused today but injected now to lock in the constructor seam used
+ * by the slice-3 batch tests, mirroring {@code TenantAwareOneTimeTokenService}.
+ */
+@Component
+public class SigningKeyRotator {
+
+    private final SigningKeyStore signingKeyStore;
+    private final ApplicationEventPublisher eventPublisher;
+    @SuppressWarnings("unused")
+    private final Clock clock;
+
+    @Autowired
+    public SigningKeyRotator(SigningKeyStore signingKeyStore, ApplicationEventPublisher eventPublisher) {
+        this(signingKeyStore, eventPublisher, Clock.systemUTC());
+    }
+
+    /** Test seam: inject a clock to drive scheduled-rotation timing deterministically. */
+    public SigningKeyRotator(
+        SigningKeyStore signingKeyStore,
+        ApplicationEventPublisher eventPublisher,
+        Clock clock
+    ) {
+        this.signingKeyStore = signingKeyStore;
+        this.eventPublisher = eventPublisher;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public void rotate(long tenantId) {
+        SigningKeyStore.RotationOutcome outcome = signingKeyStore.rotateForTenant(tenantId);
+        eventPublisher.publishEvent(new SigningKeyRotatedEvent(
+            tenantId, outcome.oldKid(), outcome.newKid()));
+    }
+}

--- a/src/main/java/com/stucray/limen/security/SigningKeyStore.java
+++ b/src/main/java/com/stucray/limen/security/SigningKeyStore.java
@@ -10,7 +10,26 @@ public interface SigningKeyStore {
 
     @Nullable RSAKey getActiveSigningKey(long tenantId);
 
+    /**
+     * Returns the tenant's full key set ordered ACTIVE-first (then RETIRED in
+     * created-at-newest order). Order matters: SAS's first-match selector picks
+     * the head of the list at sign-time, so ACTIVE-first guarantees signing
+     * keeps using the live key while the JWKS endpoint advertises both states
+     * across a rotation grace window.
+     */
     JWKSet getJwkSet(long tenantId);
 
     void deleteForTenant(long tenantId);
+
+    /**
+     * Rotates the tenant's ACTIVE signing key: marks the current ACTIVE row
+     * RETIRED with {@code retired_at = now()}, then inserts a freshly-generated
+     * ACTIVE row. Both writes happen in one transaction; order is forced by
+     * the partial unique index {@code tenant_signing_key_one_active_per_tenant}.
+     *
+     * @throws IllegalStateException if the tenant has no ACTIVE key to rotate.
+     */
+    RotationOutcome rotateForTenant(long tenantId);
+
+    record RotationOutcome(String oldKid, String newKid) {}
 }

--- a/src/main/resources/db/migration/V11__signing_key_retired_at.sql
+++ b/src/main/resources/db/migration/V11__signing_key_retired_at.sql
@@ -1,0 +1,7 @@
+-- Adds the timestamp column needed by signing-key rotation.
+--
+-- `created_at` already exists from V1. `retired_at` is set the moment a key
+-- transitions from ACTIVE to RETIRED, and read by the prune query that deletes
+-- keys older than the configured grace period.
+ALTER TABLE tenant_signing_key
+    ADD COLUMN retired_at timestamp NULL;

--- a/src/test/java/com/stucray/limen/oauth2/TenantJwkSourceUnitTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/TenantJwkSourceUnitTest.java
@@ -1,8 +1,12 @@
 package com.stucray.limen.oauth2;
 
 import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKMatcher;
 import com.nimbusds.jose.jwk.JWKSelector;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.KeyType;
 import com.nimbusds.jose.jwk.KeyUse;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
@@ -33,12 +37,12 @@ import static org.mockito.Mockito.verifyNoInteractions;
 
 /**
  * Branch-coverage unit tests for {@link TenantJwkSource}. Exercises every
- * arm of {@code resolveTenantId} plus the no-active-key throw — these
- * branches don't surface through the existing integration tests, which only
- * hit the issuer-with-slug → key happy path.
+ * arm of {@code resolveTenantId} plus the no-active-key throw and the
+ * ACTIVE-first ordering invariant — the latter is load-bearing for signing
+ * during a rotation grace window.
  */
 @ExtendWith(MockitoExtension.class)
-@DisplayName("TenantJwkSource: branch coverage for resolveTenantId() arms and the no-active-key error")
+@DisplayName("TenantJwkSource: branch coverage for resolveTenantId() arms, no-key error, and ACTIVE-first ordering")
 class TenantJwkSourceUnitTest {
 
     @Mock TenantRepository tenantRepository;
@@ -46,13 +50,15 @@ class TenantJwkSourceUnitTest {
 
     TenantJwkSource source;
     Tenant alpha;
-    RSAKey alphaKey;
+    RSAKey activeKey;
+    RSAKey retiredKey;
 
     @BeforeEach
     void setUp() throws JOSEException {
         source = new TenantJwkSource(tenantRepository, signingKeyStore);
         alpha = new Tenant(1L, "alpha", "Alpha", TenantStatus.ACTIVE, LocalDateTime.now());
-        alphaKey = new RSAKeyGenerator(2048).keyID("alpha-key").keyUse(KeyUse.SIGNATURE).generate();
+        activeKey = new RSAKeyGenerator(2048).keyID("active-kid").keyUse(KeyUse.SIGNATURE).generate();
+        retiredKey = new RSAKeyGenerator(2048).keyID("retired-kid").keyUse(KeyUse.SIGNATURE).generate();
     }
 
     @AfterEach
@@ -61,28 +67,26 @@ class TenantJwkSourceUnitTest {
     }
 
     @Test
-    @DisplayName("Issuer URL containing /t/{slug} resolves the tenant via the repo and returns that tenant's active signing key")
-    void issuerWithTenantSegmentResolvesViaRepositoryAndReturnsKey() throws Exception {
+    @DisplayName("Issuer URL containing /t/{slug} resolves the tenant via the repo and returns that tenant's signing keys (match-all → JWKS path)")
+    void issuerWithTenantSegmentResolvesViaRepositoryAndReturnsKeys() throws Exception {
         setIssuer("https://auth.example.com/t/alpha");
         given(tenantRepository.findBySlug("alpha")).willReturn(Optional.of(alpha));
-        given(signingKeyStore.getActiveSigningKey(1L)).willReturn(alphaKey);
+        given(signingKeyStore.getJwkSet(1L)).willReturn(new JWKSet(activeKey.toPublicJWK()));
 
-        List<JWK> jwks = source.get(new JWKSelector(new com.nimbusds.jose.jwk.JWKMatcher.Builder().build()), null);
+        List<JWK> jwks = source.get(matchAllSelector(), null);
 
-        assertThat(jwks).extracting(JWK::getKeyID).containsExactly("alpha-key");
+        assertThat(jwks).extracting(JWK::getKeyID).containsExactly("active-kid");
     }
 
     @Test
     @DisplayName("Issuer URL without a /t/{slug} segment falls back to the bound TenantScope and skips the repo lookup entirely")
     void issuerWithoutTenantSegmentFallsBackToTenantScope() throws Exception {
         setIssuer("https://auth.example.com");
-        given(signingKeyStore.getActiveSigningKey(1L)).willReturn(alphaKey);
+        given(signingKeyStore.getJwkSet(1L)).willReturn(new JWKSet(activeKey.toPublicJWK()));
 
-        List<JWK> jwks = TenantScope.call("alpha", 1L, () ->
-            source.get(new JWKSelector(new com.nimbusds.jose.jwk.JWKMatcher.Builder().build()), null)
-        );
+        List<JWK> jwks = TenantScope.call("alpha", 1L, () -> source.get(matchAllSelector(), null));
 
-        assertThat(jwks).extracting(JWK::getKeyID).containsExactly("alpha-key");
+        assertThat(jwks).extracting(JWK::getKeyID).containsExactly("active-kid");
         verifyNoInteractions(tenantRepository);
     }
 
@@ -91,36 +95,92 @@ class TenantJwkSourceUnitTest {
     void issuerWithUnknownSlugFallsBackToTenantScope() throws Exception {
         setIssuer("https://auth.example.com/t/ghost");
         given(tenantRepository.findBySlug("ghost")).willReturn(Optional.empty());
-        given(signingKeyStore.getActiveSigningKey(1L)).willReturn(alphaKey);
+        given(signingKeyStore.getJwkSet(1L)).willReturn(new JWKSet(activeKey.toPublicJWK()));
 
-        List<JWK> jwks = TenantScope.call("alpha", 1L, () ->
-            source.get(new JWKSelector(new com.nimbusds.jose.jwk.JWKMatcher.Builder().build()), null)
-        );
+        List<JWK> jwks = TenantScope.call("alpha", 1L, () -> source.get(matchAllSelector(), null));
 
-        assertThat(jwks).extracting(JWK::getKeyID).containsExactly("alpha-key");
+        assertThat(jwks).extracting(JWK::getKeyID).containsExactly("active-kid");
     }
 
     @Test
     @DisplayName("With neither AuthorizationServerContext nor TenantScope set, get() throws IllegalStateException and never touches the repo or key store")
     void noContextAndNoTenantScopeThrowsIllegalState() {
-        assertThatThrownBy(() ->
-            source.get(new JWKSelector(new com.nimbusds.jose.jwk.JWKMatcher.Builder().build()), null))
+        assertThatThrownBy(() -> source.get(matchAllSelector(), null))
             .isInstanceOf(IllegalStateException.class)
             .hasMessageContaining("no tenant context");
         verifyNoInteractions(tenantRepository, signingKeyStore);
     }
 
     @Test
-    @DisplayName("Tenant resolved but no active signing key — get() throws IllegalStateException naming the tenant id")
-    void resolvedTenantWithNoActiveKeyThrowsIllegalState() {
+    @DisplayName("Match-all selector with empty key set throws IllegalStateException naming the tenant id")
+    void matchAllWithNoKeysThrowsIllegalState() {
+        setIssuer("https://auth.example.com/t/alpha");
+        given(tenantRepository.findBySlug("alpha")).willReturn(Optional.of(alpha));
+        given(signingKeyStore.getJwkSet(1L)).willReturn(new JWKSet(List.of()));
+
+        assertThatThrownBy(() -> source.get(matchAllSelector(), null))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("No signing keys for tenant 1");
+    }
+
+    @Test
+    @DisplayName("Signing-style selector (constrained by keyType+keyUse+algorithm) with no active key throws IllegalStateException")
+    void signingPathWithNoActiveKeyThrowsIllegalState() {
         setIssuer("https://auth.example.com/t/alpha");
         given(tenantRepository.findBySlug("alpha")).willReturn(Optional.of(alpha));
         given(signingKeyStore.getActiveSigningKey(1L)).willReturn(null);
 
-        assertThatThrownBy(() ->
-            source.get(new JWKSelector(new com.nimbusds.jose.jwk.JWKMatcher.Builder().build()), null))
+        assertThatThrownBy(() -> source.get(signingSelector(), null))
             .isInstanceOf(IllegalStateException.class)
             .hasMessageContaining("No active signing key for tenant 1");
+    }
+
+    @Test
+    @DisplayName("Match-all selector returns ACTIVE + RETIRED keys (public-only) so the JWKS endpoint covers a rotation grace window")
+    void matchAllReturnsAllPublicKeysIncludingRetired() throws Exception {
+        setIssuer("https://auth.example.com/t/alpha");
+        given(tenantRepository.findBySlug("alpha")).willReturn(Optional.of(alpha));
+        given(signingKeyStore.getJwkSet(1L)).willReturn(new JWKSet(List.of(
+            activeKey.toPublicJWK(),
+            retiredKey.toPublicJWK()
+        )));
+
+        List<JWK> jwks = source.get(matchAllSelector(), null);
+
+        assertThat(jwks)
+            .extracting(JWK::getKeyID)
+            .containsExactly("active-kid", "retired-kid");
+        assertThat(((RSAKey) jwks.get(0)).toPrivateKey())
+            .as("JWKS path returns public-only keys — never leaks private material")
+            .isNull();
+    }
+
+    @Test
+    @DisplayName("Signing-style selector returns ONLY the ACTIVE key — NimbusJwtEncoder throws on multi-match, so RETIRED must not surface here")
+    void signingSelectorReturnsOnlyActiveWithPrivateMaterial() throws Exception {
+        setIssuer("https://auth.example.com/t/alpha");
+        given(tenantRepository.findBySlug("alpha")).willReturn(Optional.of(alpha));
+        given(signingKeyStore.getActiveSigningKey(1L)).willReturn(activeKey);
+
+        List<JWK> jwks = source.get(signingSelector(), null);
+
+        assertThat(jwks).extracting(JWK::getKeyID).containsExactly("active-kid");
+        assertThat(((RSAKey) jwks.get(0)).toPrivateKey())
+            .as("signing path returns the full key with private material")
+            .isNotNull();
+    }
+
+    private static JWKSelector matchAllSelector() {
+        return new JWKSelector(new JWKMatcher.Builder().build());
+    }
+
+    private static JWKSelector signingSelector() {
+        // Mirrors NimbusJwtEncoder.createJwkSelector for RS256.
+        return new JWKSelector(new JWKMatcher.Builder()
+            .keyType(KeyType.RSA)
+            .keyUses(KeyUse.SIGNATURE, null)
+            .algorithms(JWSAlgorithm.RS256, null)
+            .build());
     }
 
     private static void setIssuer(String issuer) {

--- a/src/test/java/com/stucray/limen/observability/AuditMetricsListenerTest.java
+++ b/src/test/java/com/stucray/limen/observability/AuditMetricsListenerTest.java
@@ -1,6 +1,7 @@
 package com.stucray.limen.observability;
 
 import com.stucray.limen.audit.events.ClientSecretRotatedEvent;
+import com.stucray.limen.audit.events.SigningKeyRotatedEvent;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.DisplayName;
@@ -33,6 +34,7 @@ class AuditMetricsListenerTest {
     void countersPreRegisteredAtConstruction() {
         assertThat(meters.find(AuditMetricsListener.LOGIN_SUCCESS).counter()).isNotNull();
         assertThat(meters.find(AuditMetricsListener.CLIENT_SECRET_ROTATED).counter()).isNotNull();
+        assertThat(meters.find(AuditMetricsListener.SIGNING_KEY_ROTATED).counter()).isNotNull();
     }
 
     @Test
@@ -85,14 +87,25 @@ class AuditMetricsListenerTest {
     }
 
     @Test
+    @DisplayName("SigningKeyRotatedEvent increments security.signing_key.rotated")
+    void onSigningKeyRotatedIncrements() {
+        listener.onSigningKeyRotated(new SigningKeyRotatedEvent(42L, "old-kid", "new-kid"));
+
+        assertThat(meters.counter(AuditMetricsListener.SIGNING_KEY_ROTATED).count()).isEqualTo(1.0);
+    }
+
+    @Test
     @DisplayName("Counters carry no tenant tag (cardinality safety)")
     void countersHaveNoTenantTag() {
         listener.onLoginSuccess(new AuthenticationSuccessEvent(authToken()));
         listener.onClientSecretRotated(new ClientSecretRotatedEvent(42L, "client-id", 7L));
+        listener.onSigningKeyRotated(new SigningKeyRotatedEvent(42L, "old-kid", "new-kid"));
 
         assertThat(meters.find(AuditMetricsListener.LOGIN_SUCCESS).counter().getId().getTags())
             .isEmpty();
         assertThat(meters.find(AuditMetricsListener.CLIENT_SECRET_ROTATED).counter().getId().getTags())
+            .isEmpty();
+        assertThat(meters.find(AuditMetricsListener.SIGNING_KEY_ROTATED).counter().getId().getTags())
             .isEmpty();
     }
 

--- a/src/test/java/com/stucray/limen/security/JdbcSigningKeyStoreIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/security/JdbcSigningKeyStoreIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.stucray.limen.security;
 
+import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.stucray.limen.TestcontainersConfiguration;
@@ -113,6 +114,53 @@ class JdbcSigningKeyStoreIntegrationTest {
         signingKeyStore.createForTenant(tenant.id());
 
         assertThatPartialUniqueIndexBlocksSecondActive();
+    }
+
+    @Test
+    @DisplayName("rotateForTenant retires the old ACTIVE row and inserts a new ACTIVE one in a single transaction; partial unique index does not fire mid-rotation")
+    void rotateForTenantSwapsActiveAndRetiresPrevious() {
+        signingKeyStore.createForTenant(tenant.id());
+        String originalKid = jdbcTemplate.queryForObject(
+            "SELECT kid FROM tenant_signing_key WHERE tenant_id = ? AND status = 'ACTIVE'",
+            String.class, tenant.id());
+
+        SigningKeyStore.RotationOutcome outcome = signingKeyStore.rotateForTenant(tenant.id());
+
+        assertThat(outcome.oldKid()).isEqualTo(originalKid);
+        assertThat(outcome.newKid()).isNotEqualTo(originalKid);
+        assertThat(rowCount(tenant.id())).isEqualTo(2);
+
+        String activeKid = jdbcTemplate.queryForObject(
+            "SELECT kid FROM tenant_signing_key WHERE tenant_id = ? AND status = 'ACTIVE'",
+            String.class, tenant.id());
+        assertThat(activeKid).isEqualTo(outcome.newKid());
+
+        Object retiredAt = jdbcTemplate.queryForObject(
+            "SELECT retired_at FROM tenant_signing_key WHERE tenant_id = ? AND status = 'RETIRED'",
+            Object.class, tenant.id());
+        assertThat(retiredAt).as("retired_at populated when key transitions to RETIRED").isNotNull();
+    }
+
+    @Test
+    @DisplayName("rotateForTenant throws IllegalStateException when the tenant has no ACTIVE key")
+    void rotateForTenantThrowsWhenNoActiveKey() {
+        org.assertj.core.api.Assertions.assertThatThrownBy(() ->
+            signingKeyStore.rotateForTenant(tenant.id()))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("no ACTIVE signing key");
+    }
+
+    @Test
+    @DisplayName("getJwkSet orders ACTIVE before RETIRED so SAS's first-match selector keeps signing on the live key during a grace window")
+    void getJwkSetOrdersActiveBeforeRetired() {
+        signingKeyStore.createForTenant(tenant.id());
+        SigningKeyStore.RotationOutcome outcome = signingKeyStore.rotateForTenant(tenant.id());
+
+        JWKSet jwkSet = signingKeyStore.getJwkSet(tenant.id());
+
+        assertThat(jwkSet.getKeys()).hasSize(2);
+        assertThat(jwkSet.getKeys()).extracting(JWK::getKeyID)
+            .containsExactly(outcome.newKid(), outcome.oldKid());
     }
 
     private void assertThatPartialUniqueIndexBlocksSecondActive() {

--- a/src/test/java/com/stucray/limen/security/SigningKeyRotationFlowIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/security/SigningKeyRotationFlowIntegrationTest.java
@@ -1,0 +1,113 @@
+package com.stucray.limen.security;
+
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.stucray.limen.TestcontainersConfiguration;
+import com.stucray.limen.provisioning.TenantProvisioningService;
+import com.stucray.limen.tenant.Tenant;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * End-to-end coverage of per-tenant signing-key rotation. Asserts the full
+ * pipeline: storage swap → audit row → counter → JWKS endpoint serving both
+ * keys for the duration of the grace window. Slice 1 of PRD #173.
+ */
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@DisplayName("Signing-key rotation flow: storage swap, audit row, counter, and JWKS endpoint advertising both keys")
+class SigningKeyRotationFlowIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired TenantProvisioningService tenantProvisioningService;
+    @Autowired SigningKeyRotator rotator;
+    @Autowired MeterRegistry meterRegistry;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanAudit() {
+        jdbcTemplate.execute(
+            "DELETE FROM audit_event WHERE event_type = 'signing_key_rotated'");
+    }
+
+    @Test
+    @DisplayName("rotate(tenantId) retires the old key, advertises both kids on /oauth2/jwks, lands a signing_key_rotated audit row, and increments the counter")
+    void rotateProducesAuditRowCounterAndJwksWithBothKeys() throws Exception {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        String slug = "rot-" + suffix;
+        Tenant tenant = tenantProvisioningService.createTenant(slug, "Rotation " + suffix);
+
+        String originalKid = jdbcTemplate.queryForObject(
+            "SELECT kid FROM tenant_signing_key WHERE tenant_id = ? AND status = 'ACTIVE'",
+            String.class, tenant.id());
+
+        double countBefore = counterCount();
+
+        rotator.rotate(tenant.id());
+
+        // Storage swap.
+        Integer rowCount = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM tenant_signing_key WHERE tenant_id = ?",
+            Integer.class, tenant.id());
+        assertThat(rowCount).isEqualTo(2);
+        String newActiveKid = jdbcTemplate.queryForObject(
+            "SELECT kid FROM tenant_signing_key WHERE tenant_id = ? AND status = 'ACTIVE'",
+            String.class, tenant.id());
+        assertThat(newActiveKid).isNotEqualTo(originalKid);
+        Object retiredAt = jdbcTemplate.queryForObject(
+            "SELECT retired_at FROM tenant_signing_key WHERE tenant_id = ? AND status = 'RETIRED'",
+            Object.class, tenant.id());
+        assertThat(retiredAt).isNotNull();
+
+        // Counter increment (synchronous on AFTER_COMMIT — no await needed).
+        assertThat(counterCount() - countBefore).isEqualTo(1.0);
+
+        // Audit row (async via Modulith publication registry — wait).
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            List<Map<String, Object>> rows = jdbcTemplate.queryForList(
+                "SELECT target_id, details::text AS details FROM audit_event "
+                    + "WHERE event_type = 'signing_key_rotated' AND tenant_id = ? "
+                    + "ORDER BY occurred_at DESC LIMIT 1",
+                tenant.id());
+            assertThat(rows).isNotEmpty();
+            Map<String, Object> row = rows.get(0);
+            assertThat(row.get("target_id")).isEqualTo(newActiveKid);
+            String details = row.get("details").toString();
+            assertThat(details).contains(originalKid);
+            assertThat(details).contains(newActiveKid);
+        });
+
+        // JWKS endpoint advertises both kids; ACTIVE first.
+        String jwksJson = mockMvc.perform(get("/t/" + slug + "/oauth2/jwks"))
+            .andExpect(status().isOk())
+            .andReturn().getResponse().getContentAsString();
+        JWKSet jwks = JWKSet.parse(jwksJson);
+        assertThat(jwks.getKeys()).extracting(JWK::getKeyID)
+            .containsExactly(newActiveKid, originalKid);
+    }
+
+    private double counterCount() {
+        // Metric name is the public contract observed by Grafana/Mimir; assert
+        // the literal so a rename in AuditMetricsListener trips this test.
+        return meterRegistry.counter("limen.security.signing_key.rotated").count();
+    }
+}

--- a/src/test/java/com/stucray/limen/security/SigningKeyRotatorTest.java
+++ b/src/test/java/com/stucray/limen/security/SigningKeyRotatorTest.java
@@ -1,0 +1,61 @@
+package com.stucray.limen.security;
+
+import com.stucray.limen.audit.events.SigningKeyRotatedEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SigningKeyRotator: per-tenant rotation orchestration + event publication")
+class SigningKeyRotatorTest {
+
+    @Mock SigningKeyStore signingKeyStore;
+    @Mock ApplicationEventPublisher eventPublisher;
+
+    private final Clock clock = Clock.fixed(Instant.parse("2026-05-07T12:00:00Z"), ZoneOffset.UTC);
+
+    @Test
+    @DisplayName("rotate() delegates to the store and publishes a SigningKeyRotatedEvent carrying the returned kids")
+    void rotateDelegatesAndPublishesEvent() {
+        given(signingKeyStore.rotateForTenant(42L))
+            .willReturn(new SigningKeyStore.RotationOutcome("old-kid", "new-kid"));
+        SigningKeyRotator rotator = new SigningKeyRotator(signingKeyStore, eventPublisher, clock);
+
+        rotator.rotate(42L);
+
+        verify(signingKeyStore).rotateForTenant(42L);
+        ArgumentCaptor<SigningKeyRotatedEvent> captor = ArgumentCaptor.forClass(SigningKeyRotatedEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        SigningKeyRotatedEvent event = captor.getValue();
+        assertThat(event.tenantId()).isEqualTo(42L);
+        assertThat(event.oldKid()).isEqualTo("old-kid");
+        assertThat(event.newKid()).isEqualTo("new-kid");
+    }
+
+    @Test
+    @DisplayName("rotate() propagates the store's IllegalStateException without publishing an event when there is no ACTIVE key to rotate")
+    void rotatePropagatesStoreFailureAndDoesNotPublish() {
+        willThrow(new IllegalStateException("no ACTIVE key"))
+            .given(signingKeyStore).rotateForTenant(42L);
+        SigningKeyRotator rotator = new SigningKeyRotator(signingKeyStore, eventPublisher, clock);
+
+        assertThatThrownBy(() -> rotator.rotate(42L))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("no ACTIVE key");
+        org.mockito.Mockito.verifyNoInteractions(eventPublisher);
+    }
+}


### PR DESCRIPTION
## Summary

Slice 1 of PRD #173 — closes #174. Ships the per-tenant rotation primitive plus the JWKS-endpoint correctness fix that the rotation grace window depends on. Dormant in production until slice 3 wires the scheduler.

- `SigningKeyStore.rotateForTenant(tenantId)` — single transaction `UPDATE old → RETIRED, retired_at=now()` then `INSERT new ACTIVE`. Order forced by the partial unique index.
- `SigningKeyRotator` — orchestration class with the `rotate(tenantId)` entry; publishes `SigningKeyRotatedEvent` for downstream audit + metrics. `Clock` injected per the existing `TenantAwareOneTimeTokenService` two-arg-constructor pattern.
- `SigningKeyRotatedEvent` + `AuditRule` (`signing_key_rotated`) + `limen.security.signing_key.rotated` counter on `AuditMetricsListener`.
- `TenantJwkSource` branches on selector intent: SAS's signing path (matcher constrained by keyType+keyUse+algorithm) returns the ACTIVE key only with private material decrypted, so `NimbusJwtEncoder`'s strict single-match contract holds. The JWKS-endpoint match-all selector returns every key for the tenant, public-only, so resource servers can validate tokens signed by either key throughout a rotation overlap.
- Flyway V11 adds `tenant_signing_key.retired_at timestamp NULL` (`created_at` already existed from V1).
- Architecture doc §4.6 updated to describe the rotation method and the JWKS-endpoint selector branching.

## Test plan

- [x] Unit: `SigningKeyRotatorTest` (delegate + event publish; store-failure propagation, no event published)
- [x] Unit: `TenantJwkSourceUnitTest` — match-all vs signing-style selector dispatch; ACTIVE-first ordering; both no-key error paths; private-material vs public-only invariant
- [x] Unit: `AuditMetricsListenerTest` — counter wiring + cardinality assertion (no tenant tag)
- [x] Integration: `JdbcSigningKeyStoreIntegrationTest` — rotation row state, retired_at populated, partial unique index does not fire mid-rotation, no-active-key throw, ACTIVE-first ordering on `getJwkSet`
- [x] End-to-end: `SigningKeyRotationFlowIntegrationTest` — DB row state + audit row (with both kids in details) + counter increment + per-tenant JWKS endpoint advertising both kids
- [x] Full suite green (423/423)

🤖 Generated with [Claude Code](https://claude.com/claude-code)