### PR TITLE
refactor: reduce public surface in the audit module (Pass 1, module 2/20)

### DIFF
--- a/src/main/java/com/stucray/limen/audit/dispatch/AuditBinding.java
+++ b/src/main/java/com/stucray/limen/audit/dispatch/AuditBinding.java
@@ -5,7 +5,7 @@ package com.stucray.limen.audit.dispatch;
  * as data on each {@link AuditRule} so the choice is visible alongside the event
  * class instead of buried in a per-method annotation.
  */
-public enum AuditBinding {
+enum AuditBinding {
     /**
      * Custom domain event emitted from inside a {@code @Transactional} method.
      * Audit row is written after the parent transaction commits, so a write

--- a/src/main/java/com/stucray/limen/audit/dispatch/AuditDispatcher.java
+++ b/src/main/java/com/stucray/limen/audit/dispatch/AuditDispatcher.java
@@ -44,7 +44,7 @@ import java.util.Map;
  * resubmitted via the registry.
  */
 @Component
-public class AuditDispatcher {
+class AuditDispatcher {
 
     private static final Logger log = LoggerFactory.getLogger(AuditDispatcher.class);
 

--- a/src/main/java/com/stucray/limen/audit/dispatch/AuditRule.java
+++ b/src/main/java/com/stucray/limen/audit/dispatch/AuditRule.java
@@ -17,7 +17,7 @@ import java.util.function.Function;
  * the {@code login_success} rule when the principal isn't a tenant user
  * (e.g. an OAuth client token).
  */
-public record AuditRule<E>(
+record AuditRule<E>(
     Class<E> eventClass,
     String eventType,
     AuditBinding binding,


### PR DESCRIPTION
## Summary
Second module of the visibility-reduction sweep. All three types in \`audit/dispatch/\` go package-private — they're imported from nowhere outside the dispatch sub-package.

| Class | Why it can go package-private |
|---|---|
| \`audit/dispatch/AuditBinding\` | enum, used only by \`AuditRule\` |
| \`audit/dispatch/AuditRule\` | record, used only by \`AuditRegistry\` + \`AuditDispatcher\` |
| \`audit/dispatch/AuditDispatcher\` | \`@Component\` \`@ApplicationModuleListener\`; Spring picks it up via reflection |

## What stayed public (and why)
- \`audit.AuditEvent\`, \`audit.AuditEventWriter\` — used cross-package within the audit module (\`audit/dispatch/\` reaches in)

## What was deliberately not touched
Named-interface sub-package \`audit.events\` — 23 event types + \`AuditedDomainEvent\` marker are the documented cross-module API.

## Test plan
- [x] \`./mvnw -B -ntp verify\` passes locally
- [x] \`LimenModuleArchitectureTest\` (Spring Modulith verifier) passes
- [ ] CI passes on the branch

## Next module
\`memberships\` (12 files) is next per the biggest-first plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)