### PR TITLE
docs: add onboarding setup (root README + .env(rc).example + local-setup)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Copy to .env (gitignored) and fill in values.
+# See docs/process/local-setup.md for first-time setup.
+
+# 32-byte AES key, base64-encoded. Wraps each tenant's RSA signing-key
+# private bytes at rest. Required — the app will fail to start without it.
+# Generate a fresh value with:
+#   openssl rand -base64 32
+LIMEN_SECURITY_KEK=
+
+# Optional: pre-create a system-admin account on first boot. Both must be
+# set together, or both left blank. If unset, run `./mvnw spring-boot:run`
+# without them and create the first admin via the signup flow.
+LIMEN_BOOTSTRAP_ADMIN_EMAIL=
+LIMEN_BOOTSTRAP_ADMIN_PASSWORD=

--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,7 @@
+# Copy to .envrc (gitignored), then run `direnv allow` from the repo root.
+# Loads the variables in .env into your shell so `mvn spring-boot:run`
+# picks up LIMEN_SECURITY_KEK and friends without you having to export
+# them manually each session.
+#
+# See docs/process/local-setup.md for first-time setup.
+dotenv

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# Limen
+
+A multi-tenant OAuth2 / OIDC Authorization Server built on
+[Spring Authorization Server](https://spring.io/projects/spring-authorization-server).
+A single deployment hosts many independent tenants — each with its own
+user pool, applications, clients, signing keys, and issuer URL — created
+via public self-service signup and managed through `/manage/t/{slug}/`.
+
+> **Status**: pre-1.0, single-developer project. APIs and admin UI are
+> stable enough to use, but expect breaking changes between minor versions
+> until 1.0.
+
+## Getting started
+
+See **[docs/process/local-setup.md](docs/process/local-setup.md)** for the
+first-time setup walkthrough (JDK 26, direnv, KEK generation, run).
+
+The short version, once direnv is installed:
+
+```bash
+cp .envrc.example .envrc
+cp .env.example .env
+# edit .env; generate LIMEN_SECURITY_KEK with: openssl rand -base64 32
+direnv allow
+./mvnw spring-boot:run
+```
+
+## Documentation
+
+| Path | What's there |
+|---|---|
+| [`docs/reference/architecture.md`](docs/reference/architecture.md) | How the system is built — modules, persistence, security model |
+| [`docs/reference/ubiquitous-language.md`](docs/reference/ubiquitous-language.md) | Domain glossary; what we call things and why |
+| [`docs/process/`](docs/process/) | How-to guides: local setup, observability, container image, releases |
+| [`docs/reports/`](docs/reports/) | Generated reports (test coverage and history) |
+| [`docs/research/`](docs/research/) | External writeups that informed design decisions |
+
+## License
+
+[MIT](LICENSE).

--- a/docs/process/local-setup.md
+++ b/docs/process/local-setup.md
@@ -1,0 +1,97 @@
+# Local development setup
+
+First-time setup for running Limen on your own machine. After these steps
+you'll be able to `./mvnw spring-boot:run` and reach the app on
+<http://localhost:8090> (set via `server.port` in `application.yaml`).
+
+## Prerequisites
+
+| Tool | Version | Notes |
+|---|---|---|
+| JDK | 26 | `pom.xml` pins `<java.version>26</java.version>`. Older JDKs won't compile. |
+| Docker | recent | For Postgres (auto-started by Spring Boot Docker Compose support) and the optional observability stack. |
+| [direnv](https://direnv.net) | recent | Loads `.env` into your shell so `mvn spring-boot:run` sees `LIMEN_SECURITY_KEK` etc. without manual exports. |
+
+Maven itself doesn't need to be installed — the bundled wrapper (`./mvnw`)
+takes care of it.
+
+## Install direnv
+
+macOS (Homebrew):
+
+```bash
+brew install direnv
+```
+
+Linux: use your package manager (`apt install direnv`, `dnf install direnv`,
+…) or follow <https://direnv.net/docs/installation.html>.
+
+Hook it into your shell so it auto-loads `.envrc` files when you `cd` into
+the repo. Add **one** of the following to your shell rc, then start a new
+shell (`exec $SHELL`):
+
+```bash
+# ~/.zshrc
+eval "$(direnv hook zsh)"
+
+# ~/.bashrc
+eval "$(direnv hook bash)"
+
+# ~/.config/fish/config.fish
+direnv hook fish | source
+```
+
+zsh users on macOS can shortcut this with the bundled
+`scripts/install-direnv-hook.sh` (idempotent; appends the zsh hook to
+`~/.zshrc` and runs `direnv allow` on the repo).
+
+## Configure the repo
+
+From the repo root:
+
+```bash
+cp .envrc.example .envrc
+cp .env.example .env
+```
+
+Edit `.env` and fill in the required values:
+
+- **`LIMEN_SECURITY_KEK`** — 32-byte AES key, base64-encoded. Generate a
+  fresh one with `openssl rand -base64 32`. Required; the app fails fast
+  without it.
+- **`LIMEN_BOOTSTRAP_ADMIN_EMAIL`** / **`LIMEN_BOOTSTRAP_ADMIN_PASSWORD`** —
+  optional. If both are set, a system-admin account is created on first
+  boot. If both are left blank, create the first admin via signup instead.
+  They must be set together or both blank.
+
+Then approve the `.envrc` (one-time per repo path):
+
+```bash
+direnv allow
+```
+
+You'll see direnv export the variables on your next prompt.
+
+## Run
+
+```bash
+./mvnw spring-boot:run
+```
+
+Spring Boot's Docker Compose support auto-starts the Postgres container
+from `docker-compose.yml`. The app is at <http://localhost:8090>.
+
+The `mailpit` profile auto-activates on `mvn spring-boot:run` (configured
+on `spring-boot-maven-plugin`), so SMTP outbound email lands in the
+Mailpit web inbox at <http://localhost:8025>. To run with the dev
+observability stack instead, see [observability.md](observability.md).
+
+## Troubleshooting
+
+- **`direnv: error .envrc is blocked`** — you skipped `direnv allow`.
+  Run it from the repo root.
+- **App fails on startup with `limen.security.kek must be base64 decoding to exactly 32 bytes`** — `LIMEN_SECURITY_KEK` is missing, malformed, or the wrong length. Re-generate with `openssl rand -base64 32`.
+- **App fails with `limen.bootstrap.admin.email and password must both be set or both be unset`** — set both or clear both; half-set is rejected.
+- **Stale `LIMEN_BOOTSTRAP_ADMIN_*` after editing `.env`** — direnv reloads
+  on `cd`, but a shell that was already in the repo before you saved the
+  edit may still hold the old values. `cd ..` and back, or `direnv reload`.


### PR DESCRIPTION
## Summary
- Adds top-level `README.md` — short project intro, quickstart, and a docs map (links into `docs/reference/` and `docs/process/`). Repo previously had no root README.
- Tracks `.envrc.example` (one-line `dotenv` contract for direnv) and `.env.example` (the three required `LIMEN_*` vars with placeholder values + `openssl rand -base64 32` hint for the KEK).
- Adds `docs/process/local-setup.md` — first-time setup walkthrough: prereqs (JDK 26, Docker, direnv), shell-hook snippets for zsh/bash/fish, copy-the-templates flow, run, and troubleshooting for the three startup failure modes the validators emit.
- Closes the gap that `.envrc` and `.env` are both gitignored, so without templates a new contributor had nothing to copy from.
- The existing zsh-only `scripts/install-direnv-hook.sh` stays gitignored as before — the new doc references it as an optional shortcut for zsh users.

## Test plan
- [ ] `cp .envrc.example .envrc && cp .env.example .env` works, `.env` parses (all 3 vars present, no syntax errors)
- [ ] `direnv allow` followed by `./mvnw spring-boot:run` reaches <http://localhost:8090>
- [ ] All cross-references in `README.md` and `local-setup.md` resolve (architecture.md, ubiquitous-language.md, observability.md, install-direnv-hook.sh, LICENSE)
- [ ] `git check-ignore .envrc.example .env.example` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)