### PR TITLE
docs: add Javadoc to the three named-interface package-info files

### DIFF
--- a/src/main/java/com/stucray/limen/audit/events/package-info.java
+++ b/src/main/java/com/stucray/limen/audit/events/package-info.java
@@ -1,3 +1,22 @@
+/**
+ * Cross-module API for the audit log: the domain event types that other
+ * modules publish via {@code ApplicationEventPublisher}.
+ *
+ * <p>Every concrete event in this package is an immutable {@code record}
+ * that implements the {@link AuditedDomainEvent} marker. Implementing the
+ * marker is what binds an event to the AFTER_COMMIT audit listener
+ * ({@code AuditDispatcher.onAfterCommit}); see {@link AuditedDomainEvent}'s
+ * Javadoc for why the marker is load-bearing rather than decorative.
+ *
+ * <p>To add a new audited event: declare a {@code record} in this package
+ * implementing {@link AuditedDomainEvent}, add its mapping to
+ * {@code AuditRegistry}, and publish it from your module's transactional
+ * code. No other coordination is needed — the listener side is wired here.
+ *
+ * <p>Spring Modulith {@code @NamedInterface}; sub-packages of {@code audit}
+ * other than this one ({@code audit.dispatch}) are internal to the
+ * {@code audit} module.
+ */
 @NamedInterface("events")
 package com.stucray.limen.audit.events;
 

--- a/src/main/java/com/stucray/limen/auth/login/package-info.java
+++ b/src/main/java/com/stucray/limen/auth/login/package-info.java
@@ -1,3 +1,29 @@
+/**
+ * Cross-module API for the login pipeline: the integration points other
+ * modules hook into.
+ *
+ * <p>Three types are the public surface:
+ * <ul>
+ *   <li>{@link TenantUrlScheme} — per-surface URL conventions (login form
+ *       match, slug extraction from any tenant-scoped URL, redirect
+ *       templates). Exposed as a {@code @Bean} so each surface (OAuth2
+ *       login, management login) registers its own scheme; integration
+ *       tests can register synthetic ones without mocking.
+ *   <li>{@link PostLoginIntent} — the strategy contract a module
+ *       implements to act on a successful login (e.g. forced-password-change
+ *       redirect). {@code PostLoginIntents} is the registry that runs
+ *       them in order.
+ *   <li>{@link TenantPasswordChangeFlow} — validation + persistence + the
+ *       OAuth2-authorize-resume hand-off shared by both change-password
+ *       surfaces. {@code PasswordChangeController} (also in this package)
+ *       is the single controller that binds both URL prefixes and
+ *       dispatches via {@code TenantUrlScheme.slugFrom(uri)}.
+ * </ul>
+ *
+ * <p>Spring Modulith {@code @NamedInterface}; sibling sub-packages
+ * ({@code auth.lockout}, {@code auth.ott}) are independent — see each
+ * one's own {@code package-info} for details.
+ */
 @NamedInterface("login")
 package com.stucray.limen.auth.login;
 

--- a/src/main/java/com/stucray/limen/auth/ott/package-info.java
+++ b/src/main/java/com/stucray/limen/auth/ott/package-info.java
@@ -1,3 +1,31 @@
+/**
+ * Cross-module API for one-time-token (OTT) issuance and completion.
+ *
+ * <p>Other modules call into this surface through two services and one
+ * extension point:
+ * <ul>
+ *   <li>{@link OttDispatcher} — the single entry point for issuing an OTT
+ *       under any {@link OttIntent}. Handles user lookup (with the
+ *       existence-oracle defence), {@code TenantScope} binding, token
+ *       generation, email dispatch, intent-specific issued-event emission,
+ *       and the transactional boundary in one place.
+ *   <li>{@link OttCompletionService} — the surface for marking an OTT
+ *       journey complete. {@code markEmailVerified} flips
+ *       {@code email_verified} (idempotent on already-verified) and emits
+ *       {@code EmailVerifiedEvent}; {@code markPasswordResetCompleted}
+ *       emits the journey-tail marker, with the password rotation itself
+ *       owned by {@code TenantPasswordChangeFlow} in {@code auth.login}.
+ *   <li>{@link OttIntentHandler} — the per-intent extension point. New
+ *       intents add one {@link OttIntent} enum constant plus one
+ *       {@code OttIntentHandler} bean; {@code OttDispatcher} discovers
+ *       handlers via {@code List<OttIntentHandler>} (not a map keyed on
+ *       enum, since Spring won't enum-coerce keys).
+ * </ul>
+ *
+ * <p>Spring Modulith {@code @NamedInterface}; sibling sub-packages
+ * ({@code auth.lockout}, {@code auth.login}) are independent — see each
+ * one's own {@code package-info} for details.
+ */
 @NamedInterface("ott")
 package com.stucray.limen.auth.ott;
 


### PR DESCRIPTION
## Summary
Adds Javadoc to the three Modulith named-interface `package-info.java` files (`audit.events`, `auth.login`, `auth.ott`). Each file already existed (Modulith reads `@NamedInterface` off `package-info.java`), but each held only the annotation and no prose — so the cross-module APIs that other modules legally import had no human-readable description in source.

Each docstring now names the public types, explains the extension shape (e.g. "to add a new audited event…", "new OTT intents add one enum constant + one bean…"), and cross-references sibling / parent-module package-info files.

## Why
This is the natural follow-up to PR #209 (which documented the 20 top-level modules). Sub-packages are normally internal to their parent module under Modulith's default rules, so they don't need docstrings — but these three are explicitly *public* APIs via `@NamedInterface`. Of all sub-packages, these are the *most* important to document, because they're the only ones outside callers reach.

## Test plan
- [x] `./mvnw -B -ntp compile test-compile` passes locally — Javadoc on `package-info.java` parses cleanly under javac
- [x] `LimenModuleArchitectureTest` (Spring Modulith verifier) still passes — confirms the three `@NamedInterface` annotations are still detected after the docstring addition
- [ ] CI passes on the branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)