### PR TITLE
refactor: reduce method visibility in oauth2 (Pass 3, PR 9/N)

### DIFF
--- a/src/main/java/com/stucray/limen/oauth2/MembershipGateFilter.java
+++ b/src/main/java/com/stucray/limen/oauth2/MembershipGateFilter.java
@@ -62,7 +62,7 @@ public final class MembershipGateFilter extends OncePerRequestFilter {
     private final ClientMembershipQuery clientMembershipQuery;
     private final RedirectStrategy redirectStrategy = new DefaultRedirectStrategy();
 
-    public MembershipGateFilter(
+    MembershipGateFilter(
         RegisteredClientRepository registeredClientRepository,
         ClientMembershipQuery clientMembershipQuery
     ) {

--- a/src/main/java/com/stucray/limen/oauth2/OAuth2LoginSecurityConfig.java
+++ b/src/main/java/com/stucray/limen/oauth2/OAuth2LoginSecurityConfig.java
@@ -46,7 +46,7 @@ class OAuth2LoginSecurityConfig {
     private final OneTimeTokenGenerationSuccessHandler ottGenerationSuccessHandler;
     private final TenantOttAuthenticationProvider ottAuthenticationProvider;
 
-    public OAuth2LoginSecurityConfig(
+    OAuth2LoginSecurityConfig(
         TenantLogin login,
         @Qualifier("oauth2UrlScheme") TenantUrlScheme oauth2UrlScheme,
         TenantAwareOneTimeTokenService oneTimeTokenService,
@@ -61,7 +61,7 @@ class OAuth2LoginSecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain oauth2LoginFilterChain(HttpSecurity http) throws Exception {
+    SecurityFilterChain oauth2LoginFilterChain(HttpSecurity http) throws Exception {
         HttpSessionRequestCache requestCache = new HttpSessionRequestCache();
         Pattern logoutSlugPattern = Pattern.compile(".*/t/([^/]+)/logout$");
 

--- a/src/main/java/com/stucray/limen/oauth2/OAuth2TenantLoginController.java
+++ b/src/main/java/com/stucray/limen/oauth2/OAuth2TenantLoginController.java
@@ -12,12 +12,12 @@ class OAuth2TenantLoginController {
 
     private final TenantRepository tenantRepository;
 
-    public OAuth2TenantLoginController(TenantRepository tenantRepository) {
+    OAuth2TenantLoginController(TenantRepository tenantRepository) {
         this.tenantRepository = tenantRepository;
     }
 
     @GetMapping("/t/{slug}/login")
-    public String loginForm(@PathVariable String slug, Model model) {
+    String loginForm(@PathVariable String slug, Model model) {
         Tenant tenant = tenantRepository.findBySlug(slug).orElse(null);
         if (tenant == null) {
             return "redirect:/manage/t/system/login";

--- a/src/main/java/com/stucray/limen/oauth2/SasConfig.java
+++ b/src/main/java/com/stucray/limen/oauth2/SasConfig.java
@@ -50,7 +50,7 @@ class SasConfig {
 
     @Bean
     @Order(Ordered.HIGHEST_PRECEDENCE)
-    public SecurityFilterChain authorizationServerSecurityFilterChain(
+    SecurityFilterChain authorizationServerSecurityFilterChain(
         HttpSecurity http,
         RegisteredClientRepository registeredClientRepository,
         ClientMembershipQuery clientMembershipQuery
@@ -87,7 +87,7 @@ class SasConfig {
     }
 
     @Bean
-    public RegisteredClientRepository registeredClientRepository(
+    RegisteredClientRepository registeredClientRepository(
         JdbcTemplate jdbcTemplate,
         TenantClientRepository tenantClientRepository
     ) {
@@ -96,12 +96,12 @@ class SasConfig {
     }
 
     @Bean
-    public JsonMapper sasJsonMapper() {
+    JsonMapper sasJsonMapper() {
         return SasJsonMapperFactory.create();
     }
 
     @Bean
-    public OAuth2AuthorizationService authorizationService(
+    OAuth2AuthorizationService authorizationService(
         JdbcTemplate jdbcTemplate,
         RegisteredClientRepository registeredClientRepository,
         JsonMapper sasJsonMapper
@@ -117,7 +117,7 @@ class SasConfig {
     }
 
     @Bean
-    public OAuth2AuthorizationConsentService authorizationConsentService(
+    OAuth2AuthorizationConsentService authorizationConsentService(
         JdbcTemplate jdbcTemplate,
         RegisteredClientRepository registeredClientRepository
     ) {
@@ -125,7 +125,7 @@ class SasConfig {
     }
 
     @Bean
-    public JWKSource<SecurityContext> jwkSource(
+    JWKSource<SecurityContext> jwkSource(
         TenantRepository tenantRepository,
         SigningKeyStore signingKeyStore
     ) {
@@ -133,14 +133,14 @@ class SasConfig {
     }
 
     @Bean
-    public AuthorizationServerSettings authorizationServerSettings() {
+    AuthorizationServerSettings authorizationServerSettings() {
         return AuthorizationServerSettings.builder()
             .issuer("http://localhost:8090")
             .build();
     }
 
     @Bean
-    public OAuth2TokenCustomizer<JwtEncodingContext> jwtTokenCustomizer(
+    OAuth2TokenCustomizer<JwtEncodingContext> jwtTokenCustomizer(
         ClientMembershipQuery clientMembershipQuery
     ) {
         return context -> {

--- a/src/main/java/com/stucray/limen/oauth2/TenantAwareOAuth2AuthorizationConsentService.java
+++ b/src/main/java/com/stucray/limen/oauth2/TenantAwareOAuth2AuthorizationConsentService.java
@@ -47,7 +47,7 @@ public class TenantAwareOAuth2AuthorizationConsentService implements OAuth2Autho
     private final JdbcTemplate jdbcTemplate;
     private final JdbcOAuth2AuthorizationConsentService.OAuth2AuthorizationConsentRowMapper rowMapper;
 
-    public TenantAwareOAuth2AuthorizationConsentService(
+    TenantAwareOAuth2AuthorizationConsentService(
         JdbcTemplate jdbcTemplate,
         RegisteredClientRepository registeredClientRepository
     ) {

--- a/src/main/java/com/stucray/limen/oauth2/TenantAwareOAuth2AuthorizationService.java
+++ b/src/main/java/com/stucray/limen/oauth2/TenantAwareOAuth2AuthorizationService.java
@@ -29,7 +29,7 @@ public class TenantAwareOAuth2AuthorizationService implements OAuth2Authorizatio
     private final JdbcTemplate jdbcTemplate;
     private final JdbcOAuth2AuthorizationService.JsonMapperOAuth2AuthorizationRowMapper rowMapper;
 
-    public TenantAwareOAuth2AuthorizationService(
+    TenantAwareOAuth2AuthorizationService(
         OAuth2AuthorizationService delegate,
         JdbcTemplate jdbcTemplate,
         RegisteredClientRepository registeredClientRepository,

--- a/src/main/java/com/stucray/limen/oauth2/TenantAwareRegisteredClientRepository.java
+++ b/src/main/java/com/stucray/limen/oauth2/TenantAwareRegisteredClientRepository.java
@@ -15,7 +15,7 @@ public class TenantAwareRegisteredClientRepository implements RegisteredClientRe
     private final RegisteredClientRepository delegate;
     private final TenantClientRepository tenantClientRepository;
 
-    public TenantAwareRegisteredClientRepository(
+    TenantAwareRegisteredClientRepository(
         RegisteredClientRepository delegate,
         TenantClientRepository tenantClientRepository
     ) {

--- a/src/main/java/com/stucray/limen/oauth2/TenantIssuerContextFilter.java
+++ b/src/main/java/com/stucray/limen/oauth2/TenantIssuerContextFilter.java
@@ -22,7 +22,7 @@ public class TenantIssuerContextFilter extends OncePerRequestFilter {
 
     private final AuthorizationServerSettings baseSettings;
 
-    public TenantIssuerContextFilter(AuthorizationServerSettings baseSettings) {
+    TenantIssuerContextFilter(AuthorizationServerSettings baseSettings) {
         this.baseSettings = baseSettings;
     }
 

--- a/src/main/java/com/stucray/limen/oauth2/TenantJwkSource.java
+++ b/src/main/java/com/stucray/limen/oauth2/TenantJwkSource.java
@@ -44,7 +44,7 @@ public class TenantJwkSource implements JWKSource<SecurityContext> {
     private final TenantRepository tenantRepository;
     private final SigningKeyStore signingKeyStore;
 
-    public TenantJwkSource(TenantRepository tenantRepository, SigningKeyStore signingKeyStore) {
+    TenantJwkSource(TenantRepository tenantRepository, SigningKeyStore signingKeyStore) {
         this.tenantRepository = tenantRepository;
         this.signingKeyStore = signingKeyStore;
     }

--- a/src/main/java/com/stucray/limen/oauth2/TenantLoginUrlAuthenticationEntryPoint.java
+++ b/src/main/java/com/stucray/limen/oauth2/TenantLoginUrlAuthenticationEntryPoint.java
@@ -26,13 +26,13 @@ public class TenantLoginUrlAuthenticationEntryPoint extends LoginUrlAuthenticati
 
     private final Function<HttpServletRequest, @Nullable String> slugResolver;
 
-    public TenantLoginUrlAuthenticationEntryPoint(Function<HttpServletRequest, @Nullable String> slugResolver) {
+    TenantLoginUrlAuthenticationEntryPoint(Function<HttpServletRequest, @Nullable String> slugResolver) {
         super("/manage/t/system/login");
         this.slugResolver = slugResolver;
     }
 
     /** Resolves the slug from the un-stripped request URL (e.g. for the OAuth2-login chain). */
-    public static TenantLoginUrlAuthenticationEntryPoint fromUrl() {
+    static TenantLoginUrlAuthenticationEntryPoint fromUrl() {
         return new TenantLoginUrlAuthenticationEntryPoint(req -> {
             Matcher m = SLUG_PATTERN.matcher(req.getRequestURI());
             return m.matches() ? m.group(1) : null;
@@ -40,7 +40,7 @@ public class TenantLoginUrlAuthenticationEntryPoint extends LoginUrlAuthenticati
     }
 
     /** Resolves the slug from the routing filter's TenantScope binding (e.g. for the SAS chain). */
-    public static TenantLoginUrlAuthenticationEntryPoint fromTenantScope() {
+    static TenantLoginUrlAuthenticationEntryPoint fromTenantScope() {
         return new TenantLoginUrlAuthenticationEntryPoint(req -> TenantScope.slug());
     }
 

--- a/src/main/java/com/stucray/limen/oauth2/TenantOAuth2RequestWrapper.java
+++ b/src/main/java/com/stucray/limen/oauth2/TenantOAuth2RequestWrapper.java
@@ -13,7 +13,7 @@ class TenantOAuth2RequestWrapper extends HttpServletRequestWrapper {
     private final String strippedUri;
     private final String strippedServletPath;
 
-    public TenantOAuth2RequestWrapper(HttpServletRequest request, String slug) {
+    TenantOAuth2RequestWrapper(HttpServletRequest request, String slug) {
         super(request);
         String prefix = "/t/" + slug;
         String originalUri = request.getRequestURI();

--- a/src/main/java/com/stucray/limen/oauth2/TenantOAuth2RoutingFilter.java
+++ b/src/main/java/com/stucray/limen/oauth2/TenantOAuth2RoutingFilter.java
@@ -37,7 +37,7 @@ class TenantOAuth2RoutingFilter extends OncePerRequestFilter {
 
     private final TenantRepository tenantRepository;
 
-    public TenantOAuth2RoutingFilter(TenantRepository tenantRepository) {
+    TenantOAuth2RoutingFilter(TenantRepository tenantRepository) {
         this.tenantRepository = tenantRepository;
     }
 


### PR DESCRIPTION
## Summary

Method-level visibility reduction in the \`oauth2\` module — **all 23 candidates flipped** from public to package-private (zero reverts).

| File | Flipped |
|---|---|
| \`MembershipGateFilter\` | 1 |
| \`OAuth2LoginSecurityConfig\` | 2 (ctor + @Bean SecurityFilterChain) |
| \`OAuth2TenantLoginController\` | 2 |
| \`SasConfig\` | 8 (all @Bean methods) |
| \`TenantAwareOAuth2AuthorizationConsentService\` | 1 |
| \`TenantAwareOAuth2AuthorizationService\` | 1 |
| \`TenantAwareRegisteredClientRepository\` | 1 |
| \`TenantIssuerContextFilter\` | 1 |
| \`TenantJwkSource\` | 1 |
| \`TenantLoginUrlAuthenticationEntryPoint\` | 3 (ctor + 2 static factories) |
| \`TenantOAuth2RequestWrapper\` | 1 |
| \`TenantOAuth2RoutingFilter\` | 1 |
| **Total** | **23** |

## Why everything flipped cleanly

The whole \`oauth2\` module is internal infrastructure. Every cross-package consumer goes through Spring bean-by-type wiring (interfaces like \`OAuth2AuthorizationService\`, \`RegisteredClientRepository\`, \`AuthenticationEntryPoint\`), not direct method calls.

Even the 8 \`@Bean\` methods on \`SasConfig\` (a \`@Configuration(proxyBeanMethods=true)\` class) flip cleanly — Spring's CGLIB-generated subclass lives in the same package family and successfully overrides package-private \`@Bean\` methods. **Lesson captured for future passes:** \`@Bean\` methods on Spring config classes can flip to package-private safely.

## Verification

\`mvn clean verify\` green: compile + test + Error Prone + NullAway + JaCoCo + PMD all pass. The 15 UI journey tests cover end-to-end OAuth2 flows (login, consent, token issuance).

## Test plan
- [x] \`mvn -B -ntp clean verify\`
- [x] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)