### PR TITLE
refactor: flip ApplicationService.createApplication package-private (test-arch PR 2/4)

### DIFF
--- a/src/main/java/com/stucray/limen/applications/ApplicationService.java
+++ b/src/main/java/com/stucray/limen/applications/ApplicationService.java
@@ -27,7 +27,7 @@ public class ApplicationService {
     }
 
     @SuppressWarnings("NullAway") // Spring Data convention: null id on insert; populated on save
-    public Application createApplication(Long tenantId, String name, String description) {
+    Application createApplication(Long tenantId, String name, String description) {
         if (applicationRepository.existsByNameAndTenantId(name, tenantId)) {
             throw new IllegalArgumentException("An application named '" + name + "' already exists in this tenant");
         }

--- a/src/test/java/com/stucray/limen/audit/AuditEventEmitIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/audit/AuditEventEmitIntegrationTest.java
@@ -4,7 +4,7 @@ import com.stucray.limen.clients.CreateClientCommand;
 
 import com.stucray.limen.TestcontainersConfiguration;
 import com.stucray.limen.applications.Application;
-import com.stucray.limen.applications.ApplicationService;
+import com.stucray.limen.applications.ApplicationRepository;
 import com.stucray.limen.clients.ClientManagementService;
 import com.stucray.limen.useradmin.UserAdministrationService;
 import com.stucray.limen.tenant.Tenant;
@@ -54,7 +54,7 @@ class AuditEventEmitIntegrationTest {
     @Autowired UserAdministrationService userAdministration;
     @Autowired UserRepository userRepository;
     @Autowired ClientManagementService clientManagementService;
-    @Autowired ApplicationService applicationService;
+    @Autowired ApplicationRepository applicationRepository;
     @Autowired PasswordEncoder passwordEncoder;
     @Autowired JdbcTemplate jdbcTemplate;
 
@@ -130,7 +130,8 @@ class AuditEventEmitIntegrationTest {
     void clientSecretRotationEmitsAuditRow() {
         Tenant tenant = tenantProvisioningService.createTenant(uniqueSlug(), "X");
         long actor = seedSystemAdminId();
-        Application app = applicationService.createApplication(tenant.id(), "App " + uniqueSlug(), null);
+        Application app = applicationRepository.save(
+            new Application(null, tenant.id(), "App " + uniqueSlug(), null, LocalDateTime.now()));
         String registeredClientId = clientManagementService.createClient(new CreateClientCommand(
             app.id(), tenant.id(), "Client",
             Set.of(AuthorizationGrantType.CLIENT_CREDENTIALS),

--- a/src/test/java/com/stucray/limen/ui/support/TestTenantFactory.java
+++ b/src/test/java/com/stucray/limen/ui/support/TestTenantFactory.java
@@ -1,7 +1,7 @@
 package com.stucray.limen.ui.support;
 
 import com.stucray.limen.applications.Application;
-import com.stucray.limen.applications.ApplicationService;
+import com.stucray.limen.applications.ApplicationRepository;
 import com.stucray.limen.clients.TenantClient;
 import com.stucray.limen.clients.TenantClientRepository;
 import com.stucray.limen.memberships.ApplicationMembershipService;
@@ -46,7 +46,7 @@ public class TestTenantFactory {
     private final TenantRepository tenantRepository;
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
-    private final ApplicationService applicationService;
+    private final ApplicationRepository applicationRepository;
     private final RegisteredClientRepository registeredClientRepository;
     private final TenantClientRepository tenantClientRepository;
     private final ApplicationMembershipService applicationMembershipService;
@@ -57,7 +57,7 @@ public class TestTenantFactory {
         TenantRepository tenantRepository,
         UserRepository userRepository,
         PasswordEncoder passwordEncoder,
-        ApplicationService applicationService,
+        ApplicationRepository applicationRepository,
         RegisteredClientRepository registeredClientRepository,
         TenantClientRepository tenantClientRepository,
         ApplicationMembershipService applicationMembershipService,
@@ -67,18 +67,21 @@ public class TestTenantFactory {
         this.tenantRepository = tenantRepository;
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
-        this.applicationService = applicationService;
+        this.applicationRepository = applicationRepository;
         this.registeredClientRepository = registeredClientRepository;
         this.tenantClientRepository = tenantClientRepository;
         this.applicationMembershipService = applicationMembershipService;
         this.clientMembershipService = clientMembershipService;
     }
 
+    @SuppressWarnings("NullAway") // Spring Data convention: null id on insert; populated on save
     @Transactional
     public SeededApplication seedApplication(SeededTenant tenant) {
         String suffix = uniqueSuffix();
         String name = "App " + suffix;
-        Application app = applicationService.createApplication(tenant.tenantId(), name, "Seeded for UI test");
+        Application app = applicationRepository.save(
+            new Application(null, tenant.tenantId(), name, "Seeded for UI test", LocalDateTime.now())
+        );
         return new SeededApplication(app.id(), name);
     }
 


### PR DESCRIPTION
## Summary

PR 2 of 4 in the test-architecture refactor (PR 1 was #235).

This PR removes the test-driven public surface on \`ApplicationService.createApplication\` by switching its two cross-package fixture callers to repository writes.

### Changes

- **\`TestTenantFactory.seedApplication\`** — replaces \`applicationService.createApplication(...)\` with \`applicationRepository.save(new Application(...))\`. Joins the user/sysadmin/forced-change seeding paths that already bypass services in this file.
- **\`AuditEventEmitIntegrationTest\`** — replaces the create call in \`clientSecretRotationEmitsAuditRow\` with the same repo-write pattern. The SUT for that test is \`rotateSecret\`; the Application is fixture state.
- **\`ApplicationService.createApplication\`** — flipped \`public\` → package-private. The same-package \`ApplicationController\` is unaffected.

### Plan deviation worth flagging

The plan said the audit test's create call would switch to MockMvc through \`ApplicationController\` because I assumed the create→event→audit binding was the SUT. After reading the test, the only audit binding it actually asserts on is \`ClientSecretRotatedEvent\` from \`rotateSecret\`. The create call is fixture, not SUT, so a repo write is the correct structural fix. PR 3 is likely to surface the same simplification on the createClient side.

## Test plan

- [x] \`mvn clean verify\` — 451 unit + 15 UI tests pass
- [x] \`TestTenantFactory.seedApplication\` still produces an \`Application\` row with the expected name, description and tenant FK
- [x] \`clientSecretRotationEmitsAuditRow\` still observes the audit row (no behavioural change to the SUT)

## Follow-ups (not this PR)

- PR 3/4: \`createClient\` package-private — 5 fixture-use tests + AuditEventEmit's createClient surface switch to direct \`RegisteredClientRepository\` + \`TenantClientRepository\` writes.
- PR 4/4: ArchUnit rule + drop the now-broken \"exercises production code paths\" claim from \`TestTenantFactory\`'s Javadoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)