### PR TITLE
refactor: reduce method visibility in clients (Pass 3, PR 11/N)

### DIFF
--- a/src/main/java/com/stucray/limen/clients/ClientManagementController.java
+++ b/src/main/java/com/stucray/limen/clients/ClientManagementController.java
@@ -22,7 +22,7 @@ class ClientManagementController {
     private final ClientManagementService clientManagementService;
     private final ApplicationService applicationService;
 
-    public ClientManagementController(
+    ClientManagementController(
         ClientManagementService clientManagementService,
         ApplicationService applicationService
     ) {
@@ -31,7 +31,7 @@ class ClientManagementController {
     }
 
     @GetMapping
-    public String list(
+    String list(
         @PathVariable String slug,
         @PathVariable Long appId,
         @AuthenticationPrincipal TenantUserDetails principal,
@@ -44,7 +44,7 @@ class ClientManagementController {
     }
 
     @GetMapping("/new")
-    public String newClientForm(
+    String newClientForm(
         @PathVariable String slug,
         @PathVariable Long appId,
         @AuthenticationPrincipal TenantUserDetails principal,
@@ -56,7 +56,7 @@ class ClientManagementController {
     }
 
     @PostMapping
-    public String createClient(
+    String createClient(
         @PathVariable String slug,
         @PathVariable Long appId,
         @AuthenticationPrincipal TenantUserDetails principal,
@@ -93,7 +93,7 @@ class ClientManagementController {
     }
 
     @GetMapping("/{registeredClientId}/edit")
-    public String editClientForm(
+    String editClientForm(
         @PathVariable String slug,
         @PathVariable Long appId,
         @PathVariable String registeredClientId,
@@ -107,7 +107,7 @@ class ClientManagementController {
     }
 
     @PostMapping("/{registeredClientId}/edit")
-    public String updateClient(
+    String updateClient(
         @PathVariable String slug,
         @PathVariable Long appId,
         @PathVariable String registeredClientId,
@@ -125,7 +125,7 @@ class ClientManagementController {
     }
 
     @PostMapping("/{registeredClientId}/delete")
-    public String deleteClient(
+    String deleteClient(
         @PathVariable String slug,
         @PathVariable Long appId,
         @PathVariable String registeredClientId,
@@ -136,7 +136,7 @@ class ClientManagementController {
     }
 
     @PostMapping("/{registeredClientId}/rotate-secret")
-    public String rotateSecret(
+    String rotateSecret(
         @PathVariable String slug,
         @PathVariable Long appId,
         @PathVariable String registeredClientId,

--- a/src/main/java/com/stucray/limen/clients/ClientManagementService.java
+++ b/src/main/java/com/stucray/limen/clients/ClientManagementService.java
@@ -28,7 +28,7 @@ public class ClientManagementService {
     private final PasswordEncoder passwordEncoder;
     private final ApplicationEventPublisher eventPublisher;
 
-    public ClientManagementService(
+    ClientManagementService(
         RegisteredClientRepository registeredClientRepository,
         TenantClientRepository tenantClientRepository,
         PasswordEncoder passwordEncoder,
@@ -40,7 +40,7 @@ public class ClientManagementService {
         this.eventPublisher = eventPublisher;
     }
 
-    public List<TenantClient> listClients(Long applicationId, Long tenantId) {
+    List<TenantClient> listClients(Long applicationId, Long tenantId) {
         return tenantClientRepository.findAllByApplicationIdAndTenantId(applicationId, tenantId);
     }
 
@@ -108,7 +108,7 @@ public class ClientManagementService {
             .orElseThrow(() -> new IllegalArgumentException("Client not found"));
     }
 
-    public ClientWithSettings getClientWithSettings(String registeredClientId, Long tenantId) {
+    ClientWithSettings getClientWithSettings(String registeredClientId, Long tenantId) {
         TenantClient tc = getClient(registeredClientId, tenantId);
         RegisteredClient rc = registeredClientRepository.findById(registeredClientId);
         if (rc == null) throw new IllegalArgumentException("Client not found");
@@ -122,7 +122,7 @@ public class ClientManagementService {
         );
     }
 
-    public void updateClientSettings(
+    void updateClientSettings(
         String registeredClientId, Long tenantId,
         long accessTokenTtlMinutes,
         long refreshTokenTtlDays,


### PR DESCRIPTION
## Summary

Method-level visibility reduction in the \`clients\` module — net **12 of 16** candidates flipped from public to package-private.

| File | Flipped | Kept public |
|---|---|---|
| \`ClientManagementController\` | 8 | — |
| \`ClientManagementService\` | 4 | \`getClient\`, \`createClient\`, \`deleteClient\`, \`rotateSecret\` |
| **Total** | **12** | **4** |

\`CreateClientForm.java\` (20 getter/setter candidates) is **excluded from this pass** — its accessors are part of the JavaBean form-binding carve-out documented in PR #221, where Spring's \`WebDataBinder\` reflectively invokes setters from outside the binder's package.

## Why four stayed public

All proven by \`mvn clean verify\`:

- **\`getClient\`** — \`memberships.ClientMembersController\` (5 call sites). Membership UI lookups need to display client metadata.
- **\`createClient\`** — cross-package integration tests in \`memberships\`, \`oauth2\`, \`useradmin\` (6 call sites). Same precedent as \`applications.createApplication\` in PR #228.
- **\`deleteClient\`** — \`memberships.ClientMembershipServiceIntegrationTest\`.
- **\`rotateSecret\`** — \`audit.AuditEventEmitIntegrationTest\`.

## Verification

\`mvn clean verify\` green: compile + test + Error Prone + NullAway + JaCoCo + PMD all pass.

## Test plan
- [x] \`mvn -B -ntp clean verify\`
- [x] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)