### PR TITLE
refactor: flip ClientManagementService.rotateSecret package-private

### DIFF
--- a/src/main/java/com/stucray/limen/clients/ClientManagementService.java
+++ b/src/main/java/com/stucray/limen/clients/ClientManagementService.java
@@ -160,7 +160,7 @@ public class ClientManagementService {
     public record SecretRotationResult(String rawSecret) {}
 
     @Transactional
-    public SecretRotationResult rotateSecret(String registeredClientId, Long tenantId, long actorUserId) {
+    SecretRotationResult rotateSecret(String registeredClientId, Long tenantId, long actorUserId) {
         getClient(registeredClientId, tenantId); // assert ownership
         RegisteredClient existing = registeredClientRepository.findById(registeredClientId);
         if (existing == null) throw new IllegalArgumentException("Client not found");

--- a/src/test/java/com/stucray/limen/architecture/ArchitectureTest.java
+++ b/src/test/java/com/stucray/limen/architecture/ArchitectureTest.java
@@ -108,10 +108,6 @@ class ArchitectureTest {
      * public. That entry will not be narrowed; it documents the structural carve-out.
      */
     private static final Set<String> SERVICE_METHODS_AWAITING_NARROWING = Set.of(
-        // TODO: AuditEventEmitIntegrationTest's clientSecretRotationEmitsAuditRow calls
-        // rotateSecret cross-package. Drive through ClientManagementController via
-        // MockMvc (the rotation IS the SUT here, not fixture), then narrow.
-        "com.stucray.limen.clients.ClientManagementService.rotateSecret(java.lang.String, java.lang.Long, long)",
         // TODO: AuditEventEmitIntegrationTest's adminResetPasswordEmitsAuditRow calls
         // resetPassword cross-package. Drive through UserManagementController via
         // MockMvc (the reset IS the SUT for this audit test), then narrow.

--- a/src/test/java/com/stucray/limen/audit/AuditEventEmitIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/audit/AuditEventEmitIntegrationTest.java
@@ -3,7 +3,6 @@ package com.stucray.limen.audit;
 import com.stucray.limen.TestcontainersConfiguration;
 import com.stucray.limen.applications.Application;
 import com.stucray.limen.applications.ApplicationRepository;
-import com.stucray.limen.clients.ClientManagementService;
 import com.stucray.limen.clients.TenantClient;
 import com.stucray.limen.clients.TenantClientRepository;
 import com.stucray.limen.useradmin.UserAdministrationService;
@@ -24,9 +23,13 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -36,6 +39,9 @@ import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
  * One assertion per emit source: the user-facing action triggers a row in
@@ -50,14 +56,15 @@ import static org.awaitility.Awaitility.await;
  */
 @SpringBootTest
 @Import(TestcontainersConfiguration.class)
+@AutoConfigureMockMvc
 @DisplayName("Audit event emit at every existing surface")
 class AuditEventEmitIntegrationTest {
 
+    @Autowired MockMvc mockMvc;
     @Autowired TenantProvisioningService tenantProvisioningService;
     @Autowired TenantRepository tenantRepository;
     @Autowired UserAdministrationService userAdministration;
     @Autowired UserRepository userRepository;
-    @Autowired ClientManagementService clientManagementService;
     @Autowired ApplicationRepository applicationRepository;
     @Autowired RegisteredClientRepository registeredClientRepository;
     @Autowired TenantClientRepository tenantClientRepository;
@@ -133,14 +140,19 @@ class AuditEventEmitIntegrationTest {
 
     @Test
     @DisplayName("Client secret rotation publishes ClientSecretRotatedEvent → client_secret_rotated row")
-    void clientSecretRotationEmitsAuditRow() {
+    void clientSecretRotationEmitsAuditRow() throws Exception {
         Tenant tenant = tenantProvisioningService.createTenant(uniqueSlug(), "X");
-        long actor = seedSystemAdminId();
+        User owner = seedTenantOwner(tenant);
+        MockHttpSession session = loginAs(tenant.slug(), owner.email(), "pass");
         Application app = applicationRepository.save(
             new Application(null, tenant.id(), "App " + uniqueSlug(), null, LocalDateTime.now()));
         String registeredClientId = seedConfidentialClient(app.id(), tenant.id(), "Client");
 
-        clientManagementService.rotateSecret(registeredClientId, tenant.id(), actor);
+        mockMvc.perform(post("/manage/t/" + tenant.slug()
+                + "/applications/" + app.id()
+                + "/clients/" + registeredClientId + "/rotate-secret")
+                .session(session).with(csrf()))
+            .andExpect(status().is3xxRedirection());
 
         awaitAuditRow(() -> latestEventForTenantOfType(tenant.id(), "client_secret_rotated"), row -> {
             assertThat(row).isNotNull();
@@ -210,6 +222,21 @@ class AuditEventEmitIntegrationTest {
         return userRepository.save(new User(
             null, tenantId, email, passwordEncoder.encode("oldPass1234"),
             true, mustChangePassword, false, true, LocalDateTime.now()));
+    }
+
+    @SuppressWarnings("NullAway") // Spring Data convention: null id on insert; populated on save
+    private User seedTenantOwner(Tenant tenant) {
+        String email = "owner-" + UUID.randomUUID().toString().substring(0, 8) + "@example.test";
+        return userRepository.save(new User(
+            null, tenant.id(), email, passwordEncoder.encode("pass"),
+            true, false, true, true, LocalDateTime.now()));
+    }
+
+    private MockHttpSession loginAs(String slug, String email, String password) throws Exception {
+        MvcResult login = mockMvc.perform(post("/manage/t/" + slug + "/login")
+                .param("email", email).param("password", password).with(csrf()))
+            .andReturn();
+        return (MockHttpSession) login.getRequest().getSession(false);
     }
 
     @SuppressWarnings("NullAway") // Spring Data convention


### PR DESCRIPTION
## Summary
- Drains the `rotateSecret` entry from `ArchitectureTest.SERVICE_METHODS_AWAITING_NARROWING`.
- Switches `clientSecretRotationEmitsAuditRow` to drive through `ClientManagementController` via MockMvc — the rotation IS the SUT for that audit-emit assertion, per `~/.claude/rules/spring-boot-tests.md`'s identify-SUT rule.
- Adds `@AutoConfigureMockMvc` + a `seedTenantOwner` / `loginAs` helper pair on the test class. PR 4 (resetPassword) will reuse both.
- Flips `ClientManagementService.rotateSecret` from public to package-private; the only main caller (`ClientManagementController`) is in the same package.

## Test plan
- [ ] CI: full `mvn verify` (the rotation flow is now exercised end-to-end through HTTP with a real tenant-owner session against Testcontainers Postgres).
- [x] Local: `mvn -Dtest=ArchitectureTest test` — passes (no new public-@Service-method violations after narrowing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)