### PR TITLE
refactor: flip ClientManagementService.deleteClient package-private

### DIFF
--- a/src/main/java/com/stucray/limen/clients/ClientManagementService.java
+++ b/src/main/java/com/stucray/limen/clients/ClientManagementService.java
@@ -147,7 +147,7 @@ public class ClientManagementService {
         registeredClientRepository.save(updated);
     }
 
-    public void deleteClient(String registeredClientId, Long tenantId) {
+    void deleteClient(String registeredClientId, Long tenantId) {
         TenantClient tenantClient = getClient(registeredClientId, tenantId);
         RegisteredClient rc = registeredClientRepository.findById(registeredClientId);
         if (rc != null) {

--- a/src/test/java/com/stucray/limen/architecture/ArchitectureTest.java
+++ b/src/test/java/com/stucray/limen/architecture/ArchitectureTest.java
@@ -108,9 +108,6 @@ class ArchitectureTest {
      * public. That entry will not be narrowed; it documents the structural carve-out.
      */
     private static final Set<String> SERVICE_METHODS_AWAITING_NARROWING = Set.of(
-        // TODO: ClientMembershipServiceIntegrationTest:311 calls deleteClient cross-package.
-        // Substitute repo writes (mirror PR #237's pattern), then narrow.
-        "com.stucray.limen.clients.ClientManagementService.deleteClient(java.lang.String, java.lang.Long)",
         // TODO: AuditEventEmitIntegrationTest's clientSecretRotationEmitsAuditRow calls
         // rotateSecret cross-package. Drive through ClientManagementController via
         // MockMvc (the rotation IS the SUT here, not fixture), then narrow.

--- a/src/test/java/com/stucray/limen/memberships/ClientMembershipServiceIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/memberships/ClientMembershipServiceIntegrationTest.java
@@ -3,7 +3,6 @@ package com.stucray.limen.memberships;
 import com.stucray.limen.TestcontainersConfiguration;
 import com.stucray.limen.applications.Application;
 import com.stucray.limen.applications.ApplicationRepository;
-import com.stucray.limen.clients.ClientManagementService;
 import com.stucray.limen.clients.TenantClient;
 import com.stucray.limen.clients.TenantClientRepository;
 import com.stucray.limen.roles.Role;
@@ -45,7 +44,6 @@ class ClientMembershipServiceIntegrationTest {
     @Autowired ApplicationMembershipService applicationMembershipService;
     @Autowired ApplicationMembershipRepository applicationMembershipRepository;
     @Autowired ApplicationRepository applicationRepository;
-    @Autowired ClientManagementService clientManagementService;
     @Autowired RegisteredClientRepository registeredClientRepository;
     @Autowired TenantClientRepository tenantClientRepository;
     @Autowired RoleRepository roleRepository;
@@ -310,7 +308,11 @@ class ClientMembershipServiceIntegrationTest {
         applicationMembershipService.grant(appA.id(), tenantA.id(), aliceA.id(), adminA.id());
         ClientMembership cm = clientMembershipService.grant(clientA.registeredClientId(), appA.id(), tenantA.id(), aliceA.id(), adminA.id());
 
-        clientManagementService.deleteClient(clientA.registeredClientId(), tenantA.id());
+        // Mirror ClientManagementService.deleteClient via repo writes — keeps
+        // the production method package-private (its only caller is the
+        // controller in the same package).
+        tenantClientRepository.delete(clientA);
+        tenantClientRepository.deleteRegisteredClient(clientA.registeredClientId());
 
         assertThat(clientMembershipRepository.findById(cm.id())).isEmpty();
     }


### PR DESCRIPTION
## Summary
- Drains the first of four entries in `ArchitectureTest.SERVICE_METHODS_AWAITING_NARROWING` (the residue from the v0.2.2 test-architecture series).
- Substitutes the cross-package fixture call in `ClientMembershipServiceIntegrationTest.deletingClientCascadesClientMembership` with the two repo writes `deleteClient` delegates to — same pattern PR #237 used for `createClient`.
- Flips `ClientManagementService.deleteClient` from public to package-private; the only main caller (`ClientManagementController`) is in the same package.

## Test plan
- [ ] CI: full `mvn verify` (the cascade behaviour is exercised by the modified integration test against Testcontainers Postgres).
- [x] Local: `mvn -Dtest=ArchitectureTest test` — passes (the narrowed method now satisfies the existing architectural rule with one fewer carve-out entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)