### PR TITLE
feat: drift-gate the code-quality reports under CI=true

### DIFF
--- a/docs/process/code-quality.md
+++ b/docs/process/code-quality.md
@@ -38,6 +38,44 @@ python3 scripts/render-pmd-report.py \
 
 The script is stdlib-only Python — no `pip install` step.
 
+## CI drift gate
+
+When the script runs under any CI provider that sets `CI=true` (GitHub Actions,
+GitLab CI, CircleCI, Travis, Jenkins-via-plugin), the regen step is followed
+by `git diff --exit-code` on the just-written files. If the committed reports
+are stale relative to what `mvn verify` just regenerated, the build fails with
+a message instructing you to rerun `mvn verify` locally and recommit.
+
+Locally (`CI` unset), the gate is a no-op — the script writes-and-exits even
+when the working tree mutated, so edit-build-test loops stay frictionless.
+
+To run the gate locally for a one-off check (e.g. before pushing):
+
+```sh
+CI=true ./mvnw verify
+```
+
+The gate logic lives in `scripts/render-pmd-report.py`, not in
+`.github/workflows/ci.yml` — that file stays a thin caller of the shared
+[`stucray/workflows`](https://github.com/stucray/workflows) reusable workflow,
+and adopting this pattern in another project is "copy script + pom block",
+no workflow edits.
+
+## Optional: pre-push hook
+
+To enforce the gate on every `git push` without round-tripping through CI,
+drop this into `.git/hooks/pre-push` (and `chmod +x` it):
+
+```sh
+#!/usr/bin/env bash
+exec env CI=true ./mvnw verify -DskipTests -DskipITs -e
+```
+
+The hook is per-developer (lives under `.git/`, not tracked) — opt in if you
+want CI-shaped strictness on your machine. The `-DskipTests -DskipITs` flags
+keep the hook fast (~10s) by skipping the test suites; PMD + the gate still
+run.
+
 ## Ad-hoc PMD HTML drilldown
 
 For interactive browsing of all findings (with cross-reference links into

--- a/scripts/render-pmd-report.py
+++ b/scripts/render-pmd-report.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import subprocess
 import sys
 import xml.etree.ElementTree as ET
 from collections import Counter
@@ -269,6 +270,26 @@ def atomic_write(path: Path, content: str) -> None:
     os.replace(tmp, path)
 
 
+def gate_drift(paths: list[Path]) -> None:
+    """In CI, fail the build when the freshly-written report files differ
+    from what's committed. Locally (``CI`` unset) this is a no-op so the
+    edit-build-test loop stays frictionless. Triggered by ``CI=true``,
+    the convention every major CI provider sets, so the gate is portable.
+    """
+    if os.environ.get("CI") != "true":
+        return
+    result = subprocess.run(
+        ["git", "diff", "--exit-code", "--", *(str(p) for p in paths)],
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(
+            "\nStale code-quality report. Run `mvn verify` locally and "
+            "recommit docs/reports/code-quality.{md,json}.\n"
+        )
+        raise SystemExit(result.returncode)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description=__doc__,
@@ -303,6 +324,7 @@ def main() -> int:
 
     atomic_write(out_json, render_json(findings, summary))
     atomic_write(out_md, render_markdown(findings, summary))
+    gate_drift([out_json, out_md])
     return 0
 
 


### PR DESCRIPTION
Slice 2 of PRD #188 — closes #191.

## Summary

- Adds `gate_drift()` to `scripts/render-pmd-report.py`. After the regen, when `os.environ.get("CI") == "true"`, the script runs `git diff --exit-code` against the just-written report files and exits non-zero with an actionable stderr message if the committed reports are stale.
- Locally (`CI` unset) the gate is a no-op — `mvn verify` still rewrites the files, but doesn't fail mid-iteration on a dirty working tree.
- `docs/process/code-quality.md` gains two subsections: "CI drift gate" (env-var trigger, why the gate lives in the script) and "Optional: pre-push hook" (per-developer opt-in for local enforcement, `chmod +x .git/hooks/pre-push`).
- **No CI workflow changes.** `.github/workflows/ci.yml` stays at its existing 16 lines, still a thin caller of `stucray/workflows@v1`. The whole gate fires off a single env-var check inside the script — portable to any provider that respects `CI=true`.

## Test plan

- [x] **Clean tree under `CI=true`** — `CI=true python3 scripts/render-pmd-report.py ...` exits 0 silently when committed reports match regen output.
- [x] **Drift under `CI=true`** — verified by injecting a fake `<violation>` into `target/pmd.xml`, then running with `CI=true`. Script regenerated reports with the new finding, `git diff --exit-code` printed the diff, stderr printed the actionable message, exit code was 1.
- [x] **Local default is silent on dirty tree** — same drift scenario without `CI=true` exits 0 (the gate doesn't fire locally).
- [x] **`./mvnw verify` (full suite, no `CI`)** passes locally; PMD + render-pmd-report still execute in order in the verify phase.
- [x] `.github/workflows/ci.yml` is unchanged; reusable workflow at `stucray/workflows` is unchanged.
- [x] CI on this PR will be the real end-to-end validation that `CI=true` is set by GitHub Actions and the gate stays silent on a clean tree (committed reports match what `mvn verify` regenerates on the runner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)