### PR TITLE
docs: add package-info to every top-level module

### DIFF
--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -567,33 +567,34 @@ Static analysis runs in two postures:
 
 CI is a single GitHub Actions workflow (`.github/workflows/ci.yml`) with one `verify` job on push and PR to `main`. The job sets up JDK 26 (Temurin, with Maven cache), runs `./mvnw -B -ntp verify`, and uploads the PMD bundle (30-day retention) and — on failure — the JaCoCo HTML report (14-day retention). The `LIMEN_SECURITY_KEK` is supplied as a GitHub Actions secret.
 
-### 4.15 Application modules
+### 4.15 Package structure (application modules)
 
 Module boundaries are enforced mechanically via [Spring Modulith](https://spring.io/projects/spring-modulith). `LimenModuleArchitectureTest` calls `ApplicationModules.of(LimenApplication.class).verify()`, which fails the build on cycles between modules and on cross-module references into a module's internal sub-packages. The verifier runs as part of `./mvnw test` so every PR is checked.
 
-Each direct sub-package of `com.stucray.limen` is one application module. As of 2026-05-06 there are 19:
+Each direct sub-package of `com.stucray.limen` is one application module. **The canonical per-module description lives in each module's `package-info.java`** (visible in IDE tooltips and Javadoc); the table below is a one-line index for navigation, plus the cross-cutting decisions that don't belong on any single module. As of 2026-05-08 there are 20:
 
-| Module | Role |
+| Module | One-line role |
 |---|---|
-| `applications` | Application entity + per-Application CRUD service and controller |
+| `applications` | `Application` entity + per-Application CRUD service and controller |
 | `audit` | `AuditEvent` row, dispatch rules, registry, writer; published events live in `audit.events` (named interface `events`) |
-| `auth` | Tenant-aware authentication: `TenantAuthProvider`, `TenantAuthToken`, `TenantUserDetailsService`, persistent remember-me, `TenantAccessFilter` defence-in-depth. Sub-features `auth.login` and `auth.ott` are named interfaces (`login`, `ott`) |
-| `clients` | TenantClient (the multi-tenant decoration of a SAS RegisteredClient) entity + repo + management UI |
+| `auth` | Tenant-aware authentication: providers, tokens, remember-me, `TenantAccessFilter`. Sub-features `auth.login` and `auth.ott` are named interfaces |
+| `clients` | `TenantClient` (Limen's multi-tenant decoration of a SAS `RegisteredClient`) + management UI |
 | `email` | `EmailSender` abstraction with `logging` + `smtp` drivers |
 | `enduser` | End-user web routes (post-OAuth2 home) |
 | `identity` | Bootstrap-admin properties + `UserBootstrap` startup runner |
-| `management` | Admin-console infrastructure: nav, login, home, model advice, and the admin Spring Security config (`management.web`, `management.auth`). Domain features that *appear* under `/manage/...` URLs (applications, clients, etc.) live in their own top-level modules |
-| `memberships` | ApplicationMembership + ClientMembership + Role-join entities, queries (`ClientMembershipQuery`, `UserMembershipPortfolioQuery`), services, and the per-app/per-client members UI |
-| `oauth2` | SAS integration: tenant-aware decorators, routing filter, issuer-context filter, JWK source, `SasConfig` |
-| `provisioning` | Tenant lifecycle orchestration: `TenantProvisioningService` (create/suspend/unsuspend/delete + signing-key seed) and `TenantProvisioner` (the deep module entered by `/signup` and `/manage/system/tenants/new`) |
-| `roles` | Per-Application `Role` catalogue + management UI |
-| `security` | Global Spring Security defaults, `SecurityProperties`, signing-key store, rate-limit filter (`security.ratelimit`) |
+| `management` | Admin-console infrastructure (`/manage/...` filter chain, nav, model advice). Per-domain `/manage/...` features live in their own modules |
+| `memberships` | `ApplicationMembership` + `ClientMembership` + Role-join entities, queries, services, members UI |
+| `oauth2` | Spring Authorization Server integration: tenant-aware decorators, routing filter, issuer-context filter, JWK source |
+| `observability` | Cross-cutting OTel/Micrometer concerns: tenant-tagging filter, named auth counters, OTel logback bridge |
+| `provisioning` | Tenant lifecycle orchestration: `TenantProvisioningService` + `TenantProvisioner` |
+| `roles` | Per-Application `Role` catalogue + `RoleResolver` + management UI |
+| `security` | Foundation security: defaults, `SecurityProperties`, signing-key store + rotator, rate-limit filter (`security.ratelimit`) |
 | `signup` | Public self-service signup form + service |
 | `system` | Cross-tenant System Admin controllers (tenant suspend/unsuspend/delete, system-admin tenant-create) |
 | `tenant` | `Tenant` entity + repository, `TenantStatus`, `TenantScope` (the per-request `ScopedValue`) |
-| `user` | `User` entity + `UserRepository` + `TenantUserDetails` (the Spring Security `UserDetails` adapter wrapping `User` + `Tenant`) |
-| `useradmin` | Tenant-Owner administration of Users: `UserAdministrationService`, `PasswordChangeRequiredInterceptor` (the change-password form itself is hosted by `auth.login.PasswordChangeController`) |
-| `web` | Top-level web routes: `RootController` (landing) and `RedirectLoginController` (slug-aware `/login` forwarder) |
+| `user` | `User` entity + `UserRepository` + `TenantUserDetails` (the Spring Security `UserDetails` adapter) |
+| `useradmin` | Tenant-Owner administration of Users: `UserAdministrationService`, `PasswordChangeRequiredInterceptor` |
+| `web` | Top-level web routes: `RootController` (landing) + `RedirectLoginController` (slug-aware `/login` forwarder) |
 
 **Three module-shaping decisions worth calling out:**
 

--- a/src/main/java/com/stucray/limen/applications/package-info.java
+++ b/src/main/java/com/stucray/limen/applications/package-info.java
@@ -1,0 +1,13 @@
+/**
+ * The {@code Application} entity and its per-Application CRUD service / controller.
+ *
+ * <p>An {@code Application} is a per-Tenant grouping of one or more OAuth2 Clients
+ * plus the catalogue of Roles assignable inside it. Tenant Owners create
+ * Applications under {@code /manage/t/{slug}/applications/...}; the Clients that
+ * belong to an Application live in the {@code clients} module, the Roles in
+ * {@code roles}, and the Memberships that grant Users access in {@code memberships}.
+ *
+ * <p>Spring Modulith application module. See {@code docs/reference/architecture.md}
+ * §4.15 (Package structure) for the cross-cutting view of all top-level modules.
+ */
+package com.stucray.limen.applications;

--- a/src/main/java/com/stucray/limen/audit/package-info.java
+++ b/src/main/java/com/stucray/limen/audit/package-info.java
@@ -1,0 +1,18 @@
+/**
+ * The audit log: {@code AuditEvent} row, dispatch rules, registry, and writer.
+ *
+ * <p>Every audited domain event is persisted as one {@code audit_event} row by
+ * {@code AuditEventWriter}, keyed by Tenant + Actor + occurred-at, with a JSON
+ * payload that captures the event-specific fields. Other modules publish events
+ * via Spring's {@code ApplicationEventPublisher}; this module owns the listener
+ * side of that contract.
+ *
+ * <p>Cross-module API: the event types other modules publish live in the
+ * {@code audit.events} sub-package and are exposed via the {@code @NamedInterface("events")}
+ * marker. Internal sub-packages ({@code audit.dispatch}) are not callable from outside
+ * this module.
+ *
+ * <p>Spring Modulith application module. See {@code docs/reference/architecture.md}
+ * §4.8 (Audit log) for behaviour, §4.15 (Package structure) for the cross-cutting view.
+ */
+package com.stucray.limen.audit;

--- a/src/main/java/com/stucray/limen/auth/package-info.java
+++ b/src/main/java/com/stucray/limen/auth/package-info.java
@@ -1,0 +1,25 @@
+/**
+ * Tenant-aware authentication primitives shared across all login surfaces.
+ *
+ * <p>Holds {@code TenantAuthProvider} (the Spring Security {@code AuthenticationProvider}
+ * that resolves a User within a Tenant), {@code TenantAuthToken} (the authenticated
+ * principal type), {@code TenantUserDetailsService}, the persistent remember-me
+ * adapter, and {@code TenantAccessFilter} (defence-in-depth: force-logout when the
+ * URL slug differs from the principal's tenant). Sub-features live under
+ * {@code auth.login} (the login pipeline + change-password orchestrator), {@code auth.ott}
+ * (one-time-token issue/complete services for email verification + password reset),
+ * and {@code auth.lockout} (account lockout state machine, internal).
+ *
+ * <p>Cross-module API: {@code auth.login} and {@code auth.ott} are exposed via
+ * {@code @NamedInterface}. Other sub-packages are internal.
+ *
+ * <p>Not to be confused with {@code com.stucray.limen.oauth2}, which holds the
+ * Spring Authorization Server integration (tenant-aware SAS decorators, routing
+ * filter, JWK source). This module is "how a User authenticates"; {@code oauth2}
+ * is "how OAuth2 protocol traffic is served."
+ *
+ * <p>Spring Modulith application module. See {@code docs/reference/architecture.md}
+ * §4.5 (Authentication flows) for behaviour, §4.15 (Package structure) for the
+ * cross-cutting view.
+ */
+package com.stucray.limen.auth;

--- a/src/main/java/com/stucray/limen/clients/package-info.java
+++ b/src/main/java/com/stucray/limen/clients/package-info.java
@@ -1,0 +1,18 @@
+/**
+ * {@code TenantClient} — Limen's multi-tenant decoration of a Spring Authorization
+ * Server {@code RegisteredClient} — and its management UI.
+ *
+ * <p>Each Client belongs to exactly one Application within one Tenant. The pair is
+ * persisted as one row in {@code client_metadata} (Limen-side: display name,
+ * owning Application + Tenant) plus one row in {@code oauth2_registered_client}
+ * (SAS-side: client id/secret, grant types, redirect URIs), joined 1:1 by foreign
+ * key. The split keeps Limen's tenant model from leaking into Spring's schema.
+ *
+ * <p>Tenant Owners manage Clients under {@code /manage/t/{slug}/clients/...}; the
+ * tenant-aware repository decorator that scopes SAS reads/writes lives in the
+ * {@code oauth2} module.
+ *
+ * <p>Spring Modulith application module. See {@code docs/reference/architecture.md}
+ * §4.3 (OAuth2 storage decorators) and §4.15 (Package structure).
+ */
+package com.stucray.limen.clients;

--- a/src/main/java/com/stucray/limen/email/package-info.java
+++ b/src/main/java/com/stucray/limen/email/package-info.java
@@ -1,0 +1,15 @@
+/**
+ * The {@code EmailSender} abstraction with {@code logging} and {@code smtp} drivers.
+ *
+ * <p>Other modules depend on the {@code EmailSender} interface to deliver
+ * verification emails, password-reset links, and similar one-time-token messages.
+ * The active driver is selected at runtime by the {@code limen.email.driver}
+ * property: {@code logging} (default in tests; renders the email body to logs)
+ * and {@code smtp} (Mailpit in dev, real SMTP in production) are the two
+ * implementations.
+ *
+ * <p>Spring Modulith application module. See {@code docs/reference/architecture.md}
+ * §4.7 (Email infrastructure) for the driver-selection details, §4.15 (Package
+ * structure) for the cross-cutting view.
+ */
+package com.stucray.limen.email;

--- a/src/main/java/com/stucray/limen/enduser/package-info.java
+++ b/src/main/java/com/stucray/limen/enduser/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * End-user web routes — the surfaces an OAuth2 end-user lands on outside the
+ * authorization-code flow.
+ *
+ * <p>Today this is the post-OAuth2 home page that an end-user sees after a
+ * successful login when no client redirect is in play. Authentication for these
+ * routes is handled by the OAuth2 login filter chain in {@code oauth2}; this
+ * module just owns the post-login destination(s).
+ *
+ * <p>Three "web-surface" modules exist and are deliberately distinct:
+ * <ul>
+ *   <li>{@code enduser} (this module) — post-OAuth2 end-user pages
+ *   <li>{@code web} — top-level routes ({@code /} landing, slug-aware {@code /login} forwarder)
+ *   <li>{@code management} — admin-console infrastructure for {@code /manage/...}
+ * </ul>
+ *
+ * <p>Spring Modulith application module. See {@code docs/reference/architecture.md}
+ * §4.12 (HTTP route map) and §4.15 (Package structure).
+ */
+package com.stucray.limen.enduser;

--- a/src/main/java/com/stucray/limen/identity/package-info.java
+++ b/src/main/java/com/stucray/limen/identity/package-info.java
@@ -1,0 +1,17 @@
+/**
+ * Bootstrap-admin identity: properties + {@code UserBootstrap} startup runner.
+ *
+ * <p>On first boot the {@code UserBootstrap} runner ensures a System Admin User
+ * exists in the System Tenant using credentials supplied by environment variables
+ * ({@code LIMEN_BOOTSTRAP_ADMIN_*}). Once the System Tenant has a usable owner,
+ * this module has no further role — it is intentionally a startup-only
+ * concern.
+ *
+ * <p>Not to be confused with {@code com.stucray.limen.user} (the User entity itself)
+ * or {@code com.stucray.limen.useradmin} (Tenant-Owner administration of Users).
+ * This module is just the bootstrap path.
+ *
+ * <p>Spring Modulith application module. See {@code docs/reference/architecture.md}
+ * §4.15 (Package structure) for the cross-cutting view.
+ */
+package com.stucray.limen.identity;

--- a/src/main/java/com/stucray/limen/management/package-info.java
+++ b/src/main/java/com/stucray/limen/management/package-info.java
@@ -1,0 +1,24 @@
+/**
+ * Admin-console infrastructure: nav, login, home, model advice, and the admin
+ * Spring Security filter chain config.
+ *
+ * <p>This module owns the *infrastructure* for the {@code /manage/t/{slug}/...}
+ * surface — the management filter chain in {@code management.auth}, the MVC
+ * configuration in {@code management.web}, the management home page, and shared
+ * model advice. Domain features that *appear* under {@code /manage/...} URLs
+ * (Applications, Clients, Roles, Memberships, Users) live in their own top-level
+ * modules ({@code applications}, {@code clients}, {@code roles}, {@code memberships},
+ * {@code useradmin}); each contributes its own {@code @Controller} that the
+ * management filter chain protects.
+ *
+ * <p>Three "web-surface" modules exist and are deliberately distinct:
+ * <ul>
+ *   <li>{@code management} (this module) — {@code /manage/...} infrastructure
+ *   <li>{@code enduser} — post-OAuth2 end-user pages
+ *   <li>{@code web} — top-level routes ({@code /} landing, {@code /login} forwarder)
+ * </ul>
+ *
+ * <p>Spring Modulith application module. See {@code docs/reference/architecture.md}
+ * §4.12 (HTTP route map) and §4.15 (Package structure).
+ */
+package com.stucray.limen.management;

--- a/src/main/java/com/stucray/limen/memberships/package-info.java
+++ b/src/main/java/com/stucray/limen/memberships/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * {@code ApplicationMembership} + {@code ClientMembership} + Role-join entities,
+ * with the queries and services that drive the per-Application and per-Client
+ * members UI.
+ *
+ * <p>An {@code ApplicationMembership} is the eligibility gate: it grants a User
+ * access to an Application (and zero-or-more App Roles for that Application).
+ * A {@code ClientMembership} is the per-Client grant under that gate: it pins
+ * Client Roles for a specific Client owned by the Application. Revoking
+ * Application Membership cascades all Client Memberships under it (DB-level
+ * {@code ON DELETE CASCADE}).
+ *
+ * <p>The two cross-cutting query objects ({@code UserMembershipPortfolioQuery},
+ * {@code ClientMembershipQuery}) are how the User-detail page and the JWT
+ * authority enricher see the world without N+1 round-trips.
+ *
+ * <p>Spring Modulith application module. See {@code docs/reference/architecture.md}
+ * §4.10 (Authorization — Roles, Memberships, and the JWT roles claim) and §4.15
+ * (Package structure).
+ */
+package com.stucray.limen.memberships;

--- a/src/main/java/com/stucray/limen/oauth2/package-info.java
+++ b/src/main/java/com/stucray/limen/oauth2/package-info.java
@@ -1,0 +1,25 @@
+/**
+ * Spring Authorization Server (SAS) integration: tenant-aware decorators, routing
+ * filter, issuer-context filter, JWK source, and SAS configuration.
+ *
+ * <p>SAS by itself is single-tenant. This module makes it multi-tenant by
+ * decorating every persistence interface SAS uses ({@code RegisteredClientRepository},
+ * {@code OAuth2AuthorizationService}, {@code OAuth2AuthorizationConsentService})
+ * with a tenant-scoping wrapper, supplying a tenant-aware {@code JWKSource} that
+ * loads keys from {@code tenant_signing_key}, and bracketing every protocol
+ * request with {@code TenantOAuth2RoutingFilter} +
+ * {@code TenantIssuerContextFilter} so that the per-tenant issuer URL,
+ * configuration document, and JWKS resolve correctly. {@code MembershipGateFilter}
+ * enforces the eligibility/role checks on the authorize endpoint before SAS sees
+ * the request.
+ *
+ * <p>Not to be confused with {@code com.stucray.limen.auth}, which holds the
+ * non-OAuth2 authentication primitives (login, OTT, lockout, remember-me). This
+ * module is "how OAuth2 protocol traffic is served"; {@code auth} is "how a User
+ * authenticates."
+ *
+ * <p>Spring Modulith application module. See {@code docs/reference/architecture.md}
+ * §4.2 (Request routing for OAuth2 traffic) and §4.3 (OAuth2 storage decorators)
+ * for behaviour, §4.15 (Package structure) for the cross-cutting view.
+ */
+package com.stucray.limen.oauth2;

--- a/src/main/java/com/stucray/limen/observability/package-info.java
+++ b/src/main/java/com/stucray/limen/observability/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Cross-cutting observability concerns: tenant tagging, named auth counters,
+ * and the OpenTelemetry/Logback bridge.
+ *
+ * <p>Holds {@code TenantObservabilityFilter} (tags every request span and every
+ * Micrometer meter created during the request with the resolved Tenant slug),
+ * {@code AuditMetricsListener} (translates audit events into named counters such
+ * as {@code limen.auth.signin.success} and {@code limen.auth.signin.failure}),
+ * and {@code OtelLogbackInstaller} (programmatic Logback appender that ships log
+ * records to the OTel collector with trace correlation).
+ *
+ * <p>Routine OTel + Micrometer wiring is configuration, not code; this module
+ * exists for the bits that need application-aware logic.
+ *
+ * <p>Spring Modulith application module. See {@code docs/reference/architecture.md}
+ * §4.15 (Package structure) for the cross-cutting view, and
+ * {@code docs/process/observability.md} for the LGTM stack runbook.
+ */
+package com.stucray.limen.observability;

--- a/src/main/java/com/stucray/limen/provisioning/package-info.java
+++ b/src/main/java/com/stucray/limen/provisioning/package-info.java
@@ -1,0 +1,26 @@
+/**
+ * Tenant lifecycle orchestration: create, suspend, unsuspend, delete.
+ *
+ * <p>{@code TenantProvisioningService} is the create/suspend/unsuspend/delete
+ * surface called by both the public {@code /signup} flow and the System Admin
+ * tenant-create UI; {@code TenantProvisioner} is the deep module that performs
+ * the atomic create — Tenant row + initial signing key + owner User + verification
+ * email — entered through both signup paths.
+ *
+ * <p>This module exists *separately* from {@code tenant} on purpose. Provisioning
+ * depends on {@code tenant}, {@code user}, {@code auth}, {@code email}, and
+ * {@code audit}; nesting it under {@code tenant} produces a real cycle
+ * ({@code tenant → auth → tenant}). Promoting orchestration to its own module
+ * surfaces its role and breaks the cycle.
+ *
+ * <p>Three "tenant lifecycle" entry points exist and are deliberately distinct:
+ * <ul>
+ *   <li>{@code provisioning} (this module) — the orchestrator both signup paths call into
+ *   <li>{@code signup} — the public self-service form for new Tenants
+ *   <li>{@code system} — the System Admin equivalent (create/suspend/unsuspend/delete from {@code /manage/system/...})
+ * </ul>
+ *
+ * <p>Spring Modulith application module. See {@code docs/reference/architecture.md}
+ * §4.15 (Package structure).
+ */
+package com.stucray.limen.provisioning;

--- a/src/main/java/com/stucray/limen/roles/package-info.java
+++ b/src/main/java/com/stucray/limen/roles/package-info.java
@@ -1,0 +1,16 @@
+/**
+ * The per-Application {@code Role} catalogue and its management UI.
+ *
+ * <p>A {@code Role} row belongs to exactly one Application. The same row can be
+ * assigned to a User as either an **App Role** (via {@code application_membership_role})
+ * or a **Client Role** (via {@code client_membership_role}); only Client Roles
+ * appear in the JWT {@code roles} claim. {@code RoleResolver} encapsulates the
+ * look-up by Application + name used by both assignment paths.
+ *
+ * <p>Tenant Owners manage Roles under {@code /manage/t/{slug}/applications/{appId}/roles/...}.
+ *
+ * <p>Spring Modulith application module. See {@code docs/reference/architecture.md}
+ * §4.10 (Authorization — Roles, Memberships, and the JWT roles claim) and §4.15
+ * (Package structure).
+ */
+package com.stucray.limen.roles;

--- a/src/main/java/com/stucray/limen/security/package-info.java
+++ b/src/main/java/com/stucray/limen/security/package-info.java
@@ -1,0 +1,17 @@
+/**
+ * Foundation security infrastructure: global Spring Security defaults, signing-key
+ * store, signing-key rotation, and the rate-limit filter.
+ *
+ * <p>{@code DefaultSecurityConfig} owns the catch-all filter chain that every
+ * request hits before more-specific chains (OAuth2, login, management) take over.
+ * {@code JdbcSigningKeyStore} (and the {@code SigningKeyRotator} cluster) own
+ * per-Tenant RSA signing-key persistence with envelope encryption — the actual
+ * tenant-aware {@code JWKSource} that loads them lives in {@code oauth2}.
+ * {@code security.ratelimit} is the in-memory token-bucket filter; it's an
+ * internal sub-package, not callable from outside this module.
+ *
+ * <p>Spring Modulith application module. See {@code docs/reference/architecture.md}
+ * §4.4 (Signing keys) and §4.9 (Rate limiting) for behaviour, §4.15 (Package
+ * structure) for the cross-cutting view.
+ */
+package com.stucray.limen.security;

--- a/src/main/java/com/stucray/limen/signup/package-info.java
+++ b/src/main/java/com/stucray/limen/signup/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * Public self-service signup: the form anyone can fill in to create a new Tenant.
+ *
+ * <p>Holds {@code SignupController} (the {@code /signup} GET/POST endpoints),
+ * {@code SignupForm} (the form-binding record), and {@code SignupService} (the
+ * thin entry point that delegates to {@code TenantProvisioner} in the
+ * {@code provisioning} module). This module *does not* own the orchestration
+ * itself — it just renders the form and hands off.
+ *
+ * <p>Three "tenant lifecycle" entry points exist and are deliberately distinct:
+ * <ul>
+ *   <li>{@code signup} (this module) — public self-service form
+ *   <li>{@code system} — System Admin equivalent ({@code /manage/system/tenants/new})
+ *   <li>{@code provisioning} — the orchestrator both entry points call into
+ * </ul>
+ *
+ * <p>Spring Modulith application module. See {@code docs/reference/architecture.md}
+ * §4.15 (Package structure).
+ */
+package com.stucray.limen.signup;

--- a/src/main/java/com/stucray/limen/system/package-info.java
+++ b/src/main/java/com/stucray/limen/system/package-info.java
@@ -1,0 +1,24 @@
+/**
+ * Cross-tenant System Admin controllers: the surfaces only a System Admin sees.
+ *
+ * <p>{@code SystemAdminController} hosts the {@code /manage/system/tenants}
+ * landing page (list all Tenants) and the suspend/unsuspend/delete actions on
+ * Tenants other than your own. {@code TenantDetailsController} hosts the
+ * per-Tenant detail page plus the System-Admin tenant-create UI at
+ * {@code /manage/system/tenants/new}, which delegates to {@code provisioning}.
+ *
+ * <p>The System Tenant itself ({@code slug = "system"}) is created by Flyway +
+ * the {@code identity} bootstrap path, not through this module. This module is
+ * about *what a System Admin can do across other Tenants*.
+ *
+ * <p>Three "tenant lifecycle" entry points exist and are deliberately distinct:
+ * <ul>
+ *   <li>{@code system} (this module) — System Admin actions on existing Tenants + create
+ *   <li>{@code signup} — public self-service form for new Tenants
+ *   <li>{@code provisioning} — the orchestrator both entry points call into
+ * </ul>
+ *
+ * <p>Spring Modulith application module. See {@code docs/reference/architecture.md}
+ * §4.15 (Package structure).
+ */
+package com.stucray.limen.system;

--- a/src/main/java/com/stucray/limen/tenant/package-info.java
+++ b/src/main/java/com/stucray/limen/tenant/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * The {@code Tenant} entity, its repository, status enum, and the per-request
+ * {@code TenantScope} {@code ScopedValue}.
+ *
+ * <p>{@code TenantScope} is the tenant-binding mechanism every layer reads to
+ * answer "which Tenant is this request for?" — it is established by the
+ * routing/issuer-context filters and consumed by the storage decorators, the
+ * signing-key store, audit, observability, etc. Keeping it here (not in
+ * {@code auth} or {@code oauth2}) means every other module can depend on
+ * {@code tenant} without picking up authentication or protocol baggage.
+ *
+ * <p>Tenant *lifecycle* (create/suspend/unsuspend/delete) lives in the
+ * {@code provisioning} module — separate to avoid a {@code tenant → auth → tenant}
+ * cycle. This module is just the data shape and the request-scoped binding.
+ *
+ * <p>Spring Modulith application module. See {@code docs/reference/architecture.md}
+ * §3 (Domain Model) and §4.15 (Package structure).
+ */
+package com.stucray.limen.tenant;

--- a/src/main/java/com/stucray/limen/user/package-info.java
+++ b/src/main/java/com/stucray/limen/user/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * The {@code User} entity, {@code UserRepository}, and {@code TenantUserDetails}
+ * (the Spring Security {@code UserDetails} adapter wrapping {@code User} +
+ * {@code Tenant}).
+ *
+ * <p>{@code TenantUserDetails} lives here, *not* in {@code auth}, because audit,
+ * auth, oauth2, management, and provisioning all need it; if it lived in
+ * {@code auth}, audit's principal-extraction would create an
+ * {@code audit ↔ auth} cycle. Co-locating it with the {@code User} entity matches
+ * the conceptual mapping (user identity ⇒ user-as-principal) and lets every
+ * consumer depend on {@code user} instead.
+ *
+ * <p>Not to be confused with {@code com.stucray.limen.useradmin}, which holds
+ * Tenant-Owner administration of Users ({@code UserAdministrationService},
+ * {@code PasswordChangeRequiredInterceptor}). This module is "what a User
+ * <em>is</em>"; {@code useradmin} is "what an admin <em>does to</em> a User."
+ *
+ * <p>Spring Modulith application module. See {@code docs/reference/architecture.md}
+ * §3 (Domain Model) and §4.15 (Package structure).
+ */
+package com.stucray.limen.user;

--- a/src/main/java/com/stucray/limen/useradmin/package-info.java
+++ b/src/main/java/com/stucray/limen/useradmin/package-info.java
@@ -1,0 +1,25 @@
+/**
+ * Tenant-Owner administration of Users within a Tenant.
+ *
+ * <p>Hosts {@code UserAdministrationService} (the service the admin console calls
+ * when an Owner creates/disables/enables/unlocks/deletes a User, resets a
+ * password, or grants/revokes Tenant Ownership), {@code UserManagementController}
+ * (the {@code /manage/t/{slug}/users/...} surface), and
+ * {@code PasswordChangeRequiredInterceptor} (the MVC interceptor that forces a
+ * password change on the next management request when the User's
+ * {@code must_change_password} flag is set).
+ *
+ * <p>The change-password form itself is hosted by
+ * {@code com.stucray.limen.auth.login.PasswordChangeController} — a single
+ * controller that serves both the OAuth2 surface and the management surface.
+ * This module is admin-side actions only.
+ *
+ * <p>Not to be confused with {@code com.stucray.limen.user}, which holds the
+ * {@code User} entity, {@code UserRepository}, and {@code TenantUserDetails}.
+ * This module is "what an admin <em>does to</em> a User"; {@code user} is "what
+ * a User <em>is</em>."
+ *
+ * <p>Spring Modulith application module. See {@code docs/reference/architecture.md}
+ * §4.15 (Package structure) for the cross-cutting view.
+ */
+package com.stucray.limen.useradmin;

--- a/src/main/java/com/stucray/limen/web/package-info.java
+++ b/src/main/java/com/stucray/limen/web/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * Top-level web routes: the landing page and the slug-aware {@code /login}
+ * forwarder.
+ *
+ * <p>{@code RootController} renders {@code /} (the landing page with sign-in
+ * and sign-up paths). {@code RedirectLoginController} handles {@code /login}:
+ * if the request carries a tenant slug it forwards to
+ * {@code /t/{slug}/login}; otherwise it renders the slug-input form.
+ *
+ * <p>Three "web-surface" modules exist and are deliberately distinct:
+ * <ul>
+ *   <li>{@code web} (this module) — top-level routes ({@code /}, {@code /login} forwarder)
+ *   <li>{@code enduser} — post-OAuth2 end-user pages
+ *   <li>{@code management} — admin-console infrastructure for {@code /manage/...}
+ * </ul>
+ *
+ * <p>Spring Modulith application module. See {@code docs/reference/architecture.md}
+ * §4.12 (HTTP route map) and §4.15 (Package structure).
+ */
+package com.stucray.limen.web;


### PR DESCRIPTION
## Summary
- Adds a `package-info.java` to each of the 20 top-level Modulith application modules under `com.stucray.limen`. Each one carries a one-paragraph role description plus an explicit "not to be confused with X" callout for the four neighbour pairs that previously needed prose every time to disambiguate (`user` vs `useradmin`, `auth` vs `oauth2`, the three web-surface modules, the three tenant-lifecycle entry points).
- Repositions arch.md §4.15 around this: renamed to "Package structure (application modules)", points to `package-info.java` as the canonical per-module description, keeps the table as a one-line index plus the cross-cutting decisions (module-shaping rationale, named interfaces, dependency policy, build deps) that don't fit on any single module.
- **Side fix:** §4.15's table had drifted — `observability` was missing. Added the row, bumped the count from 19 to 20, refreshed the as-of date. This is exactly the drift this restructure is meant to prevent going forward.

## Why
Even with §4.15 in place, the package tree at a glance is hard to parse: `user` vs `useradmin` (recently renamed from `users`), `auth` vs `oauth2`, three different `/manage/` web surfaces, three different tenant-lifecycle entry points. Putting the description next to the code means the IDE shows it on hover, Javadoc renders it, and a future reader doesn't need to know about the architecture doc to understand the package they're already looking at.

This is the second of two PRs from the package-structure discussion (first was #208 renaming `users` → `useradmin`). Background: Oracle's Javadoc guidance explicitly endorses this two-tier model ("for large, complex packages a pointer to an external architecture document is warranted"); Spring Modulith's own Application Module Canvas tooling reads package-info content if/when we switch on doc generation later.

## Test plan
- [x] `./mvnw -B -ntp verify` passes locally (compile + Error Prone + NullAway + Testcontainers tests + JaCoCo + PMD)
- [x] `LimenModuleArchitectureTest` (Spring Modulith verifier) passes — confirms no module structure regression from adding the package-info files
- [ ] CI passes on the branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)