### PR TITLE
refactor: flip ClientManagementService.createClient package-private (test-arch PR 3/4)

### DIFF
--- a/src/main/java/com/stucray/limen/clients/ClientManagementService.java
+++ b/src/main/java/com/stucray/limen/clients/ClientManagementService.java
@@ -59,7 +59,7 @@ public class ClientManagementService {
     ) {}
 
     @SuppressWarnings("NullAway") // Spring Data convention: null id on insert; populated on save
-    public ClientCreationResult createClient(CreateClientCommand cmd) {
+    ClientCreationResult createClient(CreateClientCommand cmd) {
         String rawSecret = null;
         String hashedSecret = null;
         if (cmd.confidential()) {

--- a/src/test/java/com/stucray/limen/audit/AuditEventEmitIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/audit/AuditEventEmitIntegrationTest.java
@@ -1,11 +1,11 @@
 package com.stucray.limen.audit;
 
-import com.stucray.limen.clients.CreateClientCommand;
-
 import com.stucray.limen.TestcontainersConfiguration;
 import com.stucray.limen.applications.Application;
 import com.stucray.limen.applications.ApplicationRepository;
 import com.stucray.limen.clients.ClientManagementService;
+import com.stucray.limen.clients.TenantClient;
+import com.stucray.limen.clients.TenantClientRepository;
 import com.stucray.limen.useradmin.UserAdministrationService;
 import com.stucray.limen.tenant.Tenant;
 import com.stucray.limen.provisioning.TenantProvisioningService;
@@ -14,6 +14,11 @@ import com.stucray.limen.tenant.TenantStatus;
 import com.stucray.limen.user.User;
 import com.stucray.limen.user.UserRepository;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.oidc.OidcScopes;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -26,7 +31,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
 
@@ -55,6 +59,8 @@ class AuditEventEmitIntegrationTest {
     @Autowired UserRepository userRepository;
     @Autowired ClientManagementService clientManagementService;
     @Autowired ApplicationRepository applicationRepository;
+    @Autowired RegisteredClientRepository registeredClientRepository;
+    @Autowired TenantClientRepository tenantClientRepository;
     @Autowired PasswordEncoder passwordEncoder;
     @Autowired JdbcTemplate jdbcTemplate;
 
@@ -132,13 +138,7 @@ class AuditEventEmitIntegrationTest {
         long actor = seedSystemAdminId();
         Application app = applicationRepository.save(
             new Application(null, tenant.id(), "App " + uniqueSlug(), null, LocalDateTime.now()));
-        String registeredClientId = clientManagementService.createClient(new CreateClientCommand(
-            app.id(), tenant.id(), "Client",
-            Set.of(AuthorizationGrantType.CLIENT_CREDENTIALS),
-            Set.of(), Set.of(), Set.of("openid"),
-            false, true,
-            5, 30, false
-        )).client().registeredClientId();
+        String registeredClientId = seedConfidentialClient(app.id(), tenant.id(), "Client");
 
         clientManagementService.rotateSecret(registeredClientId, tenant.id(), actor);
 
@@ -220,6 +220,28 @@ class AuditEventEmitIntegrationTest {
             null, system.id(), email, passwordEncoder.encode("pw"),
             true, false, false, true, LocalDateTime.now()));
         return admin.id();
+    }
+
+    @SuppressWarnings("NullAway") // Spring Data convention: null id on insert; populated on save
+    private String seedConfidentialClient(Long applicationId, Long tenantId, String name) {
+        String registeredClientId = UUID.randomUUID().toString();
+        String rawSecret = UUID.randomUUID().toString();
+        RegisteredClient rc = RegisteredClient.withId(registeredClientId)
+            .clientId(UUID.randomUUID().toString())
+            .clientName(name)
+            .clientSecret(passwordEncoder.encode(rawSecret))
+            .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+            .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
+            .scope(OidcScopes.OPENID)
+            .clientSettings(ClientSettings.builder()
+                .requireProofKey(false)
+                .requireAuthorizationConsent(true)
+                .build())
+            .build();
+        registeredClientRepository.save(rc);
+        tenantClientRepository.save(new TenantClient(
+            null, registeredClientId, applicationId, tenantId, name, true));
+        return registeredClientId;
     }
 
     private @org.jspecify.annotations.Nullable Map<String, Object> latestEventForTenant(Long tenantId) {

--- a/src/test/java/com/stucray/limen/memberships/ClientMembersControllerIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/memberships/ClientMembersControllerIntegrationTest.java
@@ -1,12 +1,10 @@
 package com.stucray.limen.memberships;
 
-import com.stucray.limen.clients.CreateClientCommand;
-
 import com.stucray.limen.TestcontainersConfiguration;
 import com.stucray.limen.applications.Application;
 import com.stucray.limen.applications.ApplicationRepository;
-import com.stucray.limen.clients.ClientManagementService;
 import com.stucray.limen.clients.TenantClient;
+import com.stucray.limen.clients.TenantClientRepository;
 import com.stucray.limen.roles.Role;
 import com.stucray.limen.roles.RoleRepository;
 import com.stucray.limen.tenant.Tenant;
@@ -25,11 +23,17 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.oidc.OidcScopes;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 import java.time.LocalDateTime;
 import java.util.Set;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -52,7 +56,8 @@ class ClientMembersControllerIntegrationTest {
     @Autowired RoleRepository roleRepository;
     @Autowired ApplicationMembershipRepository appMembershipRepository;
     @Autowired ClientMembershipRepository clientMembershipRepository;
-    @Autowired ClientManagementService clientManagementService;
+    @Autowired RegisteredClientRepository registeredClientRepository;
+    @Autowired TenantClientRepository tenantClientRepository;
     @Autowired PasswordEncoder passwordEncoder;
     @Autowired JdbcTemplate jdbcTemplate;
 
@@ -80,12 +85,7 @@ class ClientMembersControllerIntegrationTest {
         ownerA = userRepository.save(new User(null, tenantA.id(), "owner@example.test", passwordEncoder.encode("pass"), true, false, true, true,  LocalDateTime.now()));
         aliceA = userRepository.save(new User(null, tenantA.id(), "alice@example.test", passwordEncoder.encode("pass"), true, false, false, true, LocalDateTime.now()));
         appA = applicationRepository.save(new Application(null, tenantA.id(), "App A", "desc", LocalDateTime.now()));
-        clientA = clientManagementService.createClient(new CreateClientCommand(
-            appA.id(), tenantA.id(), "client-a",
-            Set.of(AuthorizationGrantType.AUTHORIZATION_CODE),
-            Set.of("http://localhost/callback"), Set.of(), Set.of("openid"),
-            false, true, 5, 30, false
-        )).client();
+        clientA = seedPublicClient(appA.id(), tenantA.id(), "client-a");
 
         MvcResult login = mockMvc.perform(post("/manage/t/client-mem-a/login")
                 .param("email", "owner@example.test").param("password", "pass").with(csrf()))
@@ -272,5 +272,25 @@ class ClientMembersControllerIntegrationTest {
             .andExpect(content().string(org.hamcrest.Matchers.containsString(
                 url("/members")
             )));
+    }
+
+    @SuppressWarnings("NullAway") // Spring Data convention: null id on insert; populated on save
+    private TenantClient seedPublicClient(Long applicationId, Long tenantId, String name) {
+        String registeredClientId = UUID.randomUUID().toString();
+        RegisteredClient rc = RegisteredClient.withId(registeredClientId)
+            .clientId(UUID.randomUUID().toString())
+            .clientName(name)
+            .clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .redirectUri("http://localhost/callback")
+            .scope(OidcScopes.OPENID)
+            .clientSettings(ClientSettings.builder()
+                .requireProofKey(true)
+                .requireAuthorizationConsent(true)
+                .build())
+            .build();
+        registeredClientRepository.save(rc);
+        return tenantClientRepository.save(new TenantClient(
+            null, registeredClientId, applicationId, tenantId, name, false));
     }
 }

--- a/src/test/java/com/stucray/limen/memberships/ClientMembershipQueryIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/memberships/ClientMembershipQueryIntegrationTest.java
@@ -1,12 +1,10 @@
 package com.stucray.limen.memberships;
 
-import com.stucray.limen.clients.CreateClientCommand;
-
 import com.stucray.limen.TestcontainersConfiguration;
 import com.stucray.limen.applications.Application;
 import com.stucray.limen.applications.ApplicationRepository;
-import com.stucray.limen.clients.ClientManagementService;
 import com.stucray.limen.clients.TenantClient;
+import com.stucray.limen.clients.TenantClientRepository;
 import com.stucray.limen.roles.Role;
 import com.stucray.limen.roles.RoleRepository;
 import com.stucray.limen.tenant.Tenant;
@@ -22,10 +20,16 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.oidc.OidcScopes;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -38,7 +42,8 @@ class ClientMembershipQueryIntegrationTest {
     @Autowired ClientMembershipService clientMembershipService;
     @Autowired ApplicationMembershipService applicationMembershipService;
     @Autowired ApplicationRepository applicationRepository;
-    @Autowired ClientManagementService clientManagementService;
+    @Autowired RegisteredClientRepository registeredClientRepository;
+    @Autowired TenantClientRepository tenantClientRepository;
     @Autowired RoleRepository roleRepository;
     @Autowired TenantRepository tenantRepository;
     @Autowired UserRepository userRepository;
@@ -79,14 +84,24 @@ class ClientMembershipQueryIntegrationTest {
         clientB = createClient(appB.id(), tenantB.id(), "client-b");
     }
 
+    @SuppressWarnings("NullAway") // Spring Data convention: null id on insert; populated on save
     private TenantClient createClient(Long applicationId, Long tenantId, String name) {
-        ClientManagementService.ClientCreationResult result = clientManagementService.createClient(new CreateClientCommand(
-            applicationId, tenantId, name,
-            Set.of(AuthorizationGrantType.AUTHORIZATION_CODE),
-            Set.of("http://localhost/callback"), Set.of(), Set.of("openid"),
-            false, true, 5, 30, false
-        ));
-        return result.client();
+        String registeredClientId = UUID.randomUUID().toString();
+        RegisteredClient rc = RegisteredClient.withId(registeredClientId)
+            .clientId(UUID.randomUUID().toString())
+            .clientName(name)
+            .clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .redirectUri("http://localhost/callback")
+            .scope(OidcScopes.OPENID)
+            .clientSettings(ClientSettings.builder()
+                .requireProofKey(true)
+                .requireAuthorizationConsent(true)
+                .build())
+            .build();
+        registeredClientRepository.save(rc);
+        return tenantClientRepository.save(new TenantClient(
+            null, registeredClientId, applicationId, tenantId, name, false));
     }
 
     @Test

--- a/src/test/java/com/stucray/limen/memberships/ClientMembershipServiceIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/memberships/ClientMembershipServiceIntegrationTest.java
@@ -1,7 +1,5 @@
 package com.stucray.limen.memberships;
 
-import com.stucray.limen.clients.CreateClientCommand;
-
 import com.stucray.limen.TestcontainersConfiguration;
 import com.stucray.limen.applications.Application;
 import com.stucray.limen.applications.ApplicationRepository;
@@ -24,9 +22,15 @@ import org.springframework.context.annotation.Import;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.oidc.OidcScopes;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
 
 import java.time.LocalDateTime;
 import java.util.Set;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -42,6 +46,7 @@ class ClientMembershipServiceIntegrationTest {
     @Autowired ApplicationMembershipRepository applicationMembershipRepository;
     @Autowired ApplicationRepository applicationRepository;
     @Autowired ClientManagementService clientManagementService;
+    @Autowired RegisteredClientRepository registeredClientRepository;
     @Autowired TenantClientRepository tenantClientRepository;
     @Autowired RoleRepository roleRepository;
     @Autowired TenantRepository tenantRepository;
@@ -87,14 +92,24 @@ class ClientMembershipServiceIntegrationTest {
         clientB  = createClient(appB.id(),  tenantB.id(), "client-b");
     }
 
+    @SuppressWarnings("NullAway") // Spring Data convention: null id on insert; populated on save
     private TenantClient createClient(Long applicationId, Long tenantId, String name) {
-        ClientManagementService.ClientCreationResult result = clientManagementService.createClient(new CreateClientCommand(
-            applicationId, tenantId, name,
-            Set.of(AuthorizationGrantType.AUTHORIZATION_CODE),
-            Set.of("http://localhost/callback"), Set.of(), Set.of("openid"),
-            false, true, 5, 30, false
-        ));
-        return result.client();
+        String registeredClientId = UUID.randomUUID().toString();
+        RegisteredClient rc = RegisteredClient.withId(registeredClientId)
+            .clientId(UUID.randomUUID().toString())
+            .clientName(name)
+            .clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .redirectUri("http://localhost/callback")
+            .scope(OidcScopes.OPENID)
+            .clientSettings(ClientSettings.builder()
+                .requireProofKey(true)
+                .requireAuthorizationConsent(true)
+                .build())
+            .build();
+        registeredClientRepository.save(rc);
+        return tenantClientRepository.save(new TenantClient(
+            null, registeredClientId, applicationId, tenantId, name, false));
     }
 
     @Test

--- a/src/test/java/com/stucray/limen/oauth2/TenantOAuth2RoutingIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/oauth2/TenantOAuth2RoutingIntegrationTest.java
@@ -1,7 +1,5 @@
 package com.stucray.limen.oauth2;
 
-import com.stucray.limen.clients.CreateClientCommand;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.jwk.JWK;
@@ -12,8 +10,6 @@ import com.nimbusds.jwt.SignedJWT;
 import com.stucray.limen.TestcontainersConfiguration;
 import com.stucray.limen.applications.Application;
 import com.stucray.limen.applications.ApplicationRepository;
-import com.stucray.limen.clients.ClientManagementService;
-import com.stucray.limen.clients.ClientManagementService.ClientCreationResult;
 import com.stucray.limen.clients.TenantClient;
 import com.stucray.limen.clients.TenantClientRepository;
 import com.stucray.limen.memberships.ApplicationMembershipService;
@@ -73,7 +69,6 @@ class TenantOAuth2RoutingIntegrationTest {
     @Autowired TenantRepository tenantRepository;
     @Autowired TenantProvisioningService tenantProvisioningService;
     @Autowired ApplicationRepository applicationRepository;
-    @Autowired ClientManagementService clientManagementService;
     @Autowired RegisteredClientRepository registeredClientRepository;
     @Autowired TenantClientRepository tenantClientRepository;
     @Autowired UserRepository userRepository;
@@ -147,13 +142,7 @@ class TenantOAuth2RoutingIntegrationTest {
     @Test
     @DisplayName("client_credentials token flow at /t/{slug}/oauth2/token succeeds for a client created under that tenant")
     void clientCredentialsTokenFlowSucceedsForTenantClient() throws Exception {
-        ClientCreationResult result = clientManagementService.createClient(new CreateClientCommand(
-            alphaApp.id(), alphaCorpTenant.id(),
-            "m2m-client",
-            Set.of(AuthorizationGrantType.CLIENT_CREDENTIALS),
-            Set.of(), Set.of(), Set.of("read"),
-            false, true, 5, 30, false
-        ));
+        SeededConfidentialClient result = seedConfidentialClient(alphaApp.id(), alphaCorpTenant.id(), "m2m-client");
 
         String clientId = result.client().registeredClientId();
         String rawSecret = result.rawSecret();
@@ -180,13 +169,7 @@ class TenantOAuth2RoutingIntegrationTest {
     @DisplayName("A client registered under tenant alpha cannot exchange credentials at tenant beta's /oauth2/token — the request is rejected as 401")
     void crossTenantClientRejected() throws Exception {
         // Register a client under alpha-corp
-        ClientCreationResult result = clientManagementService.createClient(new CreateClientCommand(
-            alphaApp.id(), alphaCorpTenant.id(),
-            "alpha-m2m",
-            Set.of(AuthorizationGrantType.CLIENT_CREDENTIALS),
-            Set.of(), Set.of(), Set.of("read"),
-            false, true, 5, 30, false
-        ));
+        SeededConfidentialClient result = seedConfidentialClient(alphaApp.id(), alphaCorpTenant.id(), "alpha-m2m");
 
         String clientId = result.client().registeredClientId();
         String rawSecret = result.rawSecret();
@@ -207,13 +190,7 @@ class TenantOAuth2RoutingIntegrationTest {
     @Test
     @DisplayName("client_credentials access token carries tenant + iss claims and an empty roles array")
     void clientCredentialsTokenIncludesTenantAndRolesClaims() throws Exception {
-        ClientCreationResult result = clientManagementService.createClient(new CreateClientCommand(
-            alphaApp.id(), alphaCorpTenant.id(),
-            "claims-m2m",
-            Set.of(AuthorizationGrantType.CLIENT_CREDENTIALS),
-            Set.of(), Set.of(), Set.of("read"),
-            false, true, 5, 30, false
-        ));
+        SeededConfidentialClient result = seedConfidentialClient(alphaApp.id(), alphaCorpTenant.id(), "claims-m2m");
 
         String oauthClientId = jdbcTemplate.queryForObject(
             "SELECT client_id FROM oauth2_registered_client WHERE id = ?",
@@ -341,13 +318,7 @@ class TenantOAuth2RoutingIntegrationTest {
     @Test
     @DisplayName("Each tenant's JWKS endpoint serves only its own signing keys — alpha's token verifies against alpha's JWKS but not beta's")
     void tenantJwksEndpointsServeIsolatedKeys() throws Exception {
-        ClientCreationResult result = clientManagementService.createClient(new CreateClientCommand(
-            alphaApp.id(), alphaCorpTenant.id(),
-            "isolation-m2m",
-            Set.of(AuthorizationGrantType.CLIENT_CREDENTIALS),
-            Set.of(), Set.of(), Set.of("read"),
-            false, true, 5, 30, false
-        ));
+        SeededConfidentialClient result = seedConfidentialClient(alphaApp.id(), alphaCorpTenant.id(), "isolation-m2m");
         String oauthClientId = jdbcTemplate.queryForObject(
             "SELECT client_id FROM oauth2_registered_client WHERE id = ?",
             String.class, result.client().registeredClientId()
@@ -473,5 +444,29 @@ class TenantOAuth2RoutingIntegrationTest {
                 .header("Authorization", "Bearer " + accessToken))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.sub").isNotEmpty());
+    }
+
+    private record SeededConfidentialClient(TenantClient client, String rawSecret) {}
+
+    @SuppressWarnings("NullAway") // Spring Data convention: null id on insert; populated on save
+    private SeededConfidentialClient seedConfidentialClient(Long applicationId, Long tenantId, String name) {
+        String registeredClientId = UUID.randomUUID().toString();
+        String rawSecret = UUID.randomUUID().toString();
+        RegisteredClient rc = RegisteredClient.withId(registeredClientId)
+            .clientId(UUID.randomUUID().toString())
+            .clientName(name)
+            .clientSecret(passwordEncoder.encode(rawSecret))
+            .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+            .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
+            .scope("read")
+            .clientSettings(ClientSettings.builder()
+                .requireProofKey(false)
+                .requireAuthorizationConsent(true)
+                .build())
+            .build();
+        registeredClientRepository.save(rc);
+        TenantClient tc = tenantClientRepository.save(new TenantClient(
+            null, registeredClientId, applicationId, tenantId, name, true));
+        return new SeededConfidentialClient(tc, rawSecret);
     }
 }

--- a/src/test/java/com/stucray/limen/useradmin/UserDetailControllerIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/useradmin/UserDetailControllerIntegrationTest.java
@@ -1,12 +1,10 @@
 package com.stucray.limen.useradmin;
 
-import com.stucray.limen.clients.CreateClientCommand;
-
 import com.stucray.limen.TestcontainersConfiguration;
 import com.stucray.limen.applications.Application;
 import com.stucray.limen.applications.ApplicationRepository;
-import com.stucray.limen.clients.ClientManagementService;
 import com.stucray.limen.clients.TenantClient;
+import com.stucray.limen.clients.TenantClientRepository;
 import com.stucray.limen.memberships.ApplicationMembership;
 import com.stucray.limen.memberships.ApplicationMembershipRepository;
 import com.stucray.limen.memberships.ApplicationMembershipRole;
@@ -31,11 +29,17 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.oidc.OidcScopes;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 import java.time.LocalDateTime;
 import java.util.Set;
+import java.util.UUID;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
@@ -59,7 +63,8 @@ class UserDetailControllerIntegrationTest {
     @Autowired RoleRepository roleRepository;
     @Autowired ApplicationMembershipRepository appMembershipRepository;
     @Autowired ClientMembershipRepository clientMembershipRepository;
-    @Autowired ClientManagementService clientManagementService;
+    @Autowired RegisteredClientRepository registeredClientRepository;
+    @Autowired TenantClientRepository tenantClientRepository;
     @Autowired PasswordEncoder passwordEncoder;
     @Autowired JdbcTemplate jdbcTemplate;
 
@@ -87,12 +92,7 @@ class UserDetailControllerIntegrationTest {
         ownerA = userRepository.save(new User(null, tenantA.id(), "owner@example.test", passwordEncoder.encode("pass"), true, false, true, true,  LocalDateTime.now()));
         aliceA = userRepository.save(new User(null, tenantA.id(), "alice@example.test", passwordEncoder.encode("pass"), true, false, false, true, LocalDateTime.now()));
         appA = applicationRepository.save(new Application(null, tenantA.id(), "Acme Web", "desc", LocalDateTime.now()));
-        clientA = clientManagementService.createClient(new CreateClientCommand(
-            appA.id(), tenantA.id(), "acme-spa",
-            Set.of(AuthorizationGrantType.AUTHORIZATION_CODE),
-            Set.of("http://localhost/callback"), Set.of(), Set.of("openid"),
-            false, true, 5, 30, false
-        )).client();
+        clientA = seedPublicClient(appA.id(), tenantA.id(), "acme-spa");
 
         MvcResult login = mockMvc.perform(post("/manage/t/user-detail-a/login")
                 .param("email", "owner@example.test").param("password", "pass").with(csrf()))
@@ -198,5 +198,25 @@ class UserDetailControllerIntegrationTest {
             .andExpect(status().isOk())
             .andExpect(content().string(containsString("No Memberships yet")))
             .andExpect(content().string(not(containsString("Acme Web"))));
+    }
+
+    @SuppressWarnings("NullAway") // Spring Data convention: null id on insert; populated on save
+    private TenantClient seedPublicClient(Long applicationId, Long tenantId, String name) {
+        String registeredClientId = UUID.randomUUID().toString();
+        RegisteredClient rc = RegisteredClient.withId(registeredClientId)
+            .clientId(UUID.randomUUID().toString())
+            .clientName(name)
+            .clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .redirectUri("http://localhost/callback")
+            .scope(OidcScopes.OPENID)
+            .clientSettings(ClientSettings.builder()
+                .requireProofKey(true)
+                .requireAuthorizationConsent(true)
+                .build())
+            .build();
+        registeredClientRepository.save(rc);
+        return tenantClientRepository.save(new TenantClient(
+            null, registeredClientId, applicationId, tenantId, name, false));
     }
 }


### PR DESCRIPTION
## Summary

PR 3 of 4 (PRs 1 and 2: #235, #236).

Six cross-package tests called \`createClient\` for fixture setup. Each switches to direct \`RegisteredClientRepository.save\` + \`TenantClientRepository.save\` via a private per-test helper, mirroring the pattern \`TestTenantFactory.seedOAuth2ClientForEndUser\` already uses. With all cross-package callers gone, \`ClientManagementService.createClient\` flips package-private.

### Per-test changes

| Test | Helper | Calls |
|---|---|---|
| \`UserDetailControllerIntegrationTest\` | \`seedPublicClient\` | 1 |
| \`ClientMembersControllerIntegrationTest\` | \`seedPublicClient\` | 1 |
| \`ClientMembershipServiceIntegrationTest\` | \`createClient\` (existing helper rewritten) | 3 |
| \`ClientMembershipQueryIntegrationTest\` | \`createClient\` (existing helper rewritten) | 2 |
| \`TenantOAuth2RoutingIntegrationTest\` | \`seedConfidentialClient\` + \`SeededConfidentialClient\` record | 4 |
| \`AuditEventEmitIntegrationTest\` | \`seedConfidentialClient\` | 1 |

Same-package callers — \`ClientManagementController\`, \`ClientManagementIntegrationTest\`, \`ClientTokenSettingsIntegrationTest\` — are unaffected by the visibility flip.

### Plan deviations worth flagging

- **Audit test stays repo-driven.** The plan said the audit test's \`createClient\` would switch to MockMvc through \`ClientManagementController\`. On reading, the call is fixture for the \`rotateSecret\` SUT, not the create→event binding. Repo write is the correct structural fix. (Same simplification flagged in PR #236.)
- **\`ClientMembershipServiceIntegrationTest\` retains \`@Autowired ClientManagementService\`.** One residual call (\`clientManagementService.deleteClient\` at line 311) keeps the autowire alive. That's a different cross-package smell with the same shape — out of scope for this PR; trivially follow-up-able.
- **Per-test helpers, not a shared \`ClientTestFixture\`.** Going with per-test private helpers stays consistent with the \"no service wrappers\" decision from the grill-out, even though it duplicates the SAS \`RegisteredClient.builder\` boilerplate across 5 helpers (~120 lines total of helper code). A consolidation into a single \`clients/ClientTestFixture\` would be a small follow-up if the duplication is bothering anyone — it's compositional repo-write sugar, not a service-shape wrapper, so it doesn't cross the line we drew.

## Test plan

- [x] \`mvn clean verify\` — 451 unit + 15 UI tests pass
- [x] All 6 affected tests still observe their original assertions (membership cascades, OAuth2 token issuance, audit row emission, user-detail rendering)

## Follow-ups (not this PR)

- PR 4/4: ArchUnit rule — public \`@Service\` methods must have a main-classpath cross-package caller (carve-outs for interface impls, \`@EventListener\`, \`@ApplicationModuleListener\`, \`@Scheduled\`). Plus drop the now-broken \"exercises production code paths\" claim from \`TestTenantFactory\`'s Javadoc.
- Possible PR 5+: \`deleteClient\` cross-package smell (same shape — one cross-package test caller).
- Possible consolidation: collapse the 5 per-test helpers into \`src/test/java/com/stucray/limen/clients/ClientTestFixture.java\` if duplication grates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)