### PR TITLE
refactor: reduce public surface in the auth module (Pass 1, module 1/20)

### DIFF
--- a/src/main/java/com/stucray/limen/auth/AuthBeansConfig.java
+++ b/src/main/java/com/stucray/limen/auth/AuthBeansConfig.java
@@ -12,7 +12,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import java.util.List;
 
 @Configuration
-public class AuthBeansConfig {
+class AuthBeansConfig {
 
     @Bean
     public TenantPersistentTokenRepository tenantPersistentTokenRepository(JdbcTemplate jdbcTemplate) {

--- a/src/main/java/com/stucray/limen/auth/TenantAuthTokenMixin.java
+++ b/src/main/java/com/stucray/limen/auth/TenantAuthTokenMixin.java
@@ -27,7 +27,7 @@ import java.util.Collection;
 )
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
-public abstract class TenantAuthTokenMixin {
+abstract class TenantAuthTokenMixin {
 
     @JsonCreator
     TenantAuthTokenMixin(

--- a/src/main/java/com/stucray/limen/auth/TenantPersistentRememberMeToken.java
+++ b/src/main/java/com/stucray/limen/auth/TenantPersistentRememberMeToken.java
@@ -10,7 +10,7 @@ import java.util.Date;
  * {@link TenantPersistentTokenRepository#getTokenForSeries(String, Long)} so
  * the caller can verify that the cookie's claimed tenant matches the row's.
  */
-public final class TenantPersistentRememberMeToken extends PersistentRememberMeToken {
+final class TenantPersistentRememberMeToken extends PersistentRememberMeToken {
 
     private final Long tenantId;
 

--- a/src/main/java/com/stucray/limen/auth/TenantPersistentTokenRepository.java
+++ b/src/main/java/com/stucray/limen/auth/TenantPersistentTokenRepository.java
@@ -18,7 +18,7 @@ import java.util.Date;
  * Callers (the custom {@link TenantPersistentTokenBasedRememberMeServices})
  * pass the tenant explicitly on every call.
  */
-public class TenantPersistentTokenRepository {
+class TenantPersistentTokenRepository {
 
     private static final String INSERT_SQL =
         "INSERT INTO persistent_logins (tenant_id, email, series, token, last_used) "

--- a/src/main/java/com/stucray/limen/auth/TenantUserDetailsMixin.java
+++ b/src/main/java/com/stucray/limen/auth/TenantUserDetailsMixin.java
@@ -25,7 +25,7 @@ import com.stucray.limen.user.User;
 )
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
-public abstract class TenantUserDetailsMixin {
+abstract class TenantUserDetailsMixin {
 
     @JsonCreator
     TenantUserDetailsMixin(@JsonProperty("user") User user, @JsonProperty("tenant") Tenant tenant) {

--- a/src/main/java/com/stucray/limen/auth/lockout/LoginAttemptTracker.java
+++ b/src/main/java/com/stucray/limen/auth/lockout/LoginAttemptTracker.java
@@ -47,7 +47,7 @@ import java.util.Optional;
  * </ul>
  */
 @Component
-public class LoginAttemptTracker {
+class LoginAttemptTracker {
 
     private final UserRepository userRepository;
     private final TenantRepository tenantRepository;


### PR DESCRIPTION
## Summary
First module in the visibility-reduction sweep agreed in the design grilling. Drops \`public\` from 6 top-level types in \`auth/\` and \`auth/lockout/\` that have no cross-module or intra-module cross-package callers.

| Class | Why it can go package-private |
|---|---|
| \`AuthBeansConfig\` | \`@Configuration\`; CGLIB proxy works fine in same-classloader (no DevTools in Limen) |
| \`TenantAuthTokenMixin\` | Jackson mixin, registered via reflection |
| \`TenantUserDetailsMixin\` | Jackson mixin, registered via reflection |
| \`TenantPersistentRememberMeToken\` | record class only constructed within the auth package |
| \`TenantPersistentTokenRepository\` | repository called only from the same package |
| \`auth/lockout/LoginAttemptTracker\` | \`@EventListener\` bean |

## What stayed public (and why)
- \`SasJsonMapperFactory\`, \`TenantAuthProvider\` — imported cross-module (\`oauth2\`, \`provisioning\`)
- \`LockoutProperties\` — imported cross-module
- \`ManagementAuthEntryPoint\` — imported by \`management.auth\`
- \`TenantAccessFilter\`, \`TenantAuthToken\`, \`TenantPersistentTokenBasedRememberMeServices\`, \`TenantUserDetailsService\` — used cross-package within the auth module (\`auth.login\`, \`auth.lockout\`, \`auth.ott\` reach in)

## What was deliberately not touched
Named-interface sub-packages \`auth.login\` and \`auth.ott\` — their public types are the documented cross-module API.

## Approach
Per the design conversation: visibility-only, compile-as-oracle. Flipped each candidate, ran \`mvn compile\`, full \`mvn verify\`. No reverts needed — all 6 candidates were truly internal.

## Test plan
- [x] \`./mvnw -B -ntp verify\` passes locally (compile + Error Prone + NullAway + Testcontainers tests + JaCoCo + PMD)
- [x] \`LimenModuleArchitectureTest\` (Spring Modulith verifier) passes — confirms no module-boundary regression
- [x] All auth-touching tests pass: \`TenantPersistentTokenRepositoryIntegrationTest\`, \`TenantPersistentTokenBasedRememberMeServicesUnitTest\`/\`IntegrationTest\`, \`TenantUserDetailsServiceUnitTest\`, \`CrossTenantLoginIsolationIntegrationTest\`, \`AccountLockoutJourneyUiIT\`
- [ ] CI passes on the branch

## Next module
\`audit\` (29 files) is next per the biggest-first plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)