### PR TITLE
refactor: reduce public surface in the oauth2 module (Pass 1, module 4/20)

### DIFF
--- a/src/main/java/com/stucray/limen/oauth2/OAuth2LoginSecurityConfig.java
+++ b/src/main/java/com/stucray/limen/oauth2/OAuth2LoginSecurityConfig.java
@@ -38,7 +38,7 @@ import java.util.regex.Pattern;
  */
 @Configuration
 @Order(1)
-public class OAuth2LoginSecurityConfig {
+class OAuth2LoginSecurityConfig {
 
     private final TenantLogin login;
     private final TenantUrlScheme oauth2UrlScheme;

--- a/src/main/java/com/stucray/limen/oauth2/OAuth2TenantLoginController.java
+++ b/src/main/java/com/stucray/limen/oauth2/OAuth2TenantLoginController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
 @Controller
-public class OAuth2TenantLoginController {
+class OAuth2TenantLoginController {
 
     private final TenantRepository tenantRepository;
 

--- a/src/main/java/com/stucray/limen/oauth2/SasConfig.java
+++ b/src/main/java/com/stucray/limen/oauth2/SasConfig.java
@@ -46,7 +46,7 @@ import java.util.List;
 import java.util.Set;
 
 @Configuration
-public class SasConfig {
+class SasConfig {
 
     @Bean
     @Order(Ordered.HIGHEST_PRECEDENCE)

--- a/src/main/java/com/stucray/limen/oauth2/TenantOAuth2RequestWrapper.java
+++ b/src/main/java/com/stucray/limen/oauth2/TenantOAuth2RequestWrapper.java
@@ -8,7 +8,7 @@ import org.jspecify.annotations.Nullable;
  * Strips the leading /t/{slug} segment from the request URI so that Spring Authorization Server
  * sees standard endpoint paths like /oauth2/token instead of /t/acme/oauth2/token.
  */
-public class TenantOAuth2RequestWrapper extends HttpServletRequestWrapper {
+class TenantOAuth2RequestWrapper extends HttpServletRequestWrapper {
 
     private final String strippedUri;
     private final String strippedServletPath;

--- a/src/main/java/com/stucray/limen/oauth2/TenantOAuth2RoutingFilter.java
+++ b/src/main/java/com/stucray/limen/oauth2/TenantOAuth2RoutingFilter.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
  */
 @Component
 @Order(Integer.MIN_VALUE + 10)
-public class TenantOAuth2RoutingFilter extends OncePerRequestFilter {
+class TenantOAuth2RoutingFilter extends OncePerRequestFilter {
 
     private static final Pattern TENANT_PATH =
         Pattern.compile("^/t/([^/]+)/((oauth2|\\.well-known|connect)/.*|userinfo)$");


### PR DESCRIPTION
## Summary
Five types in \`oauth2/\` go package-private — Spring picks them up via component scanning, and nothing outside the module imports them by name:

| Class | Why it can go package-private |
|---|---|
| \`OAuth2TenantLoginController\` | \`@Controller\` for \`/t/{slug}/login\`; route-only registration |
| \`OAuth2LoginSecurityConfig\` | \`@Configuration\` (OAuth2 login filter chain) |
| \`SasConfig\` | \`@Configuration\` with 8 \`@Bean\` methods (Spring Authorization Server wiring); CGLIB proxy works fine in same-classloader |
| \`TenantOAuth2RequestWrapper\` | \`HttpServletRequestWrapper\` used only inside the routing filter |
| \`TenantOAuth2RoutingFilter\` | \`@Component\` filter |

## What stayed public (the actual cross-module API)
- \`MembershipGateFilter\` — imported by \`security\`
- \`TenantAwareOAuth2AuthorizationConsentService\`, \`TenantAwareOAuth2AuthorizationService\`, \`TenantAwareRegisteredClientRepository\` — the SAS integration trio, imported by \`provisioning\` and \`auth\`
- \`TenantIssuerContextFilter\`, \`TenantJwkSource\` — imported by \`security\` / \`management.auth\`
- \`TenantLoginUrlAuthenticationEntryPoint\` — imported by \`management.auth\`

This was the largest CGLIB-stress-test module (\`SasConfig\` has 8 beans). \`mvn verify\` confirms no proxy issues.

## Test plan
- [x] \`./mvnw -B -ntp verify\` passes locally
- [x] \`LimenModuleArchitectureTest\` passes
- [ ] CI passes on the branch

## Next module
\`security\` (10 files) is next per the biggest-first plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)