### PR TITLE
refactor: reduce method visibility in auth root (Pass 3, PR 4/N)

### DIFF
--- a/src/main/java/com/stucray/limen/auth/TenantAuthProvider.java
+++ b/src/main/java/com/stucray/limen/auth/TenantAuthProvider.java
@@ -29,7 +29,7 @@ public class TenantAuthProvider implements AuthenticationProvider {
     private final Clock clock;
 
     @Autowired
-    public TenantAuthProvider(
+    TenantAuthProvider(
         TenantRepository tenantRepository,
         UserRepository userRepository,
         PasswordEncoder passwordEncoder
@@ -41,7 +41,7 @@ public class TenantAuthProvider implements AuthenticationProvider {
     }
 
     /** Test seam: inject a clock so the lockout-window check is deterministic. */
-    public TenantAuthProvider(
+    TenantAuthProvider(
         TenantRepository tenantRepository,
         UserRepository userRepository,
         PasswordEncoder passwordEncoder,

--- a/src/main/java/com/stucray/limen/auth/TenantAuthToken.java
+++ b/src/main/java/com/stucray/limen/auth/TenantAuthToken.java
@@ -18,7 +18,7 @@ public final class TenantAuthToken extends UsernamePasswordAuthenticationToken {
     }
 
     /** Authenticated — returned by the AuthenticationProvider after successful verification. */
-    public TenantAuthToken(String tenantSlug, TenantUserDetails principal, Collection<? extends GrantedAuthority> authorities) {
+    TenantAuthToken(String tenantSlug, TenantUserDetails principal, Collection<? extends GrantedAuthority> authorities) {
         super(principal, null, authorities);
         this.tenantSlug = tenantSlug;
     }

--- a/src/main/java/com/stucray/limen/auth/TenantPersistentTokenBasedRememberMeServices.java
+++ b/src/main/java/com/stucray/limen/auth/TenantPersistentTokenBasedRememberMeServices.java
@@ -49,7 +49,7 @@ public final class TenantPersistentTokenBasedRememberMeServices extends Abstract
     private final List<TenantUrlScheme> schemes;
     private final SecureRandom random = new SecureRandom();
 
-    public TenantPersistentTokenBasedRememberMeServices(
+    TenantPersistentTokenBasedRememberMeServices(
         String key,
         TenantUserDetailsService userDetailsService,
         TenantPersistentTokenRepository tokenRepository,

--- a/src/main/java/com/stucray/limen/auth/TenantUserDetailsService.java
+++ b/src/main/java/com/stucray/limen/auth/TenantUserDetailsService.java
@@ -26,7 +26,7 @@ public class TenantUserDetailsService implements UserDetailsService {
     private final TenantRepository tenantRepository;
     private final UserRepository userRepository;
 
-    public TenantUserDetailsService(TenantRepository tenantRepository, UserRepository userRepository) {
+    TenantUserDetailsService(TenantRepository tenantRepository, UserRepository userRepository) {
         this.tenantRepository = tenantRepository;
         this.userRepository = userRepository;
     }


### PR DESCRIPTION
## Summary
Third per-module real-value PR; **finishes the auth module** after PR #222 (auth/login) and PR #223 (auth/ott). Flips **5 of 10 candidates** on still-public types in `auth/` root. The other 5 stayed public per compile-as-oracle — they form the cross-(sub-)package API consumed by `auth.login`, `auth.ott`, `auth.lockout`, and `oauth2`.

## Methods kept public (cross-(sub-)package API)

| Method | External caller |
|---|---|
| `TenantAccessFilter(List<TenantUrlScheme>)` (ctor) | `auth.login.TenantLogin` |
| `TenantAuthToken(String, String, String)` (unauthenticated ctor) | `auth.login.TenantLogin` |
| `TenantAuthToken.getTenantSlug()` | `auth.lockout.LoginAttemptTracker` |
| `TenantUserDetailsService.loadByEmailAndSlug` | `auth.ott.TenantOttAuthenticationProvider` |
| `SasJsonMapperFactory.create()` | `oauth2.SasConfig` |

## Files touched (5 net flips)

| File | Flipped | Kept public |
|---|---|---|
| `TenantAuthToken.java` | 1 | 2 (the unauth ctor + `getTenantSlug`) |
| `TenantAuthProvider.java` | 2 | 0 |
| `TenantUserDetailsService.java` | 1 | 1 (`loadByEmailAndSlug`) |
| `TenantPersistentTokenBasedRememberMeServices.java` | 1 | 0 |
| `TenantAccessFilter.java` | 0 | 1 (ctor) |
| `SasJsonMapperFactory.java` | 0 | 1 (`create`) |
| **Total** | **5** | **5** |

This module's high-public-retention ratio (5/10) reflects what `auth/` root is: the cross-(sub-)package facade for the whole auth module. Pass 3's value here is small but documents the boundary.

## Test plan
- [x] `./mvnw -B -ntp clean verify` passes locally (compile + Error Prone + NullAway + Testcontainers tests + JaCoCo + PMD)
- [x] Spring Modulith verifier passes
- [x] Compile-as-oracle audit complete (5 documented reverts)
- [ ] CI passes on the branch

## Closes the auth module for Pass 3
Total auth flips landed across PRs #222 + #223 + this PR: **46 net flips** (21 + 20 + 5). Of the original 60 candidates, **14 stayed public** as the auth module's true cross-package API.

## Up next
- `memberships` (23 candidates), `user` (16), `useradmin` (11), then long tail

🤖 Generated with [Claude Code](https://claude.com/claude-code)