### PR TITLE
refactor: reduce method visibility in useradmin (Pass 3, PR 6/N)

### DIFF
--- a/src/main/java/com/stucray/limen/useradmin/UserAdministrationService.java
+++ b/src/main/java/com/stucray/limen/useradmin/UserAdministrationService.java
@@ -46,7 +46,7 @@ public class UserAdministrationService {
     private final PasswordEncoder passwordEncoder;
     private final ApplicationEventPublisher eventPublisher;
 
-    public UserAdministrationService(
+    UserAdministrationService(
         UserRepository userRepository,
         PasswordEncoder passwordEncoder,
         ApplicationEventPublisher eventPublisher
@@ -56,11 +56,11 @@ public class UserAdministrationService {
         this.eventPublisher = eventPublisher;
     }
 
-    public List<User> listUsers(Long tenantId) {
+    List<User> listUsers(Long tenantId) {
         return userRepository.findAllByTenantId(tenantId);
     }
 
-    public User getUser(Long userId, Long tenantId) {
+    User getUser(Long userId, Long tenantId) {
         return userRepository.findById(userId)
             .filter(u -> u.tenantId().equals(tenantId))
             .orElseThrow(() -> new UserAdminException.UserNotInTenant("lookup"));
@@ -81,7 +81,7 @@ public class UserAdministrationService {
     }
 
     @Transactional
-    public void enable(Long userId, Long tenantId, Long actorUserId) {
+    void enable(Long userId, Long tenantId, Long actorUserId) {
         User user = getUser(userId, tenantId);
         if (user.enabled()) return; // idempotent
         userRepository.save(user.withEnabled(true));
@@ -89,7 +89,7 @@ public class UserAdministrationService {
     }
 
     @Transactional
-    public void disable(Long userId, Long tenantId, Long actorUserId) {
+    void disable(Long userId, Long tenantId, Long actorUserId) {
         User user = getUser(userId, tenantId);
         if (Objects.equals(actorUserId, userId)) {
             throw new UserAdminException.CannotTargetSelf("disable",
@@ -105,7 +105,7 @@ public class UserAdministrationService {
     }
 
     @Transactional
-    public void deleteUser(Long userId, Long tenantId, Long actorUserId) {
+    void deleteUser(Long userId, Long tenantId, Long actorUserId) {
         User user = getUser(userId, tenantId);
         if (Objects.equals(actorUserId, userId)) {
             throw new UserAdminException.CannotTargetSelf("delete",
@@ -120,7 +120,7 @@ public class UserAdministrationService {
     }
 
     @Transactional
-    public void grantTenantOwnership(Long userId, Long tenantId, Long actorUserId) {
+    void grantTenantOwnership(Long userId, Long tenantId, Long actorUserId) {
         User user = getUser(userId, tenantId);
         if (!user.enabled()) {
             throw new UserAdminException.TargetNotEligible("grantOwner",
@@ -136,7 +136,7 @@ public class UserAdministrationService {
     }
 
     @Transactional
-    public void revokeTenantOwnership(Long userId, Long tenantId, Long actorUserId) {
+    void revokeTenantOwnership(Long userId, Long tenantId, Long actorUserId) {
         User user = getUser(userId, tenantId);
         if (Objects.equals(actorUserId, userId)) {
             throw new UserAdminException.CannotTargetSelf("revokeOwner",
@@ -176,7 +176,7 @@ public class UserAdministrationService {
     }
 
     @Transactional
-    public void unlockAccount(Long userId, Long tenantId, Long actorUserId) {
+    void unlockAccount(Long userId, Long tenantId, Long actorUserId) {
         User user = getUser(userId, tenantId);
         if (user.lockedUntil() == null && user.failedLoginAttempts() == 0) return; // idempotent
         userRepository.save(user.withFailedLoginAttempts(0).withLockedUntil(null));


### PR DESCRIPTION
## Summary
Fifth per-module real-value PR. Flips **9 of 11 candidates → package-private** on `UserAdministrationService.java`. Two methods stayed public per compile-as-oracle (cross-package test consumers).

## Methods kept public

| Method | External consumer |
|---|---|
| `createUser` | `user.EmailUniquenessIntegrationTest` |
| `resetPassword` | `audit.AuditEventEmitIntegrationTest` |

The other 9 service methods (`listUsers`, `getUser`, `enable`, `disable`, `deleteUser`, `grantTenantOwnership`, `revokeTenantOwnership`, `unlockAccount`, plus the constructor) are consumed only via the same-package `UserManagementController` (already package-private from cosmetic PR #221) and same-package tests.

## ⚠️ Note: `user` module skipped (no PR)

A parallel audit of `user/` (User.java + TenantUserDetails.java — 16 candidates) found **zero flippable candidates**:

- User constructor + all 7 `with*` mutators (`withPasswordHash`, `withEnabled`, `withMustChangePassword`, `withTenantOwner`, `withEmailVerified`, `withFailedLoginAttempts`, `withLockedUntil`) — called from `useradmin`, `identity`, `provisioning`
- All 8 TenantUserDetails accessors (constructor + `tenantId`, `userId`, `tenantSlug`, `displayEmail`, `mustChangePassword`, `tenant`, `user`) — called from controllers across many modules

Both types are pure cross-(sub-)package API. **No `user` PR opened — branch deleted, audit-only outcome documented in commit message + project memory.**

Doctrine for future passes: when 100% of a module's candidates are external API, skip the PR — the audit log + memory capture is sufficient. Don't ship a paperwork-only "0 flips" diff.

## Test plan
- [x] `./mvnw -B -ntp clean verify` passes locally (compile + Error Prone + NullAway + Testcontainers tests + JaCoCo + PMD)
- [x] Spring Modulith verifier passes
- [x] Compile-as-oracle audit complete (2 documented test-driven reverts)
- [ ] CI passes on the branch

## Up next
- `roles` (10 candidates), `applications` (10), `oauth2` (9), `tenant` (8), `clients` (8), `provisioning` (8), then small tail (audit/signup/security/email = 9 total — could bundle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)