### PR TITLE
refactor: reduce method visibility in auth/ott (Pass 3, PR 3/N)

### DIFF
--- a/src/main/java/com/stucray/limen/auth/ott/CheckInboxController.java
+++ b/src/main/java/com/stucray/limen/auth/ott/CheckInboxController.java
@@ -19,12 +19,12 @@ public class CheckInboxController {
 
     private final TenantRepository tenantRepository;
 
-    public CheckInboxController(TenantRepository tenantRepository) {
+    CheckInboxController(TenantRepository tenantRepository) {
         this.tenantRepository = tenantRepository;
     }
 
     @GetMapping("/t/{slug}/check-inbox")
-    public String checkInbox(
+    String checkInbox(
         @PathVariable String slug,
         @RequestParam(required = false) String email,
         @RequestParam(required = false) String flow,

--- a/src/main/java/com/stucray/limen/auth/ott/ForgotPasswordController.java
+++ b/src/main/java/com/stucray/limen/auth/ott/ForgotPasswordController.java
@@ -29,7 +29,7 @@ public class ForgotPasswordController {
     private final TenantRepository tenantRepository;
     private final OttDispatcher ottDispatcher;
 
-    public ForgotPasswordController(
+    ForgotPasswordController(
         TenantRepository tenantRepository,
         OttDispatcher ottDispatcher
     ) {
@@ -38,7 +38,7 @@ public class ForgotPasswordController {
     }
 
     @GetMapping("/t/{slug}/forgot-password")
-    public String form(
+    String form(
         @PathVariable String slug,
         @RequestParam(required = false) String email,
         Model model
@@ -54,7 +54,7 @@ public class ForgotPasswordController {
     }
 
     @PostMapping("/t/{slug}/forgot-password")
-    public String submit(
+    String submit(
         @PathVariable String slug,
         @RequestParam String email
     ) {

--- a/src/main/java/com/stucray/limen/auth/ott/OttCompletionService.java
+++ b/src/main/java/com/stucray/limen/auth/ott/OttCompletionService.java
@@ -36,7 +36,7 @@ public class OttCompletionService {
     private final UserRepository userRepository;
     private final ApplicationEventPublisher eventPublisher;
 
-    public OttCompletionService(
+    OttCompletionService(
         UserRepository userRepository,
         ApplicationEventPublisher eventPublisher
     ) {
@@ -45,7 +45,7 @@ public class OttCompletionService {
     }
 
     @Transactional
-    public void markEmailVerified(Long userId, Long tenantId) {
+    void markEmailVerified(Long userId, Long tenantId) {
         User user = userRepository.findByIdAndTenantId(userId, tenantId)
             .orElseThrow(() -> new IllegalStateException(
                 "User missing for OTT consume: id=" + userId + " tenant=" + tenantId));

--- a/src/main/java/com/stucray/limen/auth/ott/OttDispatcher.java
+++ b/src/main/java/com/stucray/limen/auth/ott/OttDispatcher.java
@@ -57,7 +57,7 @@ public class OttDispatcher {
     private final EmailSender emailSender;
     private final ApplicationEventPublisher eventPublisher;
 
-    public OttDispatcher(
+    OttDispatcher(
         List<OttIntentHandler> handlers,
         TenantAwareOneTimeTokenService tokenService,
         UserRepository userRepository,
@@ -117,7 +117,7 @@ public class OttDispatcher {
      * the attempt without leaking which addresses are real.
      */
     @Transactional
-    public void issue(OttIntent intent, Tenant tenant, String email) {
+    void issue(OttIntent intent, Tenant tenant, String email) {
         OttIntentHandler handler = handlerFor(intent);
         Optional<User> maybeUser = userRepository.findByEmailAndTenantId(email, tenant.id());
         boolean delivered = false;

--- a/src/main/java/com/stucray/limen/auth/ott/OttIntent.java
+++ b/src/main/java/com/stucray/limen/auth/ott/OttIntent.java
@@ -26,11 +26,11 @@ public enum OttIntent {
         this.wire = wire;
     }
 
-    public String wire() {
+    String wire() {
         return wire;
     }
 
-    public static @Nullable OttIntent fromWire(String value) {
+    static @Nullable OttIntent fromWire(String value) {
         for (OttIntent i : values()) {
             if (i.wire.equals(value)) return i;
         }

--- a/src/main/java/com/stucray/limen/auth/ott/OttSubmitController.java
+++ b/src/main/java/com/stucray/limen/auth/ott/OttSubmitController.java
@@ -24,12 +24,12 @@ public class OttSubmitController {
 
     private final TenantRepository tenantRepository;
 
-    public OttSubmitController(TenantRepository tenantRepository) {
+    OttSubmitController(TenantRepository tenantRepository) {
         this.tenantRepository = tenantRepository;
     }
 
     @GetMapping("/t/{slug}/login/ott")
-    public String submitForm(
+    String submitForm(
         @PathVariable String slug,
         @RequestParam(required = false) String token,
         Model model

--- a/src/main/java/com/stucray/limen/auth/ott/ResendVerificationController.java
+++ b/src/main/java/com/stucray/limen/auth/ott/ResendVerificationController.java
@@ -29,7 +29,7 @@ public class ResendVerificationController {
     private final TenantRepository tenantRepository;
     private final OttDispatcher ottDispatcher;
 
-    public ResendVerificationController(
+    ResendVerificationController(
         TenantRepository tenantRepository,
         OttDispatcher ottDispatcher
     ) {
@@ -38,7 +38,7 @@ public class ResendVerificationController {
     }
 
     @GetMapping("/t/{slug}/resend-verification")
-    public String form(
+    String form(
         @PathVariable String slug,
         @RequestParam(required = false) String email,
         Model model
@@ -52,7 +52,7 @@ public class ResendVerificationController {
     }
 
     @PostMapping("/t/{slug}/resend-verification")
-    public String submit(
+    String submit(
         @PathVariable String slug,
         @RequestParam String email
     ) {

--- a/src/main/java/com/stucray/limen/auth/ott/TenantAwareOneTimeTokenService.java
+++ b/src/main/java/com/stucray/limen/auth/ott/TenantAwareOneTimeTokenService.java
@@ -65,12 +65,12 @@ public class TenantAwareOneTimeTokenService implements OneTimeTokenService {
     private final Clock clock;
 
     @Autowired
-    public TenantAwareOneTimeTokenService(JdbcTemplate jdbcTemplate) {
+    TenantAwareOneTimeTokenService(JdbcTemplate jdbcTemplate) {
         this(jdbcTemplate, Clock.systemUTC());
     }
 
     /** Test seam: inject a clock to drive expiry deterministically. */
-    public TenantAwareOneTimeTokenService(JdbcTemplate jdbcTemplate, Clock clock) {
+    TenantAwareOneTimeTokenService(JdbcTemplate jdbcTemplate, Clock clock) {
         this.jdbcTemplate = jdbcTemplate;
         this.clock = clock;
     }

--- a/src/main/java/com/stucray/limen/auth/ott/TenantOttAuthenticationProvider.java
+++ b/src/main/java/com/stucray/limen/auth/ott/TenantOttAuthenticationProvider.java
@@ -53,7 +53,7 @@ public class TenantOttAuthenticationProvider implements AuthenticationProvider {
     private final TenantUserDetailsService userDetailsService;
     private final OttCompletionService completionService;
 
-    public TenantOttAuthenticationProvider(
+    TenantOttAuthenticationProvider(
         OneTimeTokenService tokenService,
         TenantUserDetailsService userDetailsService,
         OttCompletionService completionService

--- a/src/main/java/com/stucray/limen/auth/ott/TenantOttRoutingFilter.java
+++ b/src/main/java/com/stucray/limen/auth/ott/TenantOttRoutingFilter.java
@@ -41,7 +41,7 @@ public class TenantOttRoutingFilter extends OncePerRequestFilter {
 
     private final TenantRepository tenantRepository;
 
-    public TenantOttRoutingFilter(TenantRepository tenantRepository) {
+    TenantOttRoutingFilter(TenantRepository tenantRepository) {
         this.tenantRepository = tenantRepository;
     }
 


### PR DESCRIPTION
## Summary
Second per-module real-value PR (after PR #222 for `auth/login`). Flips **20 public methods/constructors → package-private** across 10 still-public types in `auth/ott/`. Compile-as-oracle kept **5 methods public** as the package's true cross-module API.

## Methods kept public (the cross-module API of `auth.ott`)

| Method | External caller |
|---|---|
| `TenantOttAuthentication(Object, Collection, OttIntent)` | test in `auth.login` package (PostLoginIntentsUnitTest) |
| `TenantOttAuthentication.intent()` | `auth.login.PostLoginIntents`, `auth.login.TenantPasswordChangeFlow` |
| `OttCompletionService.markPasswordResetCompleted` | `auth.login.TenantPasswordChangeFlow` |
| `OttDispatcher.issue(OttIntent, Tenant, User)` | `provisioning.TenantProvisioner` |
| `TenantAwareOneTimeTokenService.generateForIntent(String, OttIntent)` | `provisioning.TenantProvisionerIntegrationTest` (Mockito spy) |

The `String`-overload of `OttDispatcher.issue` and all other dispatch/completion helpers stayed package-private — they are intra-module orchestration.

## Files touched

| File | Flipped | Kept public |
|---|---|---|
| `CheckInboxController.java` | 2 | 0 |
| `ForgotPasswordController.java` | 3 | 0 |
| `ResendVerificationController.java` | 3 | 0 |
| `OttSubmitController.java` | 2 | 0 |
| `OttIntent.java` | 2 | 0 |
| `OttCompletionService.java` | 2 | 1 (`markPasswordResetCompleted`) |
| `OttDispatcher.java` | 2 | 1 (`issue(...,User)`) |
| `TenantAwareOneTimeTokenService.java` | 2 | 1 (`generateForIntent`) |
| `TenantOttAuthentication.java` | 0 | 2 (ctor + `intent()`) |
| `TenantOttAuthenticationProvider.java` | 1 | 0 |
| `TenantOttRoutingFilter.java` | 1 | 0 |
| **Total** | **20** | **5** |

The 4 `@Controller` classes had every handler method (`form`, `submit`, `checkInbox`, etc.) and their constructors flipped — Spring discovers `@RequestMapping`-annotated methods regardless of visibility.

## Durable lesson learned

**Maven's incremental test-compile does NOT recompile cross-package callers when a called class's method visibility narrows.** The first `mvn verify` reported 3 compile errors (in classes whose main-source compile re-ran) but then surfaced two extra `IllegalAccessError` failures at test runtime — surefire ran cached test bytecode against the freshly-compiled main class files. **`mvn clean verify` is the reliable oracle for visibility reductions.** Captured in the commit message; the next per-module PR will start with `clean verify` rather than incremental.

## Test plan
- [x] `./mvnw -B -ntp clean verify` passes locally (compile + Error Prone + NullAway + Testcontainers tests + JaCoCo + PMD)
- [x] Spring Modulith verifier (`LimenModuleArchitectureTest`) passes
- [x] Compile-as-oracle audit complete (5 documented reverts)
- [ ] CI passes on the branch

## Up next
- `auth/` root (10 candidates, 6 files)
- `memberships` (23), `user` (16), `useradmin` (11), then long tail

🤖 Generated with [Claude Code](https://claude.com/claude-code)