### PR TITLE
refactor: reduce public surface in infra modules (Pass 1, themed PR 3/4)

### DIFF
--- a/src/main/java/com/stucray/limen/email/LoggingEmailSender.java
+++ b/src/main/java/com/stucray/limen/email/LoggingEmailSender.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @ConditionalOnProperty(name = "limen.email.driver", havingValue = "logging", matchIfMissing = true)
-public class LoggingEmailSender implements EmailSender {
+class LoggingEmailSender implements EmailSender {
 
     private static final Logger log = LoggerFactory.getLogger(LoggingEmailSender.class);
 

--- a/src/main/java/com/stucray/limen/email/SmtpEmailSender.java
+++ b/src/main/java/com/stucray/limen/email/SmtpEmailSender.java
@@ -22,7 +22,7 @@ import java.util.Objects;
  */
 @Component
 @ConditionalOnProperty(name = "limen.email.driver", havingValue = "smtp")
-public class SmtpEmailSender implements EmailSender {
+class SmtpEmailSender implements EmailSender {
 
     private static final String DEFAULT_FROM = "no-reply@limen.local";
 

--- a/src/main/java/com/stucray/limen/identity/BootstrapAdminProperties.java
+++ b/src/main/java/com/stucray/limen/identity/BootstrapAdminProperties.java
@@ -6,7 +6,7 @@ import org.springframework.validation.annotation.Validated;
 
 @ConfigurationProperties("limen.bootstrap.admin")
 @Validated
-public record BootstrapAdminProperties(String email, String password) {
+record BootstrapAdminProperties(String email, String password) {
 
     @AssertTrue(message = "limen.bootstrap.admin.email and password must both be set or both be unset")
     public boolean isPairConsistent() {

--- a/src/main/java/com/stucray/limen/identity/IdentityConfig.java
+++ b/src/main/java/com/stucray/limen/identity/IdentityConfig.java
@@ -11,7 +11,7 @@ import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
-public class IdentityConfig {
+class IdentityConfig {
 
     @Bean
     public PasswordEncoder passwordEncoder() {

--- a/src/main/java/com/stucray/limen/identity/UserBootstrap.java
+++ b/src/main/java/com/stucray/limen/identity/UserBootstrap.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Component
-public class UserBootstrap implements CommandLineRunner {
+class UserBootstrap implements CommandLineRunner {
 
     static final String SYSTEM_SLUG = "system";
     static final String SYSTEM_DISPLAY_NAME = "System";

--- a/src/main/java/com/stucray/limen/observability/AuditMetricsListener.java
+++ b/src/main/java/com/stucray/limen/observability/AuditMetricsListener.java
@@ -32,7 +32,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
  * Disabled, …) — a small, fixed set.
  */
 @Component
-public class AuditMetricsListener {
+class AuditMetricsListener {
 
     static final String LOGIN_SUCCESS = "limen.auth.login.success";
     static final String LOGIN_FAILURE = "limen.auth.login.failure";

--- a/src/main/java/com/stucray/limen/observability/OtelLogbackInstaller.java
+++ b/src/main/java/com/stucray/limen/observability/OtelLogbackInstaller.java
@@ -20,7 +20,7 @@ import org.springframework.context.annotation.Configuration;
  * zero log records reach Loki — the bridge has nowhere to send them.
  */
 @Configuration
-public class OtelLogbackInstaller {
+class OtelLogbackInstaller {
 
     private static final Logger log = LoggerFactory.getLogger(OtelLogbackInstaller.class);
 

--- a/src/main/java/com/stucray/limen/observability/TenantObservabilityFilter.java
+++ b/src/main/java/com/stucray/limen/observability/TenantObservabilityFilter.java
@@ -32,7 +32,7 @@ import java.io.IOException;
  */
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE + 50)
-public final class TenantObservabilityFilter extends OncePerRequestFilter {
+final class TenantObservabilityFilter extends OncePerRequestFilter {
 
     private static final String MDC_TENANT_SLUG = "tenant.slug";
     private static final String MDC_TENANT_ID = "tenant.id";


### PR DESCRIPTION
## Summary
Third themed bundle: cross-cutting infrastructure modules \`email\`, \`identity\`, \`observability\`.

Eight types flipped to package-private — all have zero importers from anywhere:

| Class | Module | Why |
|---|---|---|
| \`SmtpEmailSender\` | \`email\` | \`@Component\` driver; callers use the interface |
| \`LoggingEmailSender\` | \`email\` | \`@Component\` driver; callers use the interface |
| \`BootstrapAdminProperties\` | \`identity\` | \`@ConfigurationProperties\` |
| \`IdentityConfig\` | \`identity\` | \`@Configuration\` |
| \`UserBootstrap\` | \`identity\` | \`@Component CommandLineRunner\` (System Tenant first-boot seeder) |
| \`AuditMetricsListener\` | \`observability\` | \`@Component\` audit-event-to-Micrometer-counter bridge |
| \`OtelLogbackInstaller\` | \`observability\` | \`@Configuration\` for the programmatic OTel Logback appender |
| \`TenantObservabilityFilter\` | \`observability\` | \`@Component\` request span/meter tagger |

## What stayed public (the actual cross-module API)
- \`email.EmailSender\` (interface), \`email.EmailMessage\` (record) — the abstraction other modules depend on for sending email

## Net
- \`identity\` and \`observability\` flip **100% of their public types** — neither exposes anything to other modules; both are pure infra plumbing
- \`email\` keeps its driver-abstraction API public as the documented contract

## Test plan
- [x] \`./mvnw -B -ntp verify\` passes locally
- [x] \`LimenModuleArchitectureTest\` passes
- [ ] CI passes on the branch

## Next
Themed PR 4/4 (final) — Web-surface modules: \`web\`, \`enduser\`, \`management\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)