### PR TITLE
refactor: reduce public surface in the security module (Pass 1, module 5/20)

### DIFF
--- a/src/main/java/com/stucray/limen/security/DefaultSecurityConfig.java
+++ b/src/main/java/com/stucray/limen/security/DefaultSecurityConfig.java
@@ -19,7 +19,7 @@ import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 @EnableWebSecurity
 @EnableMethodSecurity
 @Order(3)
-public class DefaultSecurityConfig {
+class DefaultSecurityConfig {
 
     @Bean
     public SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/com/stucray/limen/security/JdbcSigningKeyStore.java
+++ b/src/main/java/com/stucray/limen/security/JdbcSigningKeyStore.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 @Component
-public class JdbcSigningKeyStore implements SigningKeyStore {
+class JdbcSigningKeyStore implements SigningKeyStore {
 
     private static final String ALGORITHM = "RS256";
     private static final int RSA_KEY_SIZE = 2048;

--- a/src/main/java/com/stucray/limen/security/SecurityProperties.java
+++ b/src/main/java/com/stucray/limen/security/SecurityProperties.java
@@ -9,7 +9,7 @@ import java.util.Base64;
 
 @ConfigurationProperties("limen.security")
 @Validated
-public record SecurityProperties(@NotBlank String kek) {
+record SecurityProperties(@NotBlank String kek) {
 
     private static final int KEK_BYTES = 32;
 

--- a/src/main/java/com/stucray/limen/security/SigningKeyRotationConfig.java
+++ b/src/main/java/com/stucray/limen/security/SigningKeyRotationConfig.java
@@ -27,7 +27,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @Configuration
 @EnableScheduling
 @EnableSchedulerLock(defaultLockAtMostFor = "PT10M")
-public class SigningKeyRotationConfig {
+class SigningKeyRotationConfig {
 
     @Bean
     public LockProvider lockProvider(JdbcTemplate jdbcTemplate) {

--- a/src/main/java/com/stucray/limen/security/SigningKeyRotationProperties.java
+++ b/src/main/java/com/stucray/limen/security/SigningKeyRotationProperties.java
@@ -27,7 +27,7 @@ import java.time.Duration;
  */
 @ConfigurationProperties("limen.signing-key-rotation")
 @Validated
-public record SigningKeyRotationProperties(
+record SigningKeyRotationProperties(
     @DefaultValue("true") boolean enabled,
     @DefaultValue("0 0 3 * * *") @NotBlank String cron,
     @DefaultValue("30d") @NotNull Duration keyAge,

--- a/src/main/java/com/stucray/limen/security/SigningKeyRotationSchedule.java
+++ b/src/main/java/com/stucray/limen/security/SigningKeyRotationSchedule.java
@@ -22,7 +22,7 @@ import org.springframework.stereotype.Component;
     name = "limen.signing-key-rotation.enabled",
     havingValue = "true",
     matchIfMissing = true)
-public class SigningKeyRotationSchedule {
+class SigningKeyRotationSchedule {
 
     private final SigningKeyRotator rotator;
 

--- a/src/main/java/com/stucray/limen/security/SigningKeyRotator.java
+++ b/src/main/java/com/stucray/limen/security/SigningKeyRotator.java
@@ -43,7 +43,7 @@ import java.util.List;
  * AFTER_COMMIT audit + counter listeners fire per tenant.
  */
 @Component
-public class SigningKeyRotator {
+class SigningKeyRotator {
 
     private static final Logger log = LoggerFactory.getLogger(SigningKeyRotator.class);
 

--- a/src/main/java/com/stucray/limen/security/ratelimit/RateLimitFilter.java
+++ b/src/main/java/com/stucray/limen/security/ratelimit/RateLimitFilter.java
@@ -44,7 +44,7 @@ import java.util.regex.Pattern;
  */
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)
-public class RateLimitFilter extends OncePerRequestFilter {
+class RateLimitFilter extends OncePerRequestFilter {
 
     private final RateLimitProperties properties;
     private final ApplicationEventPublisher publisher;


### PR DESCRIPTION
## Summary
Eight types in \`security/\` and \`security/ratelimit/\` go package-private — all have zero importers from anywhere in the codebase:

| Class | Why it can go package-private |
|---|---|
| \`DefaultSecurityConfig\` | \`@Configuration\` (the catch-all filter chain) |
| \`JdbcSigningKeyStore\` | \`@Component\`, the \`SigningKeyStore\` impl — callers use the interface |
| \`SecurityProperties\` | \`@ConfigurationProperties\` |
| \`SigningKeyRotationConfig\` | \`@Configuration\` |
| \`SigningKeyRotationProperties\` | \`@ConfigurationProperties\` |
| \`SigningKeyRotationSchedule\` | \`@Component\`, scheduled rotator wrapper |
| \`SigningKeyRotator\` | \`@Component\` |
| \`security/ratelimit/RateLimitFilter\` | \`@Component\` |

## What stayed public (the actual cross-module API)
- \`SigningKeyStore\` (interface) — imported by \`oauth2\` for JWK source
- \`RateLimitProperties\` — its inner \`KeyType\` and \`RuleSpec\` records are imported for rule construction

## Net
Largest delta-ratio so far: **8/10 = 80%**. \`security\` turns out to be mostly internal plumbing — the only two genuine cross-module APIs are the \`SigningKeyStore\` interface (impl hidden) and the rate-limit configuration shape.

## Test plan
- [x] \`./mvnw -B -ntp verify\` passes locally
- [x] \`LimenModuleArchitectureTest\` passes
- [ ] CI passes on the branch

## Next module
Long tail starts: smaller modules in any order. Recommend grouping the remaining 15 modules (most are 1–6 files) into a few PRs to keep the cadence reasonable, OR continuing one PR per module if you prefer the current rhythm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)