### PR TITLE
refactor: reduce public surface in the memberships module (Pass 1, module 3/20)

### DIFF
--- a/src/main/java/com/stucray/limen/memberships/ClientMembersController.java
+++ b/src/main/java/com/stucray/limen/memberships/ClientMembersController.java
@@ -27,7 +27,7 @@ import java.util.Set;
 
 @Controller
 @RequestMapping("/manage/t/{slug}/applications/{appId}/clients/{registeredClientId}/members")
-public class ClientMembersController {
+class ClientMembersController {
 
     private final ClientMembershipService membershipService;
     private final ApplicationService applicationService;

--- a/src/main/java/com/stucray/limen/memberships/MembersController.java
+++ b/src/main/java/com/stucray/limen/memberships/MembersController.java
@@ -24,7 +24,7 @@ import java.util.Set;
 
 @Controller
 @RequestMapping("/manage/t/{slug}/applications/{appId}/members")
-public class MembersController {
+class MembersController {
 
     private final ApplicationMembershipService membershipService;
     private final ApplicationService applicationService;


### PR DESCRIPTION
## Summary
Two controllers go package-private — Spring picks them up via component scanning regardless of class-level visibility:

| Class | Why it can go package-private |
|---|---|
| \`ClientMembersController\` | \`@Controller\`, scanned by Spring; not imported by name anywhere else |
| \`MembersController\` | \`@Controller\`, scanned by Spring; not imported by name anywhere else |

## What stayed public (and why)
9 of 12 public types are imported by other modules and stay as the implicit cross-module API: \`ApplicationMembership\` / \`Repository\` / \`Role\` / \`Service\`, \`ClientMembership\` / \`Query\` / \`Repository\` / \`Role\` / \`Service\`, \`UserMembershipPortfolioQuery\`.

\`memberships\` is mostly cross-module surface — small visibility win, but every public class is now justified.

## Test plan
- [x] \`./mvnw -B -ntp verify\` passes locally
- [x] \`LimenModuleArchitectureTest\` passes
- [ ] CI passes on the branch

## Next module
\`oauth2\` (12 files) is next per the biggest-first plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)