### PR TITLE
refactor: reduce method visibility in auth/login (Pass 3, PR 2/N)

### DIFF
--- a/src/main/java/com/stucray/limen/auth/login/PostLoginIntents.java
+++ b/src/main/java/com/stucray/limen/auth/login/PostLoginIntents.java
@@ -44,13 +44,13 @@ public final class PostLoginIntents {
      * {@code OttCompletionService.markEmailVerified}, so a successful
      * verify-email login falls through to the next intent in the chain.
      */
-    public static PostLoginIntent emailVerificationRequired() {
+    static PostLoginIntent emailVerificationRequired() {
         return (req, res, principal, scheme) -> principal.user().emailVerified()
             ? null
             : "/t/" + principal.tenantSlug() + "/check-inbox";
     }
 
-    public static PostLoginIntent passwordChangeRequired() {
+    static PostLoginIntent passwordChangeRequired() {
         return (req, res, principal, scheme) -> principal.mustChangePassword()
             ? scheme.changePasswordUrl(principal.tenantSlug())
             : null;
@@ -64,7 +64,7 @@ public final class PostLoginIntents {
      * routing here until {@code TenantPasswordChangeFlow} rotates the context
      * to a plain authenticated principal on successful submission.
      */
-    public static PostLoginIntent passwordChangeAfterReset() {
+    static PostLoginIntent passwordChangeAfterReset() {
         return (req, res, principal, scheme) -> {
             Authentication auth = SecurityContextHolder.getContext().getAuthentication();
             return auth instanceof TenantOttAuthentication tott
@@ -74,7 +74,7 @@ public final class PostLoginIntents {
         };
     }
 
-    public static PostLoginIntent resumeOAuth2Authorize() {
+    static PostLoginIntent resumeOAuth2Authorize() {
         return resumeOAuth2Authorize(new HttpSessionRequestCache());
     }
 
@@ -90,7 +90,7 @@ public final class PostLoginIntents {
         };
     }
 
-    public static PostLoginIntent tenantHome() {
+    static PostLoginIntent tenantHome() {
         return (req, res, principal, scheme) -> scheme.homeUrl(principal.tenantSlug());
     }
 

--- a/src/main/java/com/stucray/limen/auth/login/TenantLogin.java
+++ b/src/main/java/com/stucray/limen/auth/login/TenantLogin.java
@@ -46,7 +46,7 @@ public final class TenantLogin {
     private final List<TenantUrlScheme> allSchemes;
     private final boolean rememberMeEnabled;
 
-    public TenantLogin(
+    TenantLogin(
         AuthenticationManager authenticationManager,
         TenantPersistentTokenBasedRememberMeServices rememberMeServices,
         String rememberMeKey,
@@ -85,21 +85,21 @@ public final class TenantLogin {
         }
     }
 
-    public TenantLogin withIntents(List<PostLoginIntent> newIntents) {
+    TenantLogin withIntents(List<PostLoginIntent> newIntents) {
         return new TenantLogin(authenticationManager, rememberMeServices, rememberMeKey,
             newIntents, allSchemes, rememberMeEnabled);
     }
 
-    public TenantLogin withRememberMe(boolean enabled) {
+    TenantLogin withRememberMe(boolean enabled) {
         return new TenantLogin(authenticationManager, rememberMeServices, rememberMeKey,
             intents, allSchemes, enabled);
     }
 
-    public List<PostLoginIntent> intents() {
+    List<PostLoginIntent> intents() {
         return intents;
     }
 
-    public boolean rememberMeEnabled() {
+    boolean rememberMeEnabled() {
         return rememberMeEnabled;
     }
 
@@ -113,7 +113,7 @@ public final class TenantLogin {
     }
 
     /** Build the form-login filter for {@code scheme}. */
-    public AbstractAuthenticationProcessingFilter filter(TenantUrlScheme scheme) {
+    AbstractAuthenticationProcessingFilter filter(TenantUrlScheme scheme) {
         TenantLoginFilter filter = new TenantLoginFilter(scheme, authenticationManager);
         filter.setSecurityContextRepository(new HttpSessionSecurityContextRepository());
         if (rememberMeEnabled) {

--- a/src/main/java/com/stucray/limen/auth/login/TenantLoginAutoConfig.java
+++ b/src/main/java/com/stucray/limen/auth/login/TenantLoginAutoConfig.java
@@ -24,7 +24,7 @@ import java.util.regex.Pattern;
 public class TenantLoginAutoConfig {
 
     @Bean
-    public TenantUrlScheme oauth2UrlScheme() {
+    TenantUrlScheme oauth2UrlScheme() {
         return new TenantUrlScheme(
             "oauth2",
             HttpMethod.POST,
@@ -37,7 +37,7 @@ public class TenantLoginAutoConfig {
     }
 
     @Bean
-    public TenantUrlScheme managementUrlScheme() {
+    TenantUrlScheme managementUrlScheme() {
         return new TenantUrlScheme(
             "management",
             HttpMethod.POST,
@@ -50,7 +50,7 @@ public class TenantLoginAutoConfig {
     }
 
     @Bean
-    public TenantLogin tenantLogin(
+    TenantLogin tenantLogin(
         AuthenticationManager authenticationManager,
         TenantPersistentTokenBasedRememberMeServices rememberMeServices,
         @Value("${limen.security.remember-me-key}") String rememberMeKey,

--- a/src/main/java/com/stucray/limen/auth/login/TenantPasswordChangeFlow.java
+++ b/src/main/java/com/stucray/limen/auth/login/TenantPasswordChangeFlow.java
@@ -54,7 +54,7 @@ public class TenantPasswordChangeFlow {
     private final HttpSessionRequestCache requestCache = new HttpSessionRequestCache();
     private final SecurityContextRepository securityContextRepository = new HttpSessionSecurityContextRepository();
 
-    public TenantPasswordChangeFlow(
+    TenantPasswordChangeFlow(
         UserRepository userRepository,
         PasswordEncoder passwordEncoder,
         ApplicationEventPublisher eventPublisher,
@@ -67,7 +67,7 @@ public class TenantPasswordChangeFlow {
     }
 
     /** Returns an error message if validation fails, else null. */
-    public @Nullable String validate(String newPassword, String confirmPassword) {
+    @Nullable String validate(String newPassword, String confirmPassword) {
         if (!newPassword.equals(confirmPassword)) return "Passwords do not match";
         if (newPassword.isBlank()) return "Password is required";
         return null;
@@ -80,7 +80,7 @@ public class TenantPasswordChangeFlow {
      * listener (AFTER_COMMIT) has a transaction to hook onto.
      */
     @Transactional
-    public String changeAndRedirect(
+    String changeAndRedirect(
         TenantUserDetails principal,
         TenantUrlScheme scheme,
         String newPassword,

--- a/src/main/java/com/stucray/limen/auth/login/TenantUrlScheme.java
+++ b/src/main/java/com/stucray/limen/auth/login/TenantUrlScheme.java
@@ -27,12 +27,12 @@ public record TenantUrlScheme(
     String changePasswordUrlTemplate
 ) {
     /** Matcher for the login form submission. */
-    public RequestMatcher loginMatcher() {
+    RequestMatcher loginMatcher() {
         return PathPatternRequestMatcher.withDefaults().matcher(loginMethod, loginPathPattern);
     }
 
     /** Extract the slug from a request URI, or {@code null} if the URI does not match this scheme. */
-    public @Nullable String slugFrom(@Nullable HttpServletRequest request) {
+    @Nullable String slugFrom(@Nullable HttpServletRequest request) {
         return request == null ? null : slugFrom(request.getRequestURI());
     }
 
@@ -46,11 +46,11 @@ public record TenantUrlScheme(
         return render(loginUrlTemplate, slug);
     }
 
-    public String homeUrl(String slug) {
+    String homeUrl(String slug) {
         return render(homeUrlTemplate, slug);
     }
 
-    public String changePasswordUrl(String slug) {
+    String changePasswordUrl(String slug) {
         return render(changePasswordUrlTemplate, slug);
     }
 


### PR DESCRIPTION
## Summary
First **per-module real-value** PR after the Pass 3 cosmetic PR (#221). Flips **21 public methods/constructors to package-private** on the 5 still-public types in `auth/login/`, keeping the **4 methods that compile-as-oracle proved are the package's cross-module API**.

Sequencing per `~/notes/spring-visibility-reduction.md` (γ): cosmetic-first, then per-module PRs, biggest module first. `auth` is the biggest at 60 candidates → split by sub-package (login: 25, ott: 25, root: 10). This PR ships the `login` sub-package.

## Methods kept public (the cross-module API of `auth.login`)

| Method | External caller |
|---|---|
| `TenantUrlScheme.slugFrom(String)` | `auth/TenantAccessFilter`, `auth/TenantPersistentTokenBasedRememberMeServices` |
| `TenantUrlScheme.loginUrl(String)` | `auth/TenantAccessFilter` |
| `TenantLogin.applyTo(...)` | `management/auth/ManagementSecurityConfig`, `oauth2/OAuth2LoginSecurityConfig` |
| `TenantLogin.successHandlerFor(...)` | `oauth2/OAuth2LoginSecurityConfig` |

These four form a tight, intent-bearing API. The 21 internal helpers (e.g. `intents()`, `withIntents`, `filter`, `loginMatcher`, `homeUrl`, `changePasswordUrl`, the static `PostLoginIntent` factories, the `@Bean` factories) are now package-private and stop appearing in the IDE's cross-package autocomplete.

## Files touched

| File | Flipped | Kept public |
|---|---|---|
| `TenantLogin.java` | 6 | 2 (`applyTo`, `successHandlerFor`) |
| `TenantUrlScheme.java` | 4 | 2 (`slugFrom(String)`, `loginUrl`) |
| `PostLoginIntents.java` | 5 | 0 — all static factories internal |
| `TenantPasswordChangeFlow.java` | 3 | 0 |
| `TenantLoginAutoConfig.java` | 3 | 0 — `@Bean` methods on `proxyBeanMethods=false` config |
| **Total** | **21** | **4** |

## Spring framework notes

`TenantLoginAutoConfig` is `@Configuration(proxyBeanMethods = false)` — CGLIB proxying is disabled, so package-private `@Bean` methods work without the same-classloader caveat (per `~/notes/spring-visibility-reduction.md`).

The `@PostConstruct verifyOrderUniqueness()` method on `TenantLogin` was already package-private and unchanged.

## Test plan
- [x] `./mvnw -B -ntp verify` passes locally (compile + Error Prone + NullAway + Testcontainers tests + JaCoCo + PMD)
- [x] Spring Modulith verifier (`LimenModuleArchitectureTest`) passes
- [x] Compile-as-oracle audit complete (4 reverted breakers documented above)
- [ ] CI passes on the branch

## Up next (Pass 3, PR 3+/N)
- `auth/ott` (25 candidates, 11 files)
- `auth` root (10 candidates, 6 files)
- `memberships` (23 candidates), `user` (16), `useradmin` (11), then long tail

🤖 Generated with [Claude Code](https://claude.com/claude-code)