### PR TITLE
refactor: extract security/signing/ sub-package (Pass 2)

### DIFF
--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -588,7 +588,7 @@ Each direct sub-package of `com.stucray.limen` is one application module. **The 
 | `observability` | Cross-cutting OTel/Micrometer concerns: tenant-tagging filter, named auth counters, OTel logback bridge |
 | `provisioning` | Tenant lifecycle orchestration: `TenantProvisioningService` + `TenantProvisioner` |
 | `roles` | Per-Application `Role` catalogue + `RoleResolver` + management UI |
-| `security` | Foundation security: defaults, `SecurityProperties`, signing-key store + rotator, rate-limit filter (`security.ratelimit`) |
+| `security` | Foundation security: defaults, `SecurityProperties`, the `SigningKeyStore` interface; impl + rotation cluster lives in internal sub-package `security.signing`; rate-limit filter in `security.ratelimit` |
 | `signup` | Public self-service signup form + service |
 | `system` | Cross-tenant System Admin controllers (tenant suspend/unsuspend/delete, system-admin tenant-create) |
 | `tenant` | `Tenant` entity + repository, `TenantStatus`, `TenantScope` (the per-request `ScopedValue`) |
@@ -610,7 +610,7 @@ Each direct sub-package of `com.stucray.limen` is one application module. **The 
 - `auth.login` — login pipeline integration points (`TenantUrlScheme`, `PostLoginIntent`, `TenantPasswordChangeFlow`)
 - `auth.ott` — OTT services consumed across modules (`OttDispatcher`, `OttCompletionService`, `OttIntent`)
 
-Other sub-packages (e.g. `audit.dispatch`, `auth.lockout`, `security.ratelimit`) are internal to their module by Modulith default — outside callers cannot import them.
+Other sub-packages (e.g. `audit.dispatch`, `auth.lockout`, `security.ratelimit`, `security.signing`) are internal to their module by Modulith default — outside callers cannot import them.
 
 **Cross-module dependency policy.** Modulith's open default: any module may depend on any other module's top-level package or its named interfaces. There are no `@ApplicationModule(allowedDependencies = ...)` whitelists. The verifier still enforces no cycles and no sub-package leaks; tightening to per-module allowed-dependency declarations is a future option if evidence warrants it.
 

--- a/src/main/java/com/stucray/limen/security/SecurityProperties.java
+++ b/src/main/java/com/stucray/limen/security/SecurityProperties.java
@@ -9,7 +9,7 @@ import java.util.Base64;
 
 @ConfigurationProperties("limen.security")
 @Validated
-record SecurityProperties(@NotBlank String kek) {
+public record SecurityProperties(@NotBlank String kek) {
 
     private static final int KEK_BYTES = 32;
 

--- a/src/main/java/com/stucray/limen/security/package-info.java
+++ b/src/main/java/com/stucray/limen/security/package-info.java
@@ -4,11 +4,13 @@
  *
  * <p>{@code DefaultSecurityConfig} owns the catch-all filter chain that every
  * request hits before more-specific chains (OAuth2, login, management) take over.
- * {@code JdbcSigningKeyStore} (and the {@code SigningKeyRotator} cluster) own
- * per-Tenant RSA signing-key persistence with envelope encryption — the actual
- * tenant-aware {@code JWKSource} that loads them lives in {@code oauth2}.
- * {@code security.ratelimit} is the in-memory token-bucket filter; it's an
- * internal sub-package, not callable from outside this module.
+ * The {@code SigningKeyStore} interface is the cross-module API for per-Tenant
+ * RSA signing-key storage; the implementation cluster ({@code JdbcSigningKeyStore},
+ * {@code SigningKeyRotator}, scheduling, properties, configuration) lives in the
+ * internal sub-package {@code security.signing}. The actual tenant-aware
+ * {@code JWKSource} that consumes the store lives in {@code oauth2}.
+ * {@code security.ratelimit} is the in-memory token-bucket filter; it's also an
+ * internal sub-package.
  *
  * <p>Spring Modulith application module. See {@code docs/reference/architecture.md}
  * §4.4 (Signing keys) and §4.9 (Rate limiting) for behaviour, §4.15 (Package

--- a/src/main/java/com/stucray/limen/security/signing/JdbcSigningKeyStore.java
+++ b/src/main/java/com/stucray/limen/security/signing/JdbcSigningKeyStore.java
@@ -1,5 +1,7 @@
-package com.stucray.limen.security;
+package com.stucray.limen.security.signing;
 
+import com.stucray.limen.security.SecurityProperties;
+import com.stucray.limen.security.SigningKeyStore;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.RSAKey;

--- a/src/main/java/com/stucray/limen/security/signing/SigningKeyRotationConfig.java
+++ b/src/main/java/com/stucray/limen/security/signing/SigningKeyRotationConfig.java
@@ -1,4 +1,4 @@
-package com.stucray.limen.security;
+package com.stucray.limen.security.signing;
 
 import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
 import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;

--- a/src/main/java/com/stucray/limen/security/signing/SigningKeyRotationProperties.java
+++ b/src/main/java/com/stucray/limen/security/signing/SigningKeyRotationProperties.java
@@ -1,4 +1,4 @@
-package com.stucray.limen.security;
+package com.stucray.limen.security.signing;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/com/stucray/limen/security/signing/SigningKeyRotationSchedule.java
+++ b/src/main/java/com/stucray/limen/security/signing/SigningKeyRotationSchedule.java
@@ -1,4 +1,4 @@
-package com.stucray.limen.security;
+package com.stucray.limen.security.signing;
 
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;

--- a/src/main/java/com/stucray/limen/security/signing/SigningKeyRotator.java
+++ b/src/main/java/com/stucray/limen/security/signing/SigningKeyRotator.java
@@ -1,5 +1,6 @@
-package com.stucray.limen.security;
+package com.stucray.limen.security.signing;
 
+import com.stucray.limen.security.SigningKeyStore;
 import com.stucray.limen.audit.events.SigningKeyPrunedEvent;
 import com.stucray.limen.audit.events.SigningKeyRotatedEvent;
 import com.stucray.limen.audit.events.SigningKeyRotationFailedEvent;

--- a/src/test/java/com/stucray/limen/security/signing/JdbcSigningKeyStoreIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/security/signing/JdbcSigningKeyStoreIntegrationTest.java
@@ -1,5 +1,6 @@
-package com.stucray.limen.security;
+package com.stucray.limen.security.signing;
 
+import com.stucray.limen.security.SigningKeyStore;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.RSAKey;

--- a/src/test/java/com/stucray/limen/security/signing/SigningKeyRotationFlowIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/security/signing/SigningKeyRotationFlowIntegrationTest.java
@@ -1,4 +1,4 @@
-package com.stucray.limen.security;
+package com.stucray.limen.security.signing;
 
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKSet;

--- a/src/test/java/com/stucray/limen/security/signing/SigningKeyRotatorTest.java
+++ b/src/test/java/com/stucray/limen/security/signing/SigningKeyRotatorTest.java
@@ -1,5 +1,6 @@
-package com.stucray.limen.security;
+package com.stucray.limen.security.signing;
 
+import com.stucray.limen.security.SigningKeyStore;
 import com.stucray.limen.audit.events.SigningKeyPrunedEvent;
 import com.stucray.limen.audit.events.SigningKeyRotatedEvent;
 import com.stucray.limen.audit.events.SigningKeyRotationFailedEvent;


### PR DESCRIPTION
## Summary
First (and likely only) Pass-2 structural move from the visibility-reduction sweep. Moves the 5 signing-key implementation types out of \`security/\` top-level into a new internal sub-package \`security.signing/\` which Modulith treats as private-by-default — invisible to other modules.

## Files moved (\`git mv\`, history preserved)

**Main (5):**
- \`JdbcSigningKeyStore\` — the \`SigningKeyStore\` impl
- \`SigningKeyRotationProperties\` — \`@ConfigurationProperties\`
- \`SigningKeyRotationConfig\` — \`@Configuration\` for ShedLock + \`@EnableScheduling\`
- \`SigningKeyRotationSchedule\` — \`@Scheduled\` cron wrapper
- \`SigningKeyRotator\` — the orchestrator

**Test (3):** relocated alongside their targets.

## What stayed at \`security/\` top-level

| Class | Why it stayed |
|---|---|
| \`SigningKeyStore\` (interface) | The cross-module API. Single-type cross-module exposure stays at the module's "front door" — a \`@NamedInterface\` sub-package for one type is structural noise per the Pass-1 design grill |
| \`SecurityProperties\` | Reverted to \`public\` (was Pass 1's flip). Now intra-module cross-package: \`signing/JdbcSigningKeyStore\` reaches for the KEK. Naming and \`limen.security.*\` prefix justify keeping it at the module's front door |
| \`DefaultSecurityConfig\` | Unrelated catch-all filter chain config |

## Other Pass-2 candidates considered and rejected
Per the post-Pass-1 cluster analysis, no other top-level module has a cluster meeting the "3+ types sharing a theme" threshold from \`~/notes/spring-visibility-reduction.md\`:

- \`auth\` (5 internal types) — splits as 2 Jackson mixins + 2 persistent-token types + 1 config; sub-clusters of 2 each, below threshold
- \`oauth2\` (5 internal types) — distinct concerns, no theme
- \`identity\` (3 internal types) — the entire module IS the cluster; sub-package would be redundant
- \`observability\` (3 internal types) — three distinct cross-cutting concerns, no theme

## Doc updates (co-located per the doc-sync rule)
- \`architecture.md\` §4.15 row for \`security\` updated to mention \`security.signing\` and \`security.ratelimit\` sub-packages
- \`architecture.md\` §4.15 "Other sub-packages internal by default" line includes \`security.signing\`
- \`security/package-info.java\` second paragraph rewritten to point at the new sub-package as the impl cluster

## Test plan
- [x] \`./mvnw -B -ntp verify\` passes locally (compile + Error Prone + NullAway + Testcontainers tests + JaCoCo + PMD)
- [x] \`LimenModuleArchitectureTest\` (Spring Modulith verifier) passes — confirms the new sub-package is correctly recognised as internal
- [x] All 3 moved tests still execute cleanly (\`SigningKeyRotatorTest\`, \`JdbcSigningKeyStoreIntegrationTest\`, \`SigningKeyRotationFlowIntegrationTest\`)
- [ ] CI passes on the branch

## Closes Pass 2
This is the only PR Pass 2 generated. Pass 1 + Pass 2 together delivered: 48 visibility flips across all 20 modules + 1 structural extraction where the cluster justified it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)