### PR TITLE
refactor: flip SignupService.signup package-private

### DIFF
--- a/src/main/java/com/stucray/limen/signup/SignupService.java
+++ b/src/main/java/com/stucray/limen/signup/SignupService.java
@@ -26,7 +26,7 @@ public class SignupService {
         record Error(String field, String message) implements SignupResult {}
     }
 
-    public SignupResult signup(SignupForm form) {
+    SignupResult signup(SignupForm form) {
         return switch (tenantProvisioner.provision(NewTenantRequest.fromSignupForm(
             form.slug(), form.organizationName(), form.email(), form.password()
         ))) {

--- a/src/test/java/com/stucray/limen/architecture/ArchitectureTest.java
+++ b/src/test/java/com/stucray/limen/architecture/ArchitectureTest.java
@@ -115,10 +115,6 @@ class ArchitectureTest {
         // rotateSecret cross-package. Drive through ClientManagementController via
         // MockMvc (the rotation IS the SUT here, not fixture), then narrow.
         "com.stucray.limen.clients.ClientManagementService.rotateSecret(java.lang.String, java.lang.Long, long)",
-        // TODO: EmailVerificationFlowIntegrationTest:197 calls signup cross-package as
-        // tenant fixture setup. Substitute direct TenantRepository.save +
-        // UserRepository.save (same pattern as TestTenantFactory), then narrow.
-        "com.stucray.limen.signup.SignupService.signup(com.stucray.limen.signup.SignupForm)",
         // TODO: AuditEventEmitIntegrationTest's adminResetPasswordEmitsAuditRow calls
         // resetPassword cross-package. Drive through UserManagementController via
         // MockMvc (the reset IS the SUT for this audit test), then narrow.

--- a/src/test/java/com/stucray/limen/auth/ott/EmailVerificationFlowIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/auth/ott/EmailVerificationFlowIntegrationTest.java
@@ -8,8 +8,6 @@ import com.stucray.limen.clients.TenantClientRepository;
 import com.stucray.limen.memberships.ApplicationMembershipService;
 import com.stucray.limen.memberships.ClientMembershipService;
 import com.stucray.limen.memberships.ClientMembershipTestFixture;
-import com.stucray.limen.signup.SignupForm;
-import com.stucray.limen.signup.SignupService;
 import com.stucray.limen.tenant.Tenant;
 import com.stucray.limen.provisioning.TenantProvisioningService;
 import com.stucray.limen.tenant.TenantScope;
@@ -75,7 +73,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class EmailVerificationFlowIntegrationTest {
 
     @Autowired MockMvc mockMvc;
-    @Autowired SignupService signupService;
     @Autowired TenantProvisioningService tenantProvisioningService;
     @Autowired ApplicationRepository applicationRepository;
     @Autowired ApplicationMembershipService applicationMembershipService;
@@ -188,15 +185,19 @@ class EmailVerificationFlowIntegrationTest {
 
         @Test
         @DisplayName("Signup publishes VerificationOttIssuedEvent → verification_ott_issued row with email in details")
-        void signupEmitsVerificationOttIssuedAuditRow() {
+        void signupEmitsVerificationOttIssuedAuditRow() throws Exception {
             String suffix = uniqueSuffix();
             String slug = "audit-" + suffix;
             String email = "owner-" + suffix + "@example.test";
 
-            SignupService.SignupResult result =
-                signupService.signup(new SignupForm("Audit " + suffix, slug, email, "password"));
+            mockMvc.perform(post("/signup")
+                    .param("organizationName", "Audit " + suffix)
+                    .param("slug", slug)
+                    .param("email", email)
+                    .param("password", "password")
+                    .with(csrf()))
+                .andExpect(status().is3xxRedirection());
 
-            assertThat(result).isInstanceOf(SignupService.SignupResult.Success.class);
             await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
                 List<Map<String, Object>> rows = jdbcTemplate.queryForList(
                     "SELECT event_type, target_type, details::text AS details FROM audit_event "


### PR DESCRIPTION
## Summary
- Drains the `signup` entry from `ArchitectureTest.SERVICE_METHODS_AWAITING_NARROWING`.
- Switches `signupEmitsVerificationOttIssuedAuditRow` to `mockMvc.perform(post(\"/signup\"))` — signup IS the SUT for that audit-emit assertion (same identify-SUT rule PR #240 applied to rotateSecret). The original TODO suggested repo writes, but `TenantRepository.save` + `UserRepository.save` would never publish `VerificationOttIssuedEvent`, which is exactly what the test asserts on.
- Flips `SignupService.signup` from public to package-private; the only main caller (`SignupController`) is in the same package.

## Test plan
- [ ] CI: full `mvn verify` (the signup flow is now exercised end-to-end through `/signup` against Testcontainers Postgres, including the OTT issuance + audit-row emission).
- [x] Local: `mvn -Dtest=ArchitectureTest test` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)