### PR TITLE
chore: bump main to 0.2.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>com.stucray</groupId>
 	<artifactId>limen</artifactId>
-	<version>0.1.5-SNAPSHOT</version>
+	<version>0.2.0-SNAPSHOT</version>
 
 	<properties>
 		<java.version>26</java.version>


### PR DESCRIPTION
## Summary
- Bumps the working version on \`main\` from \`0.1.5-SNAPSHOT\` to \`0.2.0-SNAPSHOT\`.
- Signals that the next release will be a **minor** bump (\`v0.2.0\`) rather than a patch (\`v0.1.5\`). The static-analysis loop that closed in \`v0.1.4\` — PRD #188 surfacing + PRD #189 ruleset broadening + 4-bucket PMD triage to zero — is a natural breakpoint for the new \`0.2.x\` line.
- Single-line change in \`pom.xml\`. No code, behaviour, or report changes.

## Test plan
- [x] \`./mvnw help:evaluate -Dexpression=project.version\` returns \`0.2.0-SNAPSHOT\`
- [ ] CI green on push (full \`mvn verify\` runs in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)