### PR TITLE
refactor: reduce public surface in web-surface modules (Pass 1, themed PR 4/4 — final)

### DIFF
--- a/src/main/java/com/stucray/limen/enduser/web/EndUserHomeController.java
+++ b/src/main/java/com/stucray/limen/enduser/web/EndUserHomeController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
 @Controller
-public class EndUserHomeController {
+class EndUserHomeController {
 
     @GetMapping("/t/{slug}/")
     public String home(

--- a/src/main/java/com/stucray/limen/management/auth/ManagementSecurityConfig.java
+++ b/src/main/java/com/stucray/limen/management/auth/ManagementSecurityConfig.java
@@ -14,7 +14,7 @@ import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 
 @Configuration
 @Order(2)
-public class ManagementSecurityConfig {
+class ManagementSecurityConfig {
 
     private final TenantLogin login;
     private final TenantUrlScheme managementUrlScheme;

--- a/src/main/java/com/stucray/limen/management/web/ManagementHomeController.java
+++ b/src/main/java/com/stucray/limen/management/web/ManagementHomeController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
 @Controller
-public class ManagementHomeController {
+class ManagementHomeController {
 
     @GetMapping("/manage/t/{slug}/")
     public String home(

--- a/src/main/java/com/stucray/limen/management/web/ManagementLoginController.java
+++ b/src/main/java/com/stucray/limen/management/web/ManagementLoginController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
 @Controller
-public class ManagementLoginController {
+class ManagementLoginController {
 
     private final TenantRepository tenantRepository;
 

--- a/src/main/java/com/stucray/limen/management/web/ManagementModelAdvice.java
+++ b/src/main/java/com/stucray/limen/management/web/ManagementModelAdvice.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ModelAttribute;
 
 @ControllerAdvice(basePackages = "com.stucray.limen.management")
-public class ManagementModelAdvice {
+class ManagementModelAdvice {
 
     @ModelAttribute("currentEmail")
     public @Nullable String currentEmail(@AuthenticationPrincipal @Nullable TenantUserDetails principal) {

--- a/src/main/java/com/stucray/limen/management/web/ManagementWebConfig.java
+++ b/src/main/java/com/stucray/limen/management/web/ManagementWebConfig.java
@@ -6,7 +6,7 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-public class ManagementWebConfig implements WebMvcConfigurer {
+class ManagementWebConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {

--- a/src/main/java/com/stucray/limen/web/RedirectLoginController.java
+++ b/src/main/java/com/stucray/limen/web/RedirectLoginController.java
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
-public class RedirectLoginController {
+class RedirectLoginController {
 
     @GetMapping("/login")
     public String login(@RequestParam(required = false) String slug) {

--- a/src/main/java/com/stucray/limen/web/RootController.java
+++ b/src/main/java/com/stucray/limen/web/RootController.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
-public class RootController {
+class RootController {
 
     @GetMapping("/")
     public String landing() {


### PR DESCRIPTION
## Summary
Final themed bundle of the visibility-reduction sweep: web-surface modules \`web\`, \`enduser\`, \`management\`. Closes Pass 1.

Eight types flipped to package-private — all are Spring-scanned controllers / configs / model advice with zero name-level importers anywhere:

| Class | Module | Role |
|---|---|---|
| \`RootController\` | \`web\` | Landing page \`/\` |
| \`RedirectLoginController\` | \`web\` | Slug-aware \`/login\` forwarder |
| \`EndUserHomeController\` | \`enduser\` | Post-OAuth2 home |
| \`ManagementSecurityConfig\` | \`management.auth\` | \`@Configuration\`, \`/manage/...\` filter chain |
| \`ManagementHomeController\` | \`management.web\` | \`/manage/t/{slug}/home\` |
| \`ManagementLoginController\` | \`management.web\` | \`/manage/t/{slug}/login\` |
| \`ManagementModelAdvice\` | \`management.web\` | \`@ControllerAdvice\` for \`com.stucray.limen.management\` |
| \`ManagementWebConfig\` | \`management.web\` | \`@Configuration\` implementing \`WebMvcConfigurer\` |

All three modules go **100% internal** — they expose nothing to other modules.

## Pass 1 cumulative summary

This is the 9th and final PR of Pass 1. Across all merged PRs (#211–#218 + this one):

| PR | Module(s) | Flipped | Notes |
|---|---|---|---|
| #211 | \`auth\` | 6 / 14 | named-interface sub-packages preserved |
| #212 | \`audit\` | 3 / 5 | named-interface sub-package preserved |
| #213 | \`memberships\` | 2 / 12 | mostly cross-module domain surface |
| #214 | \`oauth2\` | 5 / 12 | included \`SasConfig\` (8-bean CGLIB stress test) |
| #215 | \`security\` | 8 / 10 | mostly internal plumbing |
| #216 | \`tenant\` + \`user\` + \`applications\` + \`clients\` + \`roles\` | 4 / 27 | domain entities are cross-module by design |
| #217 | \`signup\` + \`provisioning\` + \`system\` + \`useradmin\` | 4 / 13 | controllers only |
| #218 | \`email\` + \`identity\` + \`observability\` | 8 / 10 | infra modules go nearly fully internal |
| this | \`web\` + \`enduser\` + \`management\` | 8 / 8 | 100% internal |

**Total: 48 types flipped from \`public\` to package-private across all 20 top-level Modulith modules.**

## Test plan
- [x] \`./mvnw -B -ntp verify\` passes locally
- [x] \`LimenModuleArchitectureTest\` passes
- [ ] CI passes on the branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)