### PR TITLE
refactor: reduce method visibility in memberships (Pass 3, PR 5/N)

### DIFF
--- a/src/main/java/com/stucray/limen/memberships/ApplicationMembership.java
+++ b/src/main/java/com/stucray/limen/memberships/ApplicationMembership.java
@@ -18,7 +18,7 @@ public record ApplicationMembership(
     @MappedCollection(idColumn = "application_membership_id")
     Set<ApplicationMembershipRole> roles
 ) {
-    public ApplicationMembership withRoles(Set<Long> roleIds) {
+    ApplicationMembership withRoles(Set<Long> roleIds) {
         Set<ApplicationMembershipRole> assignments = new LinkedHashSet<>();
         for (Long roleId : roleIds) {
             assignments.add(new ApplicationMembershipRole(roleId));

--- a/src/main/java/com/stucray/limen/memberships/ApplicationMembershipService.java
+++ b/src/main/java/com/stucray/limen/memberships/ApplicationMembershipService.java
@@ -30,7 +30,7 @@ public class ApplicationMembershipService {
     private final UserRepository userRepository;
     private final RoleResolver roleResolver;
 
-    public ApplicationMembershipService(
+    ApplicationMembershipService(
         ApplicationMembershipRepository membershipRepository,
         ApplicationLookup applicationLookup,
         UserRepository userRepository,
@@ -42,19 +42,19 @@ public class ApplicationMembershipService {
         this.roleResolver = roleResolver;
     }
 
-    public List<ApplicationMembership> listMemberships(Long applicationId, Long tenantId) {
+    List<ApplicationMembership> listMemberships(Long applicationId, Long tenantId) {
         applicationLookup.require(applicationId, tenantId);
         return membershipRepository.findAllByApplicationId(applicationId);
     }
 
-    public ApplicationMembership getMembership(Long membershipId, Long applicationId, Long tenantId) {
+    ApplicationMembership getMembership(Long membershipId, Long applicationId, Long tenantId) {
         applicationLookup.require(applicationId, tenantId);
         return membershipRepository.findByIdAndApplicationId(membershipId, applicationId)
             .orElseThrow(() -> new IllegalArgumentException("Membership not found"));
     }
 
     @SuppressWarnings("NullAway") // Spring Data convention: null id on insert; populated on save
-    public ApplicationMembership grant(Long applicationId, Long tenantId, Long userId, Long grantedByUserId) {
+    ApplicationMembership grant(Long applicationId, Long tenantId, Long userId, Long grantedByUserId) {
         Application app = applicationLookup.require(applicationId, tenantId);
         User user = userRepository.findByIdAndTenantId(userId, tenantId)
             .orElseThrow(() -> new IllegalArgumentException("User not found in this tenant"));
@@ -72,14 +72,14 @@ public class ApplicationMembershipService {
         ));
     }
 
-    public void updateRoles(Long membershipId, Long applicationId, Long tenantId, Set<Long> roleIds) {
+    void updateRoles(Long membershipId, Long applicationId, Long tenantId, Set<Long> roleIds) {
         ApplicationMembership membership = getMembership(membershipId, applicationId, tenantId);
         Set<Long> requested = roleIds == null ? Set.of() : new LinkedHashSet<>(roleIds);
         roleResolver.requireRolesInApplication(applicationId, requested);
         membershipRepository.save(membership.withRoles(requested));
     }
 
-    public void revoke(Long membershipId, Long applicationId, Long tenantId) {
+    void revoke(Long membershipId, Long applicationId, Long tenantId) {
         ApplicationMembership membership = getMembership(membershipId, applicationId, tenantId);
         membershipRepository.delete(membership);
     }
@@ -88,7 +88,7 @@ public class ApplicationMembershipService {
      * Users in the tenant who do not yet have a Membership for this Application.
      * Used to populate the "Add member" form's user picker.
      */
-    public List<User> listGrantableUsers(Long applicationId, Long tenantId) {
+    List<User> listGrantableUsers(Long applicationId, Long tenantId) {
         applicationLookup.require(applicationId, tenantId);
         List<User> all = userRepository.findAllByTenantId(tenantId);
         List<User> grantable = new java.util.ArrayList<>();

--- a/src/main/java/com/stucray/limen/memberships/ClientMembership.java
+++ b/src/main/java/com/stucray/limen/memberships/ClientMembership.java
@@ -19,7 +19,7 @@ public record ClientMembership(
     @MappedCollection(idColumn = "client_membership_id")
     Set<ClientMembershipRole> roles
 ) {
-    public ClientMembership withRoles(Set<Long> roleIds) {
+    ClientMembership withRoles(Set<Long> roleIds) {
         Set<ClientMembershipRole> assignments = new LinkedHashSet<>();
         for (Long roleId : roleIds) {
             assignments.add(new ClientMembershipRole(roleId));

--- a/src/main/java/com/stucray/limen/memberships/ClientMembershipQuery.java
+++ b/src/main/java/com/stucray/limen/memberships/ClientMembershipQuery.java
@@ -20,7 +20,7 @@ public class ClientMembershipQuery {
 
     private final JdbcTemplate jdbcTemplate;
 
-    public ClientMembershipQuery(JdbcTemplate jdbcTemplate) {
+    ClientMembershipQuery(JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
     }
 

--- a/src/main/java/com/stucray/limen/memberships/ClientMembershipService.java
+++ b/src/main/java/com/stucray/limen/memberships/ClientMembershipService.java
@@ -41,7 +41,7 @@ public class ClientMembershipService {
     private final UserRepository userRepository;
     private final RoleResolver roleResolver;
 
-    public ClientMembershipService(
+    ClientMembershipService(
         ClientMembershipRepository membershipRepository,
         ApplicationMembershipRepository applicationMembershipRepository,
         TenantClientRepository tenantClientRepository,
@@ -55,19 +55,19 @@ public class ClientMembershipService {
         this.roleResolver = roleResolver;
     }
 
-    public List<ClientMembership> listMemberships(String registeredClientId, Long applicationId, Long tenantId) {
+    List<ClientMembership> listMemberships(String registeredClientId, Long applicationId, Long tenantId) {
         TenantClient client = requireClient(registeredClientId, applicationId, tenantId);
         return membershipRepository.findAllByClientMetadataId(client.id());
     }
 
-    public ClientMembership getMembership(Long membershipId, String registeredClientId, Long applicationId, Long tenantId) {
+    ClientMembership getMembership(Long membershipId, String registeredClientId, Long applicationId, Long tenantId) {
         TenantClient client = requireClient(registeredClientId, applicationId, tenantId);
         return membershipRepository.findByIdAndClientMetadataId(membershipId, client.id())
             .orElseThrow(() -> new IllegalArgumentException("Client membership not found"));
     }
 
     @SuppressWarnings("NullAway") // Spring Data convention: null id on insert; populated on save
-    public ClientMembership grant(
+    ClientMembership grant(
         String registeredClientId, Long applicationId, Long tenantId,
         Long userId, Long grantedByUserId
     ) {
@@ -91,7 +91,7 @@ public class ClientMembershipService {
         ));
     }
 
-    public void updateRoles(
+    void updateRoles(
         Long membershipId, String registeredClientId, Long applicationId, Long tenantId,
         Set<Long> roleIds
     ) {
@@ -101,7 +101,7 @@ public class ClientMembershipService {
         membershipRepository.save(membership.withRoles(requested));
     }
 
-    public void revoke(Long membershipId, String registeredClientId, Long applicationId, Long tenantId) {
+    void revoke(Long membershipId, String registeredClientId, Long applicationId, Long tenantId) {
         ClientMembership membership = getMembership(membershipId, registeredClientId, applicationId, tenantId);
         membershipRepository.delete(membership);
     }
@@ -111,7 +111,7 @@ public class ClientMembershipService {
      * Client's parent App but do not yet have a Client Membership for this
      * specific Client. Drives the "Add Client Member" form's user picker.
      */
-    public List<User> listGrantableUsers(String registeredClientId, Long applicationId, Long tenantId) {
+    List<User> listGrantableUsers(String registeredClientId, Long applicationId, Long tenantId) {
         TenantClient client = requireClient(registeredClientId, applicationId, tenantId);
         List<ApplicationMembership> appMembers = applicationMembershipRepository.findAllByApplicationId(applicationId);
         List<User> grantable = new ArrayList<>();

--- a/src/main/java/com/stucray/limen/memberships/UserMembershipPortfolioQuery.java
+++ b/src/main/java/com/stucray/limen/memberships/UserMembershipPortfolioQuery.java
@@ -24,7 +24,7 @@ public class UserMembershipPortfolioQuery {
 
     private final JdbcTemplate jdbcTemplate;
 
-    public UserMembershipPortfolioQuery(JdbcTemplate jdbcTemplate) {
+    UserMembershipPortfolioQuery(JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
     }
 


### PR DESCRIPTION
## Summary
Fourth per-module real-value PR. Flips **18 of 23 candidates → package-private** on 6 still-public types in `memberships/`. Compile-as-oracle plus a new **Thymeleaf-as-oracle** check kept 5 methods public.

## Methods kept public

**Cross-module API (3 — compile-time):**

| Method | External caller |
|---|---|
| `ClientMembershipQuery.rolesFor` | `oauth2.SasConfig` |
| `ClientMembershipQuery.hasMembership` | `oauth2.MembershipGateFilter` |
| `UserMembershipPortfolioQuery.portfolioFor` | `useradmin.UserManagementController` |

**Thymeleaf SpringEL-reflected accessors (2 — runtime):**

| Method | Template binding |
|---|---|
| `ApplicationMembership.roleIds()` | `manage/applications/members/list.html:36` `${m.roleIds()}` |
| `ClientMembership.roleIds()` | `manage/clients/members/list.html:38` `${m.roleIds()}` |

## ⚠️ New durable lesson

**Thymeleaf SpringEL property access reflectively invokes methods from outside the template-renderer's package.** Any record/class accessor referenced in a template (e.g. `${m.roleIds()}`) must remain `public` — package-private fails at runtime with `TemplateProcessingException`. Same family as the `CreateClientForm` JavaBean form-binding gotcha from the cosmetic PR #221, but on the **read** path.

**Future per-module PR audit pattern:** before flipping accessors on a record/class, grep templates for SpEL expressions referencing the type:

```
grep -rn "\${[a-z]\+\.\(method1\|method2\|...\)}" src/main/resources/templates/
```

The compile-as-oracle policy stays — clean verify still catches the static breakers — but `mvn clean verify` runs all integration tests (including UI journeys), which exercise the templates. So the existing protocol already covers this; just be ready to interpret a `TemplateProcessingException` as "this method needs to stay public."

## Files touched (18 net flips)

| File | Flipped | Kept public |
|---|---|---|
| `ApplicationMembershipService.java` | 7 | 0 |
| `ClientMembershipService.java` | 7 | 0 |
| `ApplicationMembership.java` | 1 (`withRoles`) | 1 (`roleIds`) |
| `ClientMembership.java` | 1 (`withRoles`) | 1 (`roleIds`) |
| `ClientMembershipQuery.java` | 1 (ctor) | 2 (`rolesFor`, `hasMembership`) |
| `UserMembershipPortfolioQuery.java` | 1 (ctor) | 1 (`portfolioFor`) |
| **Total** | **18** | **5** |

The two `*Service` classes flipped completely (14 methods) — they're consumed only by their same-package controllers (`MembersController`, `ClientMembersController`), which were already package-private and got swept by the cosmetic PR #221.

## Test plan
- [x] `./mvnw -B -ntp clean verify` passes locally — full Testcontainers suite includes `MembersControllerIntegrationTest` and `ClientMembersControllerIntegrationTest` which exercise the affected templates
- [x] Spring Modulith verifier passes
- [ ] CI passes on the branch

## Up next
- `user` (16 candidates), `useradmin` (11), `roles` (10), `applications` (10), then long tail

🤖 Generated with [Claude Code](https://claude.com/claude-code)