### PR TITLE
refactor: flip UserAdministrationService.resetPassword package-private

### DIFF
--- a/src/main/java/com/stucray/limen/useradmin/UserAdministrationService.java
+++ b/src/main/java/com/stucray/limen/useradmin/UserAdministrationService.java
@@ -160,7 +160,7 @@ public class UserAdministrationService {
      * iff the user was carrying lockout state at reset time.
      */
     @Transactional
-    public void resetPassword(Long userId, Long tenantId, Long actorUserId, String temporaryPassword) {
+    void resetPassword(Long userId, Long tenantId, Long actorUserId, String temporaryPassword) {
         User user = getUser(userId, tenantId);
         boolean wasLocked = user.lockedUntil() != null;
         userRepository.save(user

--- a/src/test/java/com/stucray/limen/architecture/ArchitectureTest.java
+++ b/src/test/java/com/stucray/limen/architecture/ArchitectureTest.java
@@ -108,11 +108,6 @@ class ArchitectureTest {
      * public. That entry will not be narrowed; it documents the structural carve-out.
      */
     private static final Set<String> SERVICE_METHODS_AWAITING_NARROWING = Set.of(
-        // TODO: AuditEventEmitIntegrationTest's adminResetPasswordEmitsAuditRow calls
-        // resetPassword cross-package. Drive through UserManagementController via
-        // MockMvc (the reset IS the SUT for this audit test), then narrow.
-        "com.stucray.limen.useradmin.UserAdministrationService.resetPassword("
-            + "java.lang.Long, java.lang.Long, java.lang.Long, java.lang.String)",
         // Structural exemption: implements Spring Security's UserDetailsService.
         // Java forces public on interface implementations; this entry will not be narrowed.
         "com.stucray.limen.auth.TenantUserDetailsService.loadUserByUsername(java.lang.String)"

--- a/src/test/java/com/stucray/limen/audit/AuditEventEmitIntegrationTest.java
+++ b/src/test/java/com/stucray/limen/audit/AuditEventEmitIntegrationTest.java
@@ -5,7 +5,6 @@ import com.stucray.limen.applications.Application;
 import com.stucray.limen.applications.ApplicationRepository;
 import com.stucray.limen.clients.TenantClient;
 import com.stucray.limen.clients.TenantClientRepository;
-import com.stucray.limen.useradmin.UserAdministrationService;
 import com.stucray.limen.tenant.Tenant;
 import com.stucray.limen.provisioning.TenantProvisioningService;
 import com.stucray.limen.tenant.TenantRepository;
@@ -63,7 +62,6 @@ class AuditEventEmitIntegrationTest {
     @Autowired MockMvc mockMvc;
     @Autowired TenantProvisioningService tenantProvisioningService;
     @Autowired TenantRepository tenantRepository;
-    @Autowired UserAdministrationService userAdministration;
     @Autowired UserRepository userRepository;
     @Autowired ApplicationRepository applicationRepository;
     @Autowired RegisteredClientRepository registeredClientRepository;
@@ -163,12 +161,17 @@ class AuditEventEmitIntegrationTest {
 
     @Test
     @DisplayName("Admin-initiated password reset publishes PasswordChangedEvent → trigger=admin_reset")
-    void adminResetPasswordEmitsAuditRow() {
+    void adminResetPasswordEmitsAuditRow() throws Exception {
         Tenant tenant = tenantProvisioningService.createTenant(uniqueSlug(), "X");
+        User owner = seedTenantOwner(tenant);
+        MockHttpSession session = loginAs(tenant.slug(), owner.email(), "pass");
         User user = seedUser(tenant.id(), false);
-        long admin = seedSystemAdminId();
 
-        userAdministration.resetPassword(user.id(), tenant.id(), admin, "tempPass1234");
+        mockMvc.perform(post("/manage/t/" + tenant.slug()
+                + "/users/" + user.id() + "/reset-password")
+                .param("temporaryPassword", "tempPass1234")
+                .session(session).with(csrf()))
+            .andExpect(status().is3xxRedirection());
 
         awaitAuditRow(() -> latestEventForTenantOfType(tenant.id(), "password_changed"),
             row -> assertThat(row.get("details").toString().replace(" ", ""))


### PR DESCRIPTION
## Summary
- Drains the last refactor entry from `ArchitectureTest.SERVICE_METHODS_AWAITING_NARROWING`. Only the structural-exemption entry (`TenantUserDetailsService.loadUserByUsername`, forced public by Spring Security's `UserDetailsService` interface) remains after this lands.
- Switches `adminResetPasswordEmitsAuditRow` to drive through `UserManagementController` via MockMvc — the reset IS the SUT for that audit-emit assertion (same identify-SUT rule applied to `rotateSecret` in #240 and `signup` in #241).
- Flips `UserAdministrationService.resetPassword` from public to package-private; the only main caller (`UserManagementController`) is in the same package.

## Merge order note
Reuses the `@AutoConfigureMockMvc` + `seedTenantOwner` / `loginAs` scaffold introduced in #240. The duplicate-add will resolve as a no-op when this branch rebases onto the post-#240 main; if #240 lands second, the same applies in reverse.

## Test plan
- [ ] CI: full `mvn verify` (the reset flow is now exercised end-to-end through HTTP with a real tenant-owner session against Testcontainers Postgres).
- [x] Local: `mvn -Dtest=ArchitectureTest test` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)