### PR TITLE
refactor: reduce method visibility in long-tail modules (Pass 3, PR 13/N — final)

### DIFF
--- a/src/main/java/com/stucray/limen/audit/AuditEventWriter.java
+++ b/src/main/java/com/stucray/limen/audit/AuditEventWriter.java
@@ -36,7 +36,7 @@ public class AuditEventWriter {
     private final JdbcTemplate jdbcTemplate;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    public AuditEventWriter(JdbcTemplate jdbcTemplate) {
+    AuditEventWriter(JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
     }
 

--- a/src/main/java/com/stucray/limen/audit/dispatch/AuditDispatcher.java
+++ b/src/main/java/com/stucray/limen/audit/dispatch/AuditDispatcher.java
@@ -51,7 +51,7 @@ class AuditDispatcher {
     private final AuditEventWriter writer;
     private final AuditRegistry registry;
 
-    public AuditDispatcher(AuditEventWriter writer, AuditRegistry registry) {
+    AuditDispatcher(AuditEventWriter writer, AuditRegistry registry) {
         this.writer = writer;
         this.registry = registry;
     }
@@ -67,12 +67,12 @@ class AuditDispatcher {
      * persistence to the events the registry actually has rules for.
      */
     @ApplicationModuleListener
-    public void onAfterCommit(AuditedDomainEvent event) {
+    void onAfterCommit(AuditedDomainEvent event) {
         dispatch(event, AuditBinding.AFTER_COMMIT);
     }
 
     @EventListener
-    public void onImmediate(Object event) {
+    void onImmediate(Object event) {
         dispatch(event, AuditBinding.IMMEDIATE);
     }
 

--- a/src/main/java/com/stucray/limen/audit/dispatch/AuditRegistry.java
+++ b/src/main/java/com/stucray/limen/audit/dispatch/AuditRegistry.java
@@ -208,7 +208,7 @@ public class AuditRegistry {
 
     private final Map<CacheKey, Optional<AuditRule<?>>> resolutionCache = new ConcurrentHashMap<>();
 
-    public AuditRegistry() {
+    AuditRegistry() {
         // Same event class registered twice would silently double-write. Catch
         // it at startup, where it's a one-line fix in this file.
         Map<Class<?>, AuditRule<?>> seen = new HashMap<>();
@@ -227,7 +227,7 @@ public class AuditRegistry {
      * registered event class is a superclass of {@code eventClass} matches.
      * Results are cached per (class, binding) pair.
      */
-    public @Nullable AuditRule<?> findRule(Class<?> eventClass, AuditBinding binding) {
+    @Nullable AuditRule<?> findRule(Class<?> eventClass, AuditBinding binding) {
         return resolutionCache
             .computeIfAbsent(new CacheKey(eventClass, binding), this::resolve)
             .orElse(null);
@@ -249,7 +249,7 @@ public class AuditRegistry {
         return Optional.ofNullable(exact != null ? exact : assignable);
     }
 
-    public List<AuditRule<?>> rules() {
+    List<AuditRule<?>> rules() {
         return rules;
     }
 

--- a/src/main/java/com/stucray/limen/email/SmtpEmailSender.java
+++ b/src/main/java/com/stucray/limen/email/SmtpEmailSender.java
@@ -28,7 +28,7 @@ class SmtpEmailSender implements EmailSender {
 
     private final JavaMailSender mailSender;
 
-    public SmtpEmailSender(JavaMailSender mailSender) {
+    SmtpEmailSender(JavaMailSender mailSender) {
         this.mailSender = mailSender;
     }
 

--- a/src/main/java/com/stucray/limen/enduser/web/EndUserHomeController.java
+++ b/src/main/java/com/stucray/limen/enduser/web/EndUserHomeController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 class EndUserHomeController {
 
     @GetMapping("/t/{slug}/")
-    public String home(
+    String home(
         @PathVariable String slug,
         @AuthenticationPrincipal TenantUserDetails principal,
         Model model

--- a/src/main/java/com/stucray/limen/identity/BootstrapAdminProperties.java
+++ b/src/main/java/com/stucray/limen/identity/BootstrapAdminProperties.java
@@ -9,13 +9,13 @@ import org.springframework.validation.annotation.Validated;
 record BootstrapAdminProperties(String email, String password) {
 
     @AssertTrue(message = "limen.bootstrap.admin.email and password must both be set or both be unset")
-    public boolean isPairConsistent() {
+    boolean isPairConsistent() {
         boolean emailSet = email != null && !email.isBlank();
         boolean passSet = password != null && !password.isBlank();
         return emailSet == passSet;
     }
 
-    public boolean isConfigured() {
+    boolean isConfigured() {
         return email != null && !email.isBlank()
             && password != null && !password.isBlank();
     }

--- a/src/main/java/com/stucray/limen/identity/IdentityConfig.java
+++ b/src/main/java/com/stucray/limen/identity/IdentityConfig.java
@@ -14,12 +14,12 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 class IdentityConfig {
 
     @Bean
-    public PasswordEncoder passwordEncoder() {
+    PasswordEncoder passwordEncoder() {
         return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 
     @Bean
-    public AuthenticationManager authenticationManager(
+    AuthenticationManager authenticationManager(
         TenantAuthProvider tenantAuthProvider,
         ApplicationEventPublisher applicationEventPublisher
     ) {

--- a/src/main/java/com/stucray/limen/identity/UserBootstrap.java
+++ b/src/main/java/com/stucray/limen/identity/UserBootstrap.java
@@ -25,7 +25,7 @@ class UserBootstrap implements CommandLineRunner {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
-    public UserBootstrap(
+    UserBootstrap(
         BootstrapAdminProperties adminProperties,
         TenantRepository tenantRepository,
         TenantProvisioningService tenantProvisioningService,

--- a/src/main/java/com/stucray/limen/management/auth/ManagementSecurityConfig.java
+++ b/src/main/java/com/stucray/limen/management/auth/ManagementSecurityConfig.java
@@ -19,7 +19,7 @@ class ManagementSecurityConfig {
     private final TenantLogin login;
     private final TenantUrlScheme managementUrlScheme;
 
-    public ManagementSecurityConfig(
+    ManagementSecurityConfig(
         TenantLogin login,
         @Qualifier("managementUrlScheme") TenantUrlScheme managementUrlScheme
     ) {
@@ -28,7 +28,7 @@ class ManagementSecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain managementFilterChain(HttpSecurity http) throws Exception {
+    SecurityFilterChain managementFilterChain(HttpSecurity http) throws Exception {
         login.applyTo(http, managementUrlScheme);
 
         http

--- a/src/main/java/com/stucray/limen/management/web/ManagementHomeController.java
+++ b/src/main/java/com/stucray/limen/management/web/ManagementHomeController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 class ManagementHomeController {
 
     @GetMapping("/manage/t/{slug}/")
-    public String home(
+    String home(
         @PathVariable String slug,
         @AuthenticationPrincipal TenantUserDetails principal,
         Model model

--- a/src/main/java/com/stucray/limen/management/web/ManagementLoginController.java
+++ b/src/main/java/com/stucray/limen/management/web/ManagementLoginController.java
@@ -12,12 +12,12 @@ class ManagementLoginController {
 
     private final TenantRepository tenantRepository;
 
-    public ManagementLoginController(TenantRepository tenantRepository) {
+    ManagementLoginController(TenantRepository tenantRepository) {
         this.tenantRepository = tenantRepository;
     }
 
     @GetMapping("/manage/t/{slug}/login")
-    public String loginPage(@PathVariable String slug, Model model) {
+    String loginPage(@PathVariable String slug, Model model) {
         Tenant tenant = tenantRepository.findBySlug(slug).orElse(null);
         if (tenant == null) {
             return "redirect:/signup";

--- a/src/main/java/com/stucray/limen/management/web/ManagementModelAdvice.java
+++ b/src/main/java/com/stucray/limen/management/web/ManagementModelAdvice.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 class ManagementModelAdvice {
 
     @ModelAttribute("currentEmail")
-    public @Nullable String currentEmail(@AuthenticationPrincipal @Nullable TenantUserDetails principal) {
+    @Nullable String currentEmail(@AuthenticationPrincipal @Nullable TenantUserDetails principal) {
         return principal == null ? null : principal.displayEmail();
     }
 }

--- a/src/main/java/com/stucray/limen/observability/AuditMetricsListener.java
+++ b/src/main/java/com/stucray/limen/observability/AuditMetricsListener.java
@@ -47,7 +47,7 @@ class AuditMetricsListener {
     private final Counter signingKeyRotated;
     private final Counter signingKeyPruned;
 
-    public AuditMetricsListener(MeterRegistry registry) {
+    AuditMetricsListener(MeterRegistry registry) {
         this.registry = registry;
         this.loginSuccess = Counter.builder(LOGIN_SUCCESS)
             .description("Successful logins (Spring Security AuthenticationSuccessEvent).")
@@ -68,12 +68,12 @@ class AuditMetricsListener {
     }
 
     @EventListener
-    public void onLoginSuccess(AuthenticationSuccessEvent event) {
+    void onLoginSuccess(AuthenticationSuccessEvent event) {
         loginSuccess.increment();
     }
 
     @EventListener
-    public void onLoginFailure(AbstractAuthenticationFailureEvent event) {
+    void onLoginFailure(AbstractAuthenticationFailureEvent event) {
         Counter.builder(LOGIN_FAILURE)
             .description("Failed logins, tagged by Spring Security exception class.")
             .baseUnit("events")
@@ -83,17 +83,17 @@ class AuditMetricsListener {
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void onClientSecretRotated(ClientSecretRotatedEvent event) {
+    void onClientSecretRotated(ClientSecretRotatedEvent event) {
         clientSecretRotated.increment();
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void onSigningKeyRotated(SigningKeyRotatedEvent event) {
+    void onSigningKeyRotated(SigningKeyRotatedEvent event) {
         signingKeyRotated.increment();
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void onSigningKeyPruned(SigningKeyPrunedEvent event) {
+    void onSigningKeyPruned(SigningKeyPrunedEvent event) {
         signingKeyPruned.increment();
     }
 
@@ -109,7 +109,7 @@ class AuditMetricsListener {
      * a small fixed set, like {@code limen.auth.login.failure}.
      */
     @EventListener
-    public void onSigningKeyRotationFailure(SigningKeyRotationFailedEvent event) {
+    void onSigningKeyRotationFailure(SigningKeyRotationFailedEvent event) {
         Counter.builder(SIGNING_KEY_ROTATION_FAILURE)
             .description("Per-tenant signing-key rotations that threw mid-batch, tagged by exception class.")
             .baseUnit("events")

--- a/src/main/java/com/stucray/limen/observability/OtelLogbackInstaller.java
+++ b/src/main/java/com/stucray/limen/observability/OtelLogbackInstaller.java
@@ -24,7 +24,7 @@ class OtelLogbackInstaller {
 
     private static final Logger log = LoggerFactory.getLogger(OtelLogbackInstaller.class);
 
-    public OtelLogbackInstaller(OpenTelemetry openTelemetry) {
+    OtelLogbackInstaller(OpenTelemetry openTelemetry) {
         OpenTelemetryAppender.install(openTelemetry);
         log.info("OpenTelemetry Logback appender installed; subsequent logs forward to OTLP.");
     }

--- a/src/main/java/com/stucray/limen/security/DefaultSecurityConfig.java
+++ b/src/main/java/com/stucray/limen/security/DefaultSecurityConfig.java
@@ -22,7 +22,7 @@ import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 class DefaultSecurityConfig {
 
     @Bean
-    public SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) throws Exception {
+    SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) throws Exception {
         return http
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/", "/login", "/actuator/health").permitAll()

--- a/src/main/java/com/stucray/limen/security/SecurityProperties.java
+++ b/src/main/java/com/stucray/limen/security/SecurityProperties.java
@@ -14,7 +14,7 @@ public record SecurityProperties(@NotBlank String kek) {
     private static final int KEK_BYTES = 32;
 
     @AssertTrue(message = "limen.security.kek must be base64 decoding to exactly 32 bytes (256 bits)")
-    public boolean isKekValid() {
+    boolean isKekValid() {
         if (kek == null || kek.isBlank()) return true;
         try {
             return Base64.getDecoder().decode(kek).length == KEK_BYTES;

--- a/src/main/java/com/stucray/limen/security/ratelimit/RateLimitFilter.java
+++ b/src/main/java/com/stucray/limen/security/ratelimit/RateLimitFilter.java
@@ -51,7 +51,7 @@ class RateLimitFilter extends OncePerRequestFilter {
     private final List<CompiledRule> compiledRules;
     private final ConcurrentHashMap<RuleKey, Bucket> buckets = new ConcurrentHashMap<>();
 
-    public RateLimitFilter(RateLimitProperties properties, ApplicationEventPublisher publisher) {
+    RateLimitFilter(RateLimitProperties properties, ApplicationEventPublisher publisher) {
         this.properties = properties;
         this.publisher = publisher;
         this.compiledRules = properties.rules().entrySet().stream()
@@ -98,7 +98,7 @@ class RateLimitFilter extends OncePerRequestFilter {
      * remaining wait of any in-flight bucket. Tests use it to keep one
      * scenario from polluting the next within a single Spring context.
      */
-    public void resetBucketsForTesting() {
+    void resetBucketsForTesting() {
         buckets.clear();
     }
 

--- a/src/main/java/com/stucray/limen/security/signing/JdbcSigningKeyStore.java
+++ b/src/main/java/com/stucray/limen/security/signing/JdbcSigningKeyStore.java
@@ -36,7 +36,7 @@ class JdbcSigningKeyStore implements SigningKeyStore {
     private final JdbcTemplate jdbcTemplate;
     private final String kekPassword;
 
-    public JdbcSigningKeyStore(JdbcTemplate jdbcTemplate, SecurityProperties properties) {
+    JdbcSigningKeyStore(JdbcTemplate jdbcTemplate, SecurityProperties properties) {
         this.jdbcTemplate = jdbcTemplate;
         this.kekPassword = properties.kek();
     }

--- a/src/main/java/com/stucray/limen/security/signing/SigningKeyRotationConfig.java
+++ b/src/main/java/com/stucray/limen/security/signing/SigningKeyRotationConfig.java
@@ -30,7 +30,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 class SigningKeyRotationConfig {
 
     @Bean
-    public LockProvider lockProvider(JdbcTemplate jdbcTemplate) {
+    LockProvider lockProvider(JdbcTemplate jdbcTemplate) {
         return new JdbcTemplateLockProvider(JdbcTemplateLockProvider.Configuration.builder()
             .withJdbcTemplate(jdbcTemplate)
             .usingDbTime()

--- a/src/main/java/com/stucray/limen/security/signing/SigningKeyRotationSchedule.java
+++ b/src/main/java/com/stucray/limen/security/signing/SigningKeyRotationSchedule.java
@@ -26,7 +26,7 @@ class SigningKeyRotationSchedule {
 
     private final SigningKeyRotator rotator;
 
-    public SigningKeyRotationSchedule(SigningKeyRotator rotator) {
+    SigningKeyRotationSchedule(SigningKeyRotator rotator) {
         this.rotator = rotator;
     }
 
@@ -35,7 +35,7 @@ class SigningKeyRotationSchedule {
         name = "rotate-signing-keys",
         lockAtMostFor = "10m",
         lockAtLeastFor = "30s")
-    public void run() {
+    void run() {
         rotator.runScheduledRotation();
     }
 }

--- a/src/main/java/com/stucray/limen/security/signing/SigningKeyRotator.java
+++ b/src/main/java/com/stucray/limen/security/signing/SigningKeyRotator.java
@@ -56,7 +56,7 @@ class SigningKeyRotator {
     private final Clock clock;
 
     @Autowired
-    public SigningKeyRotator(
+    SigningKeyRotator(
         SigningKeyStore signingKeyStore,
         ApplicationEventPublisher eventPublisher,
         SigningKeyRotationProperties properties,
@@ -81,7 +81,7 @@ class SigningKeyRotator {
     }
 
     @Transactional
-    public void rotate(long tenantId) {
+    void rotate(long tenantId) {
         SigningKeyStore.RotationOutcome outcome = signingKeyStore.rotateForTenant(tenantId);
         eventPublisher.publishEvent(new SigningKeyRotatedEvent(
             tenantId, outcome.oldKid(), outcome.newKid()));
@@ -96,7 +96,7 @@ class SigningKeyRotator {
      * this method returns successfully.
      */
     @Transactional
-    public void pruneRetired(Duration grace) {
+    void pruneRetired(Duration grace) {
         for (SigningKeyStore.PrunedKey pruned : signingKeyStore.pruneRetiredOlderThan(grace)) {
             eventPublisher.publishEvent(new SigningKeyPrunedEvent(pruned.tenantId(), pruned.kid()));
         }
@@ -112,7 +112,7 @@ class SigningKeyRotator {
      * continues for subsequent tenants. Pruning runs once at the end of the
      * batch regardless of per-tenant outcomes.
      */
-    public void runScheduledRotation() {
+    void runScheduledRotation() {
         List<Long> tenantIds = signingKeyStore.findTenantIdsWithActiveKeyOlderThan(properties.keyAge());
         log.info("Scheduled signing-key rotation: {} tenants eligible", tenantIds.size());
 

--- a/src/main/java/com/stucray/limen/signup/SignupController.java
+++ b/src/main/java/com/stucray/limen/signup/SignupController.java
@@ -14,18 +14,18 @@ class SignupController {
 
     private final SignupService signupService;
 
-    public SignupController(SignupService signupService) {
+    SignupController(SignupService signupService) {
         this.signupService = signupService;
     }
 
     @GetMapping("/signup")
-    public String signupForm(Model model) {
+    String signupForm(Model model) {
         model.addAttribute("form", new SignupForm("", "", "", ""));
         return "signup";
     }
 
     @PostMapping("/signup")
-    public String signup(
+    String signup(
         @RequestParam String organizationName,
         @RequestParam String slug,
         @RequestParam String email,

--- a/src/main/java/com/stucray/limen/signup/SignupService.java
+++ b/src/main/java/com/stucray/limen/signup/SignupService.java
@@ -17,7 +17,7 @@ public class SignupService {
 
     private final TenantProvisioner tenantProvisioner;
 
-    public SignupService(TenantProvisioner tenantProvisioner) {
+    SignupService(TenantProvisioner tenantProvisioner) {
         this.tenantProvisioner = tenantProvisioner;
     }
 

--- a/src/main/java/com/stucray/limen/system/SystemAdminController.java
+++ b/src/main/java/com/stucray/limen/system/SystemAdminController.java
@@ -26,7 +26,7 @@ class SystemAdminController {
     private final TenantProvisioningService tenantProvisioningService;
     private final TenantProvisioner tenantProvisioner;
 
-    public SystemAdminController(
+    SystemAdminController(
         TenantRepository tenantRepository,
         TenantProvisioningService tenantProvisioningService,
         TenantProvisioner tenantProvisioner
@@ -37,13 +37,13 @@ class SystemAdminController {
     }
 
     @GetMapping("/tenants")
-    public String listTenants(Model model) {
+    String listTenants(Model model) {
         model.addAttribute("tenants", tenantRepository.findAll());
         return "manage/system/tenants";
     }
 
     @GetMapping("/tenants/new")
-    public String newTenantForm(Model model) {
+    String newTenantForm(Model model) {
         if (!model.containsAttribute("form")) {
             model.addAttribute("form", new TenantCreateForm("", "", ""));
         }
@@ -51,7 +51,7 @@ class SystemAdminController {
     }
 
     @PostMapping("/tenants/new")
-    public String createTenant(
+    String createTenant(
         @RequestParam String slug,
         @RequestParam String displayName,
         @RequestParam String ownerEmail,
@@ -77,7 +77,7 @@ class SystemAdminController {
     }
 
     @PostMapping("/tenants/{tenantId}/suspend")
-    public String suspendTenant(
+    String suspendTenant(
         @PathVariable Long tenantId,
         @AuthenticationPrincipal TenantUserDetails principal,
         RedirectAttributes redirectAttributes
@@ -93,7 +93,7 @@ class SystemAdminController {
     }
 
     @PostMapping("/tenants/{tenantId}/unsuspend")
-    public String unsuspendTenant(
+    String unsuspendTenant(
         @PathVariable Long tenantId,
         @AuthenticationPrincipal TenantUserDetails principal
     ) {
@@ -104,7 +104,7 @@ class SystemAdminController {
     }
 
     @PostMapping("/tenants/{tenantId}/delete")
-    public String deleteTenant(
+    String deleteTenant(
         @PathVariable Long tenantId,
         @AuthenticationPrincipal TenantUserDetails principal,
         RedirectAttributes redirectAttributes

--- a/src/main/java/com/stucray/limen/system/TenantDetailsController.java
+++ b/src/main/java/com/stucray/limen/system/TenantDetailsController.java
@@ -13,12 +13,12 @@ class TenantDetailsController {
 
     private final TenantRepository tenantRepository;
 
-    public TenantDetailsController(TenantRepository tenantRepository) {
+    TenantDetailsController(TenantRepository tenantRepository) {
         this.tenantRepository = tenantRepository;
     }
 
     @GetMapping
-    public String settings(
+    String settings(
         @PathVariable String slug,
         @AuthenticationPrincipal TenantUserDetails principal,
         Model model
@@ -29,7 +29,7 @@ class TenantDetailsController {
     }
 
     @PostMapping("/display-name")
-    public String updateDisplayName(
+    String updateDisplayName(
         @PathVariable String slug,
         @AuthenticationPrincipal TenantUserDetails principal,
         @RequestParam String displayName

--- a/src/main/java/com/stucray/limen/web/RedirectLoginController.java
+++ b/src/main/java/com/stucray/limen/web/RedirectLoginController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 class RedirectLoginController {
 
     @GetMapping("/login")
-    public String login(@RequestParam(required = false) String slug) {
+    String login(@RequestParam(required = false) String slug) {
         if (slug == null || slug.isBlank()) {
             return "redirect:/";
         }

--- a/src/main/java/com/stucray/limen/web/RootController.java
+++ b/src/main/java/com/stucray/limen/web/RootController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 class RootController {
 
     @GetMapping("/")
-    public String landing() {
+    String landing() {
         return "landing";
     }
 }


### PR DESCRIPTION
## Summary

**Final per-module/themed PR for Pass 3 method-visibility reduction.** Bundles the remaining smaller modules into one PR. Net **56 of 59** candidates flipped from public to package-private.

| Module | Net flips | Files touched |
|---|---:|---|
| \`audit\` | 7 | \`AuditEventWriter\` (kept \`write\` public), \`AuditDispatcher\`, \`AuditRegistry\` |
| \`email\` | 1 | \`SmtpEmailSender\` (kept \`EmailMessage\` 3-arg ctor public) |
| \`enduser\` | 1 | \`EndUserHomeController\` |
| \`identity\` | 5 | \`BootstrapAdminProperties\`, \`IdentityConfig\`, \`UserBootstrap\` |
| \`management\` | 6 | \`ManagementSecurityConfig\`, \`ManagementLoginController\`, \`ManagementHomeController\`, \`ManagementModelAdvice\` |
| \`observability\` | 8 | \`AuditMetricsListener\`, \`OtelLogbackInstaller\` |
| \`security\` | 10 | \`DefaultSecurityConfig\`, \`SecurityProperties\`, \`RateLimitFilter\`, \`signing/*\` (4 files) |
| \`signup\` | 4 | \`SignupController\`, \`SignupService\` (kept \`signup\` public) |
| \`system\` | 10 | \`SystemAdminController\`, \`TenantDetailsController\` |
| \`web\` | 2 | \`RootController\`, \`RedirectLoginController\` |
| **Total** | **56** | |

## Why three stayed public

All proven by \`mvn clean verify\`:

- **\`audit.AuditEventWriter.write\`** — \`audit/dispatch/AuditDispatcher\` is in a sub-package. Package-private from \`audit\` parent does not reach into \`audit.dispatch\` — Java treats them as separate packages. The class doc claims "production code outside the audit package never references it", but the dispatch sub-package is technically separate.
- **\`email.EmailMessage\` 3-arg constructor** — used by \`auth.ott.OttDispatcher\` and \`auth.ott.OttSpringContractHandler\` to construct outbound email messages without an HTML body.
- **\`signup.SignupService.signup\`** — used by \`auth.ott.EmailVerificationFlowIntegrationTest\` to drive the signup flow as part of the email-verification end-to-end test.

## Verification

\`mvn clean verify\` green: compile + test + Error Prone + NullAway + JaCoCo + PMD all pass. The 15 UI journey tests cover end-to-end flows across all touched modules.

## Pass 3 wrap-up

This closes the per-module/themed phase of Pass 3. Combined Pass 3 net flips across all 13 PRs:

| PR | Branch | Module | Net flips |
|---|---|---|---:|
| #221 | \`cosmetic-method-visibility\` | (cosmetic, all package-private classes) | 137 |
| #222 | \`auth-login\` | auth/login | 21 |
| #223 | \`auth-ott\` | auth/ott | 20 |
| #224 | \`auth-root\` | auth (top-level) | 5 |
| #225 | \`memberships\` | memberships | 18 |
| #226 | \`useradmin\` | useradmin | 9 |
| #227 | \`roles\` | roles | 15 |
| #228 | \`applications\` | applications | 14 |
| #229 | \`oauth2\` | oauth2 | 23 |
| #230 | \`tenant\` | tenant | 1 |
| #231 | \`clients\` | clients | 12 |
| #232 | \`provisioning\` | provisioning | 3 |
| #233 (this) | \`long-tail\` | audit, email, enduser, identity, management, observability, security, signup, system, web | 56 |
| | | **Pass 3 total** | **~334** |

\`user\` module was audited and skipped (zero flips possible — all 16 candidates are by-design cross-package API).

## Test plan
- [x] \`mvn -B -ntp clean verify\`
- [x] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)