### PR TITLE
refactor: reduce public surface in domain modules (Pass 1, themed PR 1/4)

### DIFF
--- a/src/main/java/com/stucray/limen/applications/ApplicationController.java
+++ b/src/main/java/com/stucray/limen/applications/ApplicationController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.*;
 
 @Controller
 @RequestMapping("/manage/t/{slug}/applications")
-public class ApplicationController {
+class ApplicationController {
 
     private final ApplicationService applicationService;
 

--- a/src/main/java/com/stucray/limen/clients/ClientManagementController.java
+++ b/src/main/java/com/stucray/limen/clients/ClientManagementController.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 
 @Controller
 @RequestMapping("/manage/t/{slug}/applications/{appId}/clients")
-public class ClientManagementController {
+class ClientManagementController {
 
     private final ClientManagementService clientManagementService;
     private final ApplicationService applicationService;

--- a/src/main/java/com/stucray/limen/clients/CreateClientForm.java
+++ b/src/main/java/com/stucray/limen/clients/CreateClientForm.java
@@ -23,7 +23,7 @@ import java.util.List;
  * separator-delimited input here; parsing into typed collections happens at
  * the controller before building a {@link CreateClientCommand}.
  */
-public final class CreateClientForm {
+final class CreateClientForm {
 
     private @Nullable String displayName;
     private List<String> grantTypes = List.of();

--- a/src/main/java/com/stucray/limen/roles/RolesController.java
+++ b/src/main/java/com/stucray/limen/roles/RolesController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 @RequestMapping("/manage/t/{slug}/applications/{appId}/roles")
-public class RolesController {
+class RolesController {
 
     private final RoleManagementService roleManagementService;
     private final ApplicationService applicationService;


### PR DESCRIPTION
## Summary
First themed bundle of the long-tail visibility-reduction sweep, covering the five domain-entity modules: \`tenant\`, \`user\`, \`applications\`, \`clients\`, \`roles\`.

Four types flipped to package-private — all have zero importers from anywhere in the codebase:

| Class | Module | Why |
|---|---|---|
| \`ApplicationController\` | \`applications\` | \`@Controller\` for \`/manage/.../applications\` |
| \`ClientManagementController\` | \`clients\` | \`@Controller\` for \`/manage/.../clients\` |
| \`CreateClientForm\` | \`clients\` | form-binding record, only constructed by its controller |
| \`RolesController\` | \`roles\` | \`@Controller\` for \`/manage/.../roles\` |

## Why so small?
Domain modules are genuinely cross-module surface: the entity records (\`Tenant\`, \`User\`, \`Application\`, \`TenantClient\`, \`Role\`), repositories, services, and domain-shaped types (\`TenantStatus\`, \`TenantScope\`, \`ApplicationLookup\`, \`RoleResolver\`, \`CreateClientCommand\`) are all imported by other modules as the public domain model.

The only flippable types in these 5 modules are the per-module web controllers and one internal form record. **23 of 27 public types stay public** — and now every one of them is justified by a real cross-module import.

## Test plan
- [x] \`./mvnw -B -ntp verify\` passes locally
- [x] \`LimenModuleArchitectureTest\` passes
- [ ] CI passes on the branch

## Next
Themed PR 2/4 — Tenant lifecycle modules: \`signup\`, \`provisioning\`, \`system\`, \`useradmin\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)