### PR TITLE
refactor: reduce method visibility in applications (Pass 3, PR 8/N)

### DIFF
--- a/src/main/java/com/stucray/limen/applications/Application.java
+++ b/src/main/java/com/stucray/limen/applications/Application.java
@@ -13,11 +13,11 @@ public record Application(
     String description,
     LocalDateTime createdAt
 ) {
-    public Application withName(String newName) {
+    Application withName(String newName) {
         return new Application(id, tenantId, newName, description, createdAt);
     }
 
-    public Application withDescription(String newDescription) {
+    Application withDescription(String newDescription) {
         return new Application(id, tenantId, name, newDescription, createdAt);
     }
 }

--- a/src/main/java/com/stucray/limen/applications/ApplicationController.java
+++ b/src/main/java/com/stucray/limen/applications/ApplicationController.java
@@ -12,12 +12,12 @@ class ApplicationController {
 
     private final ApplicationService applicationService;
 
-    public ApplicationController(ApplicationService applicationService) {
+    ApplicationController(ApplicationService applicationService) {
         this.applicationService = applicationService;
     }
 
     @GetMapping
-    public String list(
+    String list(
         @PathVariable String slug,
         @AuthenticationPrincipal TenantUserDetails principal,
         Model model
@@ -28,13 +28,13 @@ class ApplicationController {
     }
 
     @GetMapping("/new")
-    public String newForm(@PathVariable String slug, Model model) {
+    String newForm(@PathVariable String slug, Model model) {
         model.addAttribute("slug", slug);
         return "manage/applications/new";
     }
 
     @PostMapping
-    public String create(
+    String create(
         @PathVariable String slug,
         @AuthenticationPrincipal TenantUserDetails principal,
         @RequestParam String name,
@@ -54,7 +54,7 @@ class ApplicationController {
     }
 
     @GetMapping("/{appId}/edit")
-    public String editForm(
+    String editForm(
         @PathVariable String slug,
         @PathVariable Long appId,
         @AuthenticationPrincipal TenantUserDetails principal,
@@ -66,7 +66,7 @@ class ApplicationController {
     }
 
     @PostMapping("/{appId}/edit")
-    public String update(
+    String update(
         @PathVariable String slug,
         @PathVariable Long appId,
         @AuthenticationPrincipal TenantUserDetails principal,
@@ -78,7 +78,7 @@ class ApplicationController {
     }
 
     @PostMapping("/{appId}/delete")
-    public String delete(
+    String delete(
         @PathVariable String slug,
         @PathVariable Long appId,
         @AuthenticationPrincipal TenantUserDetails principal,

--- a/src/main/java/com/stucray/limen/applications/ApplicationLookup.java
+++ b/src/main/java/com/stucray/limen/applications/ApplicationLookup.java
@@ -16,7 +16,7 @@ public class ApplicationLookup {
 
     private final ApplicationRepository applicationRepository;
 
-    public ApplicationLookup(ApplicationRepository applicationRepository) {
+    ApplicationLookup(ApplicationRepository applicationRepository) {
         this.applicationRepository = applicationRepository;
     }
 

--- a/src/main/java/com/stucray/limen/applications/ApplicationService.java
+++ b/src/main/java/com/stucray/limen/applications/ApplicationService.java
@@ -12,12 +12,12 @@ public class ApplicationService {
     private final ApplicationRepository applicationRepository;
     private final JdbcTemplate jdbcTemplate;
 
-    public ApplicationService(ApplicationRepository applicationRepository, JdbcTemplate jdbcTemplate) {
+    ApplicationService(ApplicationRepository applicationRepository, JdbcTemplate jdbcTemplate) {
         this.applicationRepository = applicationRepository;
         this.jdbcTemplate = jdbcTemplate;
     }
 
-    public List<Application> listApplications(Long tenantId) {
+    List<Application> listApplications(Long tenantId) {
         return applicationRepository.findAllByTenantId(tenantId);
     }
 
@@ -36,12 +36,12 @@ public class ApplicationService {
         );
     }
 
-    public void updateApplication(Long appId, Long tenantId, String name, String description) {
+    void updateApplication(Long appId, Long tenantId, String name, String description) {
         Application app = getApplication(appId, tenantId);
         applicationRepository.save(app.withName(name).withDescription(description));
     }
 
-    public void deleteApplication(Long appId, Long tenantId) {
+    void deleteApplication(Long appId, Long tenantId) {
         Application app = getApplication(appId, tenantId);
         Integer clientCount = jdbcTemplate.queryForObject(
             "SELECT COUNT(*) FROM oauth2_registered_client WHERE application_id = ?",


### PR DESCRIPTION
## Summary

Method-level visibility reduction in the \`applications\` module — net **14 of 17** candidates flipped from public to package-private.

| File | Flipped | Kept public |
|---|---|---|
| \`Application\` | 2 | — |
| \`ApplicationController\` | 7 | — |
| \`ApplicationLookup\` | 1 | \`require\` |
| \`ApplicationService\` | 4 | \`getApplication\`, \`createApplication\` |
| **Total** | **14** | **3** |

## Why three stayed public

All proven by \`mvn clean verify\` (compile-as-oracle):

- **\`ApplicationService.getApplication\`** — the application-id resolver for the management UI; used by 4 cross-package controllers: \`clients.ClientManagementController\`, \`memberships.MembersController\`, \`memberships.ClientMembersController\`, \`roles.RolesController\` (~12 call sites).
- **\`ApplicationService.createApplication\`** — called from cross-package integration tests (\`audit.AuditEventEmitIntegrationTest\`, \`ui.support.TestTenantFactory\`). Same precedent as \`useradmin\`'s \`createUser\`/\`resetPassword\` in PR #226.
- **\`ApplicationLookup.require\`** — boundary validator called from \`memberships.ApplicationMembershipService\` and \`roles.RoleManagementService\`.

## ApplicationController note

\`ApplicationController\` is \`@Controller\`, already package-private from Pass 1. Flipping its ctor + 6 \`@RequestMapping\` methods to package-private works — Spring's \`RequestMappingHandlerMapping\` uses \`setAccessible(true)\`.

## Verification

\`mvn clean verify\` green: compile + test + Error Prone + NullAway + JaCoCo + PMD all pass.

## Test plan
- [x] \`mvn -B -ntp clean verify\`
- [x] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)