### PR TITLE
chore: ArchUnit rule — public @Service methods need cross-package main caller (test-arch PR 4/4)

### DIFF
--- a/src/test/java/com/stucray/limen/architecture/ArchitectureTest.java
+++ b/src/test/java/com/stucray/limen/architecture/ArchitectureTest.java
@@ -3,22 +3,35 @@ package com.stucray.limen.architecture;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.EventListener;
+import org.springframework.modulith.events.ApplicationModuleListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.lang.annotation.Annotation;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
 import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_TESTS;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
 import static java.util.stream.Collectors.toUnmodifiableSet;
 
 /**
@@ -80,6 +93,98 @@ class ArchitectureTest {
         classes().that().areAnnotatedWith(Configuration.class)
             .and(notIn(autoConfigs))
             .should().notBePublic().check(CLASSES);
+    }
+
+    /**
+     * Public methods on @Service classes that have NO cross-package caller in the
+     * main classpath as of writing. These have only same-package main callers
+     * (typically a controller) plus a cross-package test caller, and are pending
+     * the same repo-write-or-MockMvc substitution that PRs #235/#236/#237 applied
+     * to the createX factories. Each entry should disappear when its corresponding
+     * test refactor lands.
+     *
+     * <p>Plus one true-public-by-Java entry: {@code loadUserByUsername} implements
+     * Spring Security's {@code UserDetailsService} interface, so Java forces it
+     * public. That entry will not be narrowed; it documents the structural carve-out.
+     */
+    private static final Set<String> SERVICE_METHODS_AWAITING_NARROWING = Set.of(
+        // TODO: ClientMembershipServiceIntegrationTest:311 calls deleteClient cross-package.
+        // Substitute repo writes (mirror PR #237's pattern), then narrow.
+        "com.stucray.limen.clients.ClientManagementService.deleteClient(java.lang.String, java.lang.Long)",
+        // TODO: AuditEventEmitIntegrationTest's clientSecretRotationEmitsAuditRow calls
+        // rotateSecret cross-package. Drive through ClientManagementController via
+        // MockMvc (the rotation IS the SUT here, not fixture), then narrow.
+        "com.stucray.limen.clients.ClientManagementService.rotateSecret(java.lang.String, java.lang.Long, long)",
+        // TODO: EmailVerificationFlowIntegrationTest:197 calls signup cross-package as
+        // tenant fixture setup. Substitute direct TenantRepository.save +
+        // UserRepository.save (same pattern as TestTenantFactory), then narrow.
+        "com.stucray.limen.signup.SignupService.signup(com.stucray.limen.signup.SignupForm)",
+        // TODO: AuditEventEmitIntegrationTest's adminResetPasswordEmitsAuditRow calls
+        // resetPassword cross-package. Drive through UserManagementController via
+        // MockMvc (the reset IS the SUT for this audit test), then narrow.
+        "com.stucray.limen.useradmin.UserAdministrationService.resetPassword("
+            + "java.lang.Long, java.lang.Long, java.lang.Long, java.lang.String)",
+        // Structural exemption: implements Spring Security's UserDetailsService.
+        // Java forces public on interface implementations; this entry will not be narrowed.
+        "com.stucray.limen.auth.TenantUserDetailsService.loadUserByUsername(java.lang.String)"
+    );
+
+    private static final List<Class<? extends Annotation>> REFLECTION_ENTRY_POINT_ANNOTATIONS = List.of(
+        EventListener.class,
+        TransactionalEventListener.class,
+        ApplicationModuleListener.class,
+        Scheduled.class,
+        Async.class
+    );
+
+    @Test
+    @DisplayName("Public methods on @Service classes have a main-classpath cross-package caller")
+    void servicePublicMethodsHaveMainCrossPackageCaller() {
+        methods()
+            .that().areDeclaredInClassesThat().areAnnotatedWith(Service.class)
+            .and().arePublic()
+            .and(notReflectionEntryPoint())
+            .and(methodFullNameNotIn(SERVICE_METHODS_AWAITING_NARROWING))
+            .should(haveCrossPackageCallerInMainClasspath())
+            .check(CLASSES);
+    }
+
+    private static DescribedPredicate<JavaMethod> notReflectionEntryPoint() {
+        return new DescribedPredicate<>("not a Spring reflection entry point") {
+            @Override
+            public boolean test(JavaMethod m) {
+                return REFLECTION_ENTRY_POINT_ANNOTATIONS.stream().noneMatch(m::isAnnotatedWith);
+            }
+        };
+    }
+
+    private static DescribedPredicate<JavaMethod> methodFullNameNotIn(Set<String> excluded) {
+        return new DescribedPredicate<>("not in service-method narrowing-TODO list") {
+            @Override
+            public boolean test(JavaMethod m) {
+                return !excluded.contains(m.getFullName());
+            }
+        };
+    }
+
+    private static ArchCondition<JavaMethod> haveCrossPackageCallerInMainClasspath() {
+        return new ArchCondition<>("have a cross-package caller in the main classpath") {
+            @Override
+            public void check(JavaMethod method, ConditionEvents events) {
+                String declaringPackage = method.getOwner().getPackageName();
+                boolean hasCrossPackageCaller = method.getAccessesToSelf().stream()
+                    .map(access -> access.getOriginOwner().getPackageName())
+                    .anyMatch(pkg -> !pkg.equals(declaringPackage));
+                if (!hasCrossPackageCaller) {
+                    events.add(SimpleConditionEvent.violated(method,
+                        method.getFullName() + " is public on an @Service class but has no main-classpath "
+                            + "cross-package caller. Narrow to package-private, or — if it's only public for "
+                            + "a cross-package test — substitute repo writes / MockMvc in the test and "
+                            + "narrow. Add to SERVICE_METHODS_AWAITING_NARROWING with a TODO if a clean-up "
+                            + "is staged for a follow-up PR."));
+                }
+            }
+        };
     }
 
     private static Set<String> readAutoConfigurationImports() {

--- a/src/test/java/com/stucray/limen/ui/support/TestTenantFactory.java
+++ b/src/test/java/com/stucray/limen/ui/support/TestTenantFactory.java
@@ -33,9 +33,12 @@ import java.util.UUID;
  * so concurrent tests cannot collide on slug/email and no teardown is needed —
  * the Testcontainers Postgres is discarded at JVM exit.
  *
- * <p>Goes through real service-layer code ({@link TenantProvisioningService} +
- * {@link UserRepository} + {@link PasswordEncoder}) rather than raw SQL, so test
- * preconditions exercise the same code paths production uses.
+ * <p>Fixture state is built via repository writes, not service calls. Service contracts
+ * are shaped around production scenarios (require an actor, publish events, hardcode
+ * temporary-password / force-change semantics) — correct for production, wrong for
+ * fixtures. Tests that need to assert on a production code path drive that path
+ * through MockMvc directly in the test class; this factory only produces precondition
+ * state.
  */
 @Component
 public class TestTenantFactory {


### PR DESCRIPTION
## Summary

Final PR in the test-architecture series (PRs 1-3: #235, #236, #237). Locks the gain against drift.

### The rule

\`ArchitectureTest.servicePublicMethodsHaveMainCrossPackageCaller\`: every public method on an \`@Service\` class must have a main-classpath cross-package caller. Carve-outs for Spring reflection entry points: \`@EventListener\`, \`@TransactionalEventListener\`, \`@ApplicationModuleListener\`, \`@Scheduled\`, \`@Async\`.

The rule reuses the existing \`ArchUnit\` infrastructure bootstrapped in PR #234 (Pass 4 type-level visibility). Same \`CLASSES\` import (\`DO_NOT_INCLUDE_TESTS\`), same allow-list pattern as \`COMPONENTS_PUBLIC_BY_NECESSITY\`.

### The unexpected finding

The rule surfaced **3 additional violations** beyond the deferred \`deleteClient\` case I went in expecting:

| Method | Cross-package test caller | Status |
|---|---|---|
| \`ClientManagementService.deleteClient\` | \`ClientMembershipServiceIntegrationTest:311\` | TODO (deferred to follow-up at user request 2026-05-09) |
| \`ClientManagementService.rotateSecret\` | \`AuditEventEmitIntegrationTest\` (rotation IS the SUT) | TODO — drive through MockMvc |
| \`SignupService.signup\` | \`EmailVerificationFlowIntegrationTest:197\` (fixture setup) | TODO — substitute repo writes |
| \`UserAdministrationService.resetPassword\` | \`AuditEventEmitIntegrationTest\` (reset IS the SUT) | TODO — drive through MockMvc |
| \`TenantUserDetailsService.loadUserByUsername\` | n/a | **Structural exemption** — implements Spring Security's \`UserDetailsService\` interface, Java forces public, will not be narrowed |

The 4 TODO entries each carry an in-line comment with the suggested fix pattern. They're all the same shape as the \`createX\` factories just narrowed — concrete evidence that the smell was systemic, not three isolated cases. Each is independently fixable in a small follow-up PR (~10–50 LOC).

This was a useful surprise: the rule did its job of finding latent smells before locking. Future drift will land on this allow-list with a TODO at PR review time, forcing a decision rather than silently accumulating.

### TestTenantFactory javadoc

Class-level javadoc previously claimed fixtures \"exercise the same code paths production uses\". After PR 2 (createTenant→repo) and PR 3 (createApplication→repo, createClient→repo), nothing in the file goes through services anymore — that claim was wrong. New text:

> Fixture state is built via repository writes, not service calls. Service contracts are shaped around production scenarios (require an actor, publish events, hardcode temporary-password / force-change semantics) — correct for production, wrong for fixtures. Tests that need to assert on a production code path drive that path through MockMvc directly in the test class; this factory only produces precondition state.

## Test plan

- [x] \`mvn clean verify\` — 452 unit + 15 UI tests pass (the +1 vs PR #237 is the new ArchUnit rule)
- [x] Rule fails on a NEW public \`@Service\` method without a cross-package caller (verified by removing an allow-list entry — fails as expected, restored)
- [x] Allow-list is justified entry-by-entry in the source comment

## Closing the test-architecture series

After this PR, the locked-in shape is:
- Cross-package fixture state goes through repositories (\`TestTenantFactory\` and 5 in-test helpers)
- Cross-package SUT-relevant calls go through MockMvc through controllers
- Public \`@Service\` method surface is gated by ArchUnit
- 4 known violations carry TODOs with clear fix patterns; 1 structural Java exemption documented

The 4 TODOs can be picked up independently at any time; each unblocks its allow-list entry by mirroring the pattern PRs #235/#236/#237 set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)