### PR TITLE
refactor: reduce method visibility in provisioning (Pass 3, PR 12/N)

### DIFF
--- a/src/main/java/com/stucray/limen/provisioning/TenantProvisioner.java
+++ b/src/main/java/com/stucray/limen/provisioning/TenantProvisioner.java
@@ -57,7 +57,7 @@ public class TenantProvisioner {
     private final PasswordEncoder passwordEncoder;
     private final OttDispatcher ottDispatcher;
 
-    public TenantProvisioner(
+    TenantProvisioner(
         TenantRepository tenantRepository,
         TenantProvisioningService tenantProvisioningService,
         UserRepository userRepository,

--- a/src/main/java/com/stucray/limen/provisioning/TenantProvisioningService.java
+++ b/src/main/java/com/stucray/limen/provisioning/TenantProvisioningService.java
@@ -46,7 +46,7 @@ public class TenantProvisioningService {
     private final SigningKeyStore signingKeyStore;
     private final ApplicationEventPublisher eventPublisher;
 
-    public TenantProvisioningService(
+    TenantProvisioningService(
         TenantRepository tenantRepository,
         SigningKeyStore signingKeyStore,
         ApplicationEventPublisher eventPublisher
@@ -87,7 +87,7 @@ public class TenantProvisioningService {
             new TenantDeletedEvent(tenant.id(), tenant.slug(), actorUserId));
     }
 
-    public void deleteTenant(long id) {
+    void deleteTenant(long id) {
         tenantRepository.deleteById(id);
     }
 


### PR DESCRIPTION
## Summary

Method-level visibility reduction in the \`provisioning\` module — net **3 of 8** candidates flipped.

The \`provisioning\` module is a cross-cutting orchestrator for tenant-lifecycle operations (create, suspend, delete, unsuspend), so most of its public methods are by-design API for the system-admin controller and signup pipeline.

| File | Flipped | Kept public |
|---|---|---|
| \`TenantProvisioner\` | 1 (ctor) | \`provision\` |
| \`TenantProvisioningService\` | 2 (ctor, \`deleteTenant\`) | \`createTenant\`, \`suspend\`, \`unsuspend\`, \`delete\` |
| **Total** | **3** | **5** |

## Why five stayed public

All proven by \`mvn clean verify\`:

- **\`TenantProvisioner.provision\`** — used by \`signup.SignupService\` and \`system.SystemAdminController\`. The end-to-end "make a tenant + admin user" entry point.
- **\`TenantProvisioningService.createTenant\`** — used by \`identity.UserBootstrap\` (system-admin bootstrap on first start).
- **\`TenantProvisioningService.suspend\`/\`unsuspend\`/\`delete\`** — all called by \`system.SystemAdminController\` for tenant-lifecycle UI.

## Verification

\`mvn clean verify\` green: compile + test + Error Prone + NullAway + JaCoCo + PMD all pass.

## Test plan
- [x] \`mvn -B -ntp clean verify\`
- [x] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)