### PR TITLE
refactor: reduce method visibility in roles (Pass 3, PR 7/N)

### DIFF
--- a/src/main/java/com/stucray/limen/roles/Role.java
+++ b/src/main/java/com/stucray/limen/roles/Role.java
@@ -13,11 +13,11 @@ public record Role(
     String description,
     LocalDateTime createdAt
 ) {
-    public Role withName(String newName) {
+    Role withName(String newName) {
         return new Role(id, applicationId, newName, description, createdAt);
     }
 
-    public Role withDescription(String newDescription) {
+    Role withDescription(String newDescription) {
         return new Role(id, applicationId, name, newDescription, createdAt);
     }
 }

--- a/src/main/java/com/stucray/limen/roles/RoleManagementService.java
+++ b/src/main/java/com/stucray/limen/roles/RoleManagementService.java
@@ -18,7 +18,7 @@ public class RoleManagementService {
     private final RoleRepository roleRepository;
     private final ApplicationLookup applicationLookup;
 
-    public RoleManagementService(RoleRepository roleRepository, ApplicationLookup applicationLookup) {
+    RoleManagementService(RoleRepository roleRepository, ApplicationLookup applicationLookup) {
         this.roleRepository = roleRepository;
         this.applicationLookup = applicationLookup;
     }
@@ -28,14 +28,14 @@ public class RoleManagementService {
         return roleRepository.findAllByApplicationId(applicationId);
     }
 
-    public Role getRole(Long roleId, Long applicationId, Long tenantId) {
+    Role getRole(Long roleId, Long applicationId, Long tenantId) {
         applicationLookup.require(applicationId, tenantId);
         return roleRepository.findByIdAndApplicationId(roleId, applicationId)
             .orElseThrow(() -> new IllegalArgumentException("Role not found"));
     }
 
     @SuppressWarnings("NullAway") // Spring Data convention: null id on insert; populated on save
-    public Role createRole(Long applicationId, Long tenantId, String name, String description) {
+    Role createRole(Long applicationId, Long tenantId, String name, String description) {
         applicationLookup.require(applicationId, tenantId);
         if (roleRepository.existsByNameAndApplicationId(name, applicationId)) {
             throw new IllegalArgumentException("A role named '" + name + "' already exists in this application");
@@ -45,7 +45,7 @@ public class RoleManagementService {
         );
     }
 
-    public void updateRole(Long roleId, Long applicationId, Long tenantId, String name, String description) {
+    void updateRole(Long roleId, Long applicationId, Long tenantId, String name, String description) {
         Role role = getRole(roleId, applicationId, tenantId);
         if (!role.name().equals(name) && roleRepository.existsByNameAndApplicationId(name, applicationId)) {
             throw new IllegalArgumentException("A role named '" + name + "' already exists in this application");
@@ -53,7 +53,7 @@ public class RoleManagementService {
         roleRepository.save(role.withName(name).withDescription(description));
     }
 
-    public void deleteRole(Long roleId, Long applicationId, Long tenantId) {
+    void deleteRole(Long roleId, Long applicationId, Long tenantId) {
         Role role = getRole(roleId, applicationId, tenantId);
         roleRepository.delete(role);
     }

--- a/src/main/java/com/stucray/limen/roles/RoleResolver.java
+++ b/src/main/java/com/stucray/limen/roles/RoleResolver.java
@@ -21,7 +21,7 @@ public class RoleResolver {
 
     private final RoleRepository roleRepository;
 
-    public RoleResolver(RoleRepository roleRepository) {
+    RoleResolver(RoleRepository roleRepository) {
         this.roleRepository = roleRepository;
     }
 

--- a/src/main/java/com/stucray/limen/roles/RolesController.java
+++ b/src/main/java/com/stucray/limen/roles/RolesController.java
@@ -19,13 +19,13 @@ class RolesController {
     private final RoleManagementService roleManagementService;
     private final ApplicationService applicationService;
 
-    public RolesController(RoleManagementService roleManagementService, ApplicationService applicationService) {
+    RolesController(RoleManagementService roleManagementService, ApplicationService applicationService) {
         this.roleManagementService = roleManagementService;
         this.applicationService = applicationService;
     }
 
     @GetMapping
-    public String list(
+    String list(
         @PathVariable String slug,
         @PathVariable Long appId,
         @AuthenticationPrincipal TenantUserDetails principal,
@@ -39,7 +39,7 @@ class RolesController {
     }
 
     @GetMapping("/new")
-    public String newForm(
+    String newForm(
         @PathVariable String slug,
         @PathVariable Long appId,
         @AuthenticationPrincipal TenantUserDetails principal,
@@ -52,7 +52,7 @@ class RolesController {
     }
 
     @PostMapping
-    public String create(
+    String create(
         @PathVariable String slug,
         @PathVariable Long appId,
         @AuthenticationPrincipal TenantUserDetails principal,
@@ -75,7 +75,7 @@ class RolesController {
     }
 
     @GetMapping("/{roleId}/edit")
-    public String editForm(
+    String editForm(
         @PathVariable String slug,
         @PathVariable Long appId,
         @PathVariable Long roleId,
@@ -90,7 +90,7 @@ class RolesController {
     }
 
     @PostMapping("/{roleId}/edit")
-    public String update(
+    String update(
         @PathVariable String slug,
         @PathVariable Long appId,
         @PathVariable Long roleId,
@@ -113,7 +113,7 @@ class RolesController {
     }
 
     @PostMapping("/{roleId}/delete")
-    public String delete(
+    String delete(
         @PathVariable String slug,
         @PathVariable Long appId,
         @PathVariable Long roleId,


### PR DESCRIPTION
## Summary

Method-level visibility reduction in the \`roles\` module — net **15 of 17** candidates flipped from public to package-private.

| File | Flipped | Kept public |
|---|---|---|
| \`Role\` | 2 | — |
| \`RoleManagementService\` | 5 | \`listRoles\` |
| \`RoleResolver\` | 1 | \`requireRolesInApplication\` |
| \`RolesController\` | 7 | — |
| **Total** | **15** | **2** |

## Why two stayed public

Both proven by \`mvn clean verify\` (compile-as-oracle):

- **\`RoleManagementService.listRoles\`** — called from \`memberships.MembersController\` and \`memberships.ClientMembersController\` (3 call sites). Memberships UI lists available roles when assigning them.
- **\`RoleResolver.requireRolesInApplication\`** — called from \`memberships.ApplicationMembershipService\` and \`memberships.ClientMembershipService\` validators. Membership writes resolve role IDs at the boundary.

\`roles\` is the domain definition; \`memberships\` is the only legitimate cross-package consumer.

## RolesController note

\`RolesController\` is \`@Controller\`, already package-private from Pass 1. Flipping its ctor + 6 \`@RequestMapping\` methods to package-private works — Spring's \`RequestMappingHandlerMapping\` uses \`setAccessible(true)\`. UI journey tests confirm no runtime breakage.

## Verification

\`mvn clean verify\` green: compile + test + Error Prone + NullAway + JaCoCo + PMD all pass.

## Test plan
- [x] \`mvn -B -ntp clean verify\` (NOT \`mvn verify\` — incremental compile masks visibility narrowings)
- [x] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)