### PR TITLE
refactor: reduce method visibility in tenant (Pass 3, PR 10/N)

### DIFF
--- a/src/main/java/com/stucray/limen/tenant/TenantScope.java
+++ b/src/main/java/com/stucray/limen/tenant/TenantScope.java
@@ -11,7 +11,7 @@ public final class TenantScope {
 
     public record Data(String slug, Long tenantId) {}
 
-    public static final ScopedValue<Data> SCOPE = ScopedValue.newInstance();
+    static final ScopedValue<Data> SCOPE = ScopedValue.newInstance();
 
     private TenantScope() {}
 


### PR DESCRIPTION
## Summary

Method-level visibility reduction in the \`tenant\` module — net **1 of 8** candidates flipped.

The \`tenant\` module is a near-pure-interface module (domain entity + cross-cutting scope utility) so most of its public surface is by-design cross-package API. Bringing this in for completeness even though the net is small.

| File | Flipped | Kept public |
|---|---|---|
| \`Tenant\` | 0 | \`withDisplayName\`, \`withStatus\`, \`isSystem\` |
| \`TenantScope\` | 1 (\`SCOPE\` constant) | \`slug\`, \`tenantId\`, \`run\`, \`call\` |
| **Total** | **1** | **7** |

## Why seven stayed public

All proven by \`mvn clean verify\`:

- **\`Tenant.withDisplayName\`** — \`system.TenantDetailsController\`
- **\`Tenant.withStatus\`** — \`provisioning.TenantProvisioningService\`
- **\`Tenant.isSystem\`** — used in \`system\`, \`user\`, \`provisioning\`, \`management.web\`
- **\`TenantScope.slug/tenantId/run/call\`** — used across \`auth/ott\`, \`oauth2\`, \`observability\` (15+ call sites). The whole point of \`TenantScope\` is cross-package per-request context propagation via Loom \`ScopedValue\`.

## The one flip

\`TenantScope.SCOPE\` — the underlying \`ScopedValue<Data>\` — is internal to the class. The public surface is the 4 static accessor methods (\`slug\`/\`tenantId\`/\`run\`/\`call\`), not the \`ScopedValue\` itself.

## Verification

\`mvn clean verify\` green: compile + test + Error Prone + NullAway + JaCoCo + PMD all pass.

## Test plan
- [x] \`mvn -B -ntp clean verify\`
- [x] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)