### PR TITLE
refactor: flip UserAdministrationService.createUser package-private (test-arch PR 1/4)

### DIFF
--- a/src/main/java/com/stucray/limen/useradmin/UserAdministrationService.java
+++ b/src/main/java/com/stucray/limen/useradmin/UserAdministrationService.java
@@ -68,7 +68,7 @@ public class UserAdministrationService {
 
     @Transactional
     @SuppressWarnings("NullAway") // Spring Data convention: null id on insert; populated on save
-    public void createUser(Long tenantId, Long actorUserId, String email, String temporaryPassword) {
+    void createUser(Long tenantId, Long actorUserId, String email, String temporaryPassword) {
         if (userRepository.existsByEmailAndTenantId(email, tenantId)) {
             throw new IllegalArgumentException("Email already exists in this tenant");
         }

--- a/src/test/java/com/stucray/limen/useradmin/EmailUniquenessIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/useradmin/EmailUniquenessIntegrationTest.java
@@ -1,10 +1,11 @@
-package com.stucray.limen.user;
+package com.stucray.limen.useradmin;
 
 import com.stucray.limen.TestcontainersConfiguration;
-import com.stucray.limen.useradmin.UserAdministrationService;
 import com.stucray.limen.tenant.Tenant;
 import com.stucray.limen.provisioning.TenantProvisioningService;
 import com.stucray.limen.tenant.TenantRepository;
+import com.stucray.limen.user.User;
+import com.stucray.limen.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## Summary

PR 1 of 4 in a test-architecture refactor. The aim across the series: stop widening service visibility for cross-package integration tests, by routing fixture state through repositories and SUT-relevant calls through MockMvc.

This PR:

- Relocates \`EmailUniquenessIntegrationTest\` from \`com.stucray.limen.user\` to \`com.stucray.limen.useradmin\`. The test's real subject is the per-tenant email-uniqueness contract on \`UserAdministrationService\`; it was misfiled.
- Flips \`UserAdministrationService.createUser\` from \`public\` to package-private. With the test relocated, no cross-package caller remains.

### Why

\`createUser\` has a production-scenario contract (requires \`actorUserId\`, hardcodes \`forcePasswordChange=true\`, publishes \`UserCreatedEvent\`) that's correct for production but actively wrong for fixture setup. \`TestTenantFactory\` already bypasses it for that reason — admin/end-user/sysadmin/forced-change seeding all goes through \`userRepository.save\` directly. The single cross-package test that did call \`createUser\` was testing the contract itself, not using it as a fixture, so co-locating it in \`useradmin/\` is the right structural fix.

## Test plan

- [x] \`mvn clean verify\` — 451 unit + 15 UI tests pass
- [x] Relocated test runs successfully in its new package and asserts the same behaviour (rename diff is 97% similarity)
- [ ] Reviewer confirms the test belongs in \`useradmin/\` (it tests \`UserAdministrationService\`, not \`User\`)

## Follow-ups (not this PR)

- PR 2/4: \`createApplication\` package-private — \`TestTenantFactory.seedApplication\` switches to \`applicationRepository.save\`, \`AuditEventEmitIntegrationTest\` switches to MockMvc.
- PR 3/4: \`createClient\` package-private — 5 fixture-use tests switch to direct \`RegisteredClientRepository\` + \`TenantClientRepository\` writes; \`AuditEventEmitIntegrationTest\` switches to MockMvc.
- PR 4/4: ArchUnit rule — public \`@Service\` methods must have a main-classpath cross-package caller (with carve-outs for interface impls, \`@EventListener\`, \`@Scheduled\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)