### PR TITLE
chore: bootstrap ArchUnit + Pass 4 type-level visibility

### DIFF
--- a/src/main/java/com/stucray/limen/audit/dispatch/AuditRegistry.java
+++ b/src/main/java/com/stucray/limen/audit/dispatch/AuditRegistry.java
@@ -53,7 +53,7 @@ import static com.stucray.limen.audit.dispatch.AuditBinding.IMMEDIATE;
  * {@link Class#isAssignableFrom(Class)}.
  */
 @Component
-public class AuditRegistry {
+class AuditRegistry {
 
     private final List<AuditRule<?>> rules = List.of(
         new AuditRule<>(AuthenticationSuccessEvent.class, "login_success", IMMEDIATE,

--- a/src/main/java/com/stucray/limen/auth/login/TenantLoginAutoConfig.java
+++ b/src/main/java/com/stucray/limen/auth/login/TenantLoginAutoConfig.java
@@ -21,7 +21,7 @@ import java.util.regex.Pattern;
  * intents, so {@code @Order} on a user bean places it ahead of the defaults.
  */
 @Configuration(proxyBeanMethods = false)
-public class TenantLoginAutoConfig {
+class TenantLoginAutoConfig {
 
     @Bean
     TenantUrlScheme oauth2UrlScheme() {

--- a/src/main/java/com/stucray/limen/auth/login/TenantPasswordChangeFlow.java
+++ b/src/main/java/com/stucray/limen/auth/login/TenantPasswordChangeFlow.java
@@ -45,7 +45,7 @@ import java.util.Objects;
  * surface.
  */
 @Component
-public class TenantPasswordChangeFlow {
+class TenantPasswordChangeFlow {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;

--- a/src/main/java/com/stucray/limen/auth/ott/CheckInboxController.java
+++ b/src/main/java/com/stucray/limen/auth/ott/CheckInboxController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RequestParam;
  * server behaviour, so a user reloading the page does not retrigger sending.
  */
 @Controller
-public class CheckInboxController {
+class CheckInboxController {
 
     private final TenantRepository tenantRepository;
 

--- a/src/main/java/com/stucray/limen/auth/ott/ForgotPasswordController.java
+++ b/src/main/java/com/stucray/limen/auth/ott/ForgotPasswordController.java
@@ -24,7 +24,7 @@ import java.nio.charset.StandardCharsets;
  * the form is not a user-existence oracle (PRD #120 user story 14).
  */
 @Controller
-public class ForgotPasswordController {
+class ForgotPasswordController {
 
     private final TenantRepository tenantRepository;
     private final OttDispatcher ottDispatcher;

--- a/src/main/java/com/stucray/limen/auth/ott/OttSubmitController.java
+++ b/src/main/java/com/stucray/limen/auth/ott/OttSubmitController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RequestParam;
  * resolved slug.
  */
 @Controller
-public class OttSubmitController {
+class OttSubmitController {
 
     private final TenantRepository tenantRepository;
 

--- a/src/main/java/com/stucray/limen/auth/ott/ResendVerificationController.java
+++ b/src/main/java/com/stucray/limen/auth/ott/ResendVerificationController.java
@@ -24,7 +24,7 @@ import java.nio.charset.StandardCharsets;
  * laid out in PRD #120 story 14.
  */
 @Controller
-public class ResendVerificationController {
+class ResendVerificationController {
 
     private final TenantRepository tenantRepository;
     private final OttDispatcher ottDispatcher;

--- a/src/main/java/com/stucray/limen/auth/ott/TenantOttRoutingFilter.java
+++ b/src/main/java/com/stucray/limen/auth/ott/TenantOttRoutingFilter.java
@@ -34,7 +34,7 @@ import java.util.regex.Pattern;
  */
 @Component
 @Order(Integer.MIN_VALUE + 11)
-public class TenantOttRoutingFilter extends OncePerRequestFilter {
+class TenantOttRoutingFilter extends OncePerRequestFilter {
 
     private static final Pattern TENANT_OTT_PATH =
         Pattern.compile("^/t/([^/]+)/(login/ott|check-inbox|resend-verification|forgot-password)(?:[/?].*)?$");

--- a/src/test/java/com/stucray/limen/architecture/ArchitectureTest.java
+++ b/src/test/java/com/stucray/limen/architecture/ArchitectureTest.java
@@ -1,0 +1,106 @@
+package com.stucray.limen.architecture;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_TESTS;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static java.util.stream.Collectors.toUnmodifiableSet;
+
+/**
+ * Architectural rules enforced at test time. Cycle-freedom is covered by
+ * {@link LimenModuleArchitectureTest} via Spring Modulith's
+ * {@code ApplicationModules.verify()}. Add project-specific rules below;
+ * if a rule is disabled, document the carve-out reason on @Disabled.
+ */
+@DisplayName("Architectural rules hold")
+class ArchitectureTest {
+
+    private static final JavaClasses CLASSES = new ClassFileImporter()
+        .withImportOption(DO_NOT_INCLUDE_TESTS)
+        .importPackages("com.stucray.limen");
+
+    /**
+     * Pre-existing public @Component classes that have legitimate cross-package
+     * consumers (services injected by sibling-module controllers/configs, or
+     * referenced by test fixtures across module boundaries). Locked here as an
+     * explicit carve-out so the rule still catches *new* drift — additions to
+     * this set should justify themselves at PR review.
+     */
+    private static final Set<String> COMPONENTS_PUBLIC_BY_NECESSITY = Set.of(
+        "com.stucray.limen.applications.ApplicationLookup",
+        "com.stucray.limen.applications.ApplicationService",
+        "com.stucray.limen.audit.AuditEventWriter",
+        "com.stucray.limen.auth.TenantAuthProvider",
+        "com.stucray.limen.auth.TenantUserDetailsService",
+        "com.stucray.limen.auth.ott.OttCompletionService",
+        "com.stucray.limen.auth.ott.OttDispatcher",
+        "com.stucray.limen.auth.ott.TenantAwareOneTimeTokenService",
+        "com.stucray.limen.auth.ott.TenantOttAuthenticationProvider",
+        "com.stucray.limen.clients.ClientManagementService",
+        "com.stucray.limen.memberships.ApplicationMembershipService",
+        "com.stucray.limen.memberships.ClientMembershipQuery",
+        "com.stucray.limen.memberships.ClientMembershipService",
+        "com.stucray.limen.memberships.UserMembershipPortfolioQuery",
+        "com.stucray.limen.provisioning.TenantProvisioner",
+        "com.stucray.limen.provisioning.TenantProvisioningService",
+        "com.stucray.limen.roles.RoleManagementService",
+        "com.stucray.limen.roles.RoleResolver",
+        "com.stucray.limen.signup.SignupService",
+        "com.stucray.limen.useradmin.UserAdministrationService"
+    );
+
+    @Test
+    @DisplayName("@Component classes are package-private (except documented cross-package carve-outs)")
+    void componentsArePackagePrivate() {
+        classes().that().areMetaAnnotatedWith(Component.class)
+            .and().areNotMetaAnnotatedWith(Configuration.class)
+            .and(notIn(COMPONENTS_PUBLIC_BY_NECESSITY))
+            .should().notBePublic().check(CLASSES);
+    }
+
+    @Test
+    @DisplayName("@Configuration classes are package-private (except AutoConfigurations)")
+    void configsArePackagePrivate() {
+        Set<String> autoConfigs = readAutoConfigurationImports();
+        classes().that().areAnnotatedWith(Configuration.class)
+            .and(notIn(autoConfigs))
+            .should().notBePublic().check(CLASSES);
+    }
+
+    private static Set<String> readAutoConfigurationImports() {
+        Path imports = Paths.get("src/main/resources/META-INF/spring/"
+            + "org.springframework.boot.autoconfigure.AutoConfiguration.imports");
+        if (!Files.exists(imports)) return Set.of();
+        try (Stream<String> lines = Files.lines(imports)) {
+            return lines.map(String::trim)
+                .filter(l -> !l.isBlank() && !l.startsWith("#"))
+                .collect(toUnmodifiableSet());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static DescribedPredicate<JavaClass> notIn(Set<String> excluded) {
+        return new DescribedPredicate<>("not listed in AutoConfiguration.imports") {
+            @Override
+            public boolean test(JavaClass c) {
+                return !excluded.contains(c.getName());
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Adds an \`ArchitectureTest\` enforcing visibility rules at PR time, plus a Pass 4 of the visibility-reduction work flipping 8 type declarations from public to package-private.

## What landed

**New test file** \`src/test/java/com/stucray/limen/architecture/ArchitectureTest.java\` with two rules:

- \`@Component\` classes are package-private (with documented carve-out for cross-package necessities)
- \`@Configuration\` classes are package-private (with runtime \`AutoConfiguration.imports\` exclusion — empty for Limen since it's an application, not a starter)

Cycle freedom is already covered by \`LimenModuleArchitectureTest\` via Spring Modulith's \`ApplicationModules.verify()\` — the new test deliberately doesn't duplicate it.

**8 type-level flips** (the 8 of 28 audited candidates that narrowed cleanly):

| Module | Class |
|---|---|
| \`audit/dispatch\` | \`AuditRegistry\` |
| \`auth/login\` | \`TenantPasswordChangeFlow\`, \`TenantLoginAutoConfig\` |
| \`auth/ott\` | \`CheckInboxController\`, \`ForgotPasswordController\`, \`OttSubmitController\`, \`ResendVerificationController\`, \`TenantOttRoutingFilter\` |

## What stayed public — the 20 cross-package carve-outs

Locked into \`COMPONENTS_PUBLIC_BY_NECESSITY\` in the test. Each has at least one cross-package consumer (sibling-module controller/config injecting it, or a test fixture referencing it across module boundaries):

\`ApplicationLookup\`, \`ApplicationService\`, \`AuditEventWriter\`, \`TenantAuthProvider\`, \`TenantUserDetailsService\`, \`OttCompletionService\`, \`OttDispatcher\`, \`TenantAwareOneTimeTokenService\`, \`TenantOttAuthenticationProvider\`, \`ClientManagementService\`, \`ApplicationMembershipService\`, \`ClientMembershipQuery\`, \`ClientMembershipService\`, \`UserMembershipPortfolioQuery\`, \`TenantProvisioner\`, \`TenantProvisioningService\`, \`RoleManagementService\`, \`RoleResolver\`, \`SignupService\`, \`UserAdministrationService\`.

The rule still catches *new* drift — additions to the carve-out set must justify themselves at PR review.

## Why no pom change

ArchUnit is already on the test classpath transitively via \`spring-modulith-starter-test\` (Modulith uses ArchUnit internally). No new dependency needed.

## Tooling

Bootstrapped via the new user-level \`bootstrap-archunit\` skill — runs once per project, detects Modulith vs non-Modulith, generates the test scaffold. The carve-out list above was added by hand based on what the initial test run surfaced.

## Test plan
- [x] \`mvn -B -ntp clean verify\` — green
- [x] \`mvn -B -ntp -Dtest=ArchitectureTest test\` — both rules pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)