### PR TITLE
refactor: reduce public surface in lifecycle modules (Pass 1, themed PR 2/4)

### DIFF
--- a/src/main/java/com/stucray/limen/signup/SignupController.java
+++ b/src/main/java/com/stucray/limen/signup/SignupController.java
@@ -10,7 +10,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 import java.nio.charset.StandardCharsets;
 
 @Controller
-public class SignupController {
+class SignupController {
 
     private final SignupService signupService;
 

--- a/src/main/java/com/stucray/limen/system/SystemAdminController.java
+++ b/src/main/java/com/stucray/limen/system/SystemAdminController.java
@@ -20,7 +20,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 @Controller
 @RequestMapping("/manage/system")
 @PreAuthorize("hasRole('SYSTEM_ADMIN')")
-public class SystemAdminController {
+class SystemAdminController {
 
     private final TenantRepository tenantRepository;
     private final TenantProvisioningService tenantProvisioningService;

--- a/src/main/java/com/stucray/limen/system/TenantDetailsController.java
+++ b/src/main/java/com/stucray/limen/system/TenantDetailsController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.*;
 
 @Controller
 @RequestMapping("/manage/t/{slug}/settings")
-public class TenantDetailsController {
+class TenantDetailsController {
 
     private final TenantRepository tenantRepository;
 

--- a/src/main/java/com/stucray/limen/useradmin/UserManagementController.java
+++ b/src/main/java/com/stucray/limen/useradmin/UserManagementController.java
@@ -23,7 +23,7 @@ import java.util.Map;
 @SuppressWarnings("PMD.TooManyMethods")
 @Controller
 @RequestMapping("/manage/t/{slug}/users")
-public class UserManagementController {
+class UserManagementController {
 
     private final UserAdministrationService userAdministration;
     private final UserMembershipPortfolioQuery userMembershipPortfolioQuery;


### PR DESCRIPTION
## Summary
Second themed bundle of the long-tail visibility-reduction sweep, covering the four tenant-lifecycle modules: \`signup\`, \`provisioning\`, \`system\`, \`useradmin\`.

Four controllers flipped to package-private — Spring scans them, nothing imports them:

| Class | Module | URL |
|---|---|---|
| \`SignupController\` | \`signup\` | \`/signup\` |
| \`SystemAdminController\` | \`system\` | \`/manage/system\` |
| \`TenantDetailsController\` | \`system\` | \`/manage/t/{slug}/settings\` |
| \`UserManagementController\` | \`useradmin\` | \`/manage/t/{slug}/users\` |

## What stayed public (and why)
- \`signup.SignupForm\`, \`signup.SignupService\` — the form-binding chain
- \`provisioning.TenantProvisioner\` (+ inner \`NewTenantRequest\`, \`Result\`), \`provisioning.TenantProvisioningService\` — both signup paths (\`/signup\` and \`/manage/system/tenants/new\`) call into these
- \`useradmin.UserAdministrationService\`, \`useradmin.PasswordChangeRequiredInterceptor\` — referenced by management web config

\`provisioning\` is the smallest module (2 files) and both are cross-module entry points — zero candidates there. \`system\` flips both its files because it's pure controller surface.

## Test plan
- [x] \`./mvnw -B -ntp verify\` passes locally
- [x] \`LimenModuleArchitectureTest\` passes
- [ ] CI passes on the branch

## Next
Themed PR 3/4 — Infra modules: \`email\`, \`identity\`, \`observability\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)