### PR TITLE
test: enforce architecture.md citations resolve in package-info

### DIFF
--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -2,6 +2,8 @@
 
 > A companion to `ubiquitous-language.md`. That file defines *what we call things*; this file describes *how the system is built*.
 
+> **Heading convention.** Section headings are plain prose — no markdown decoration (backticks, bold, links) and no clarifying parentheticals; put those in the section body. `package-info.java` files cite sections from this document as `§N.M (<heading text>)` and must match the heading byte-for-byte. `ArchitectureDocCitationTest` enforces this on every CI build.
+
 ## 1. Purpose
 
 Limen is a **multi-tenant OAuth2 / OIDC Authorization Server** built on top of Spring Authorization Server (SAS). It is a SaaS-style product: a single deployment hosts many independent **Tenants**, each with its own User pool, Applications, Clients, signing keys, and issuer URL.
@@ -425,7 +427,7 @@ Properties:
 - **Response:** 429 with `Retry-After` (seconds until the bucket has at least one token), and the filter publishes `RateLimitHitEvent` so the rule firing lands in the audit log.
 - **Test posture:** disabled by default in unit tests via `limen.rate-limit.enabled=false` so suite timing is not bucket-bound; integration tests that exercise the filter set the property explicitly.
 
-### 4.10 Authorization — Roles, Memberships, and the JWT `roles` claim
+### 4.10 Authorization — Roles, Memberships, and the JWT roles claim
 
 v1 left the `roles` JWT claim hardcoded to `[]`. v2 replaces that with a query against the new Membership tables and adds an explicit gate at `/oauth2/authorize` that rejects authenticated Users without a Client Membership.
 
@@ -567,7 +569,7 @@ Static analysis runs in two postures:
 
 CI is a single GitHub Actions workflow (`.github/workflows/ci.yml`) with one `verify` job on push and PR to `main`. The job sets up JDK 26 (Temurin, with Maven cache), runs `./mvnw -B -ntp verify`, and uploads the PMD bundle (30-day retention) and — on failure — the JaCoCo HTML report (14-day retention). The `LIMEN_SECURITY_KEK` is supplied as a GitHub Actions secret. Docs-only changes (`**.md`, `docs/**`, `LICENSE`, `.github/ISSUE_TEMPLATE/**`, `.github/PULL_REQUEST_TEMPLATE.md`) are skipped via `paths-ignore`; the same filter is applied to `publish-image.yml` so docs commits don't trigger a no-op image rebuild. A `workflow_dispatch` trigger on `ci.yml` provides a manual run lever when the path filter would otherwise skip a run you want to force.
 
-### 4.15 Package structure (application modules)
+### 4.15 Package structure
 
 Module boundaries are enforced mechanically via [Spring Modulith](https://spring.io/projects/spring-modulith). `LimenModuleArchitectureTest` calls `ApplicationModules.of(LimenApplication.class).verify()`, which fails the build on cycles between modules and on cross-module references into a module's internal sub-packages. The verifier runs as part of `./mvnw test` so every PR is checked.
 

--- a/src/test/java/com/stucray/limen/architecture/ArchitectureDocCitationTest.java
+++ b/src/test/java/com/stucray/limen/architecture/ArchitectureDocCitationTest.java
@@ -1,0 +1,127 @@
+package com.stucray.limen.architecture;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toUnmodifiableSet;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Referential-integrity check on cross-cutting documentation citations.
+ *
+ * <p>Every {@code §N.M (Name)} citation of {@code docs/reference/architecture.md}
+ * appearing in a {@code package-info.java} file must resolve to an actual heading
+ * in that document. Catches drift introduced when a section is renumbered,
+ * renamed, or removed without a corresponding update to the citing modules.
+ *
+ * <p>Semantic correctness — "is this still the right section to cite for this
+ * module?" — remains a human-judgement call; this test only proves the cited
+ * section exists.
+ *
+ * <p>Heading-text convention enforced indirectly: section headings in
+ * {@code architecture.md} are plain prose (no markdown decoration, no
+ * parentheticals); citations match the heading text byte-for-byte after
+ * stripping the {@code §N.M (}{@code )} wrapper. The convention is documented
+ * in {@code architecture.md}'s preamble.
+ */
+@DisplayName("package-info §N.M citations resolve to architecture.md headings")
+class ArchitectureDocCitationTest {
+
+    private static final Path ARCHITECTURE_DOC = Paths.get("docs/reference/architecture.md");
+    private static final Path PACKAGE_INFO_ROOT = Paths.get("src/main/java/com/stucray/limen");
+
+    private static final Pattern HEADING_PATTERN = Pattern.compile(
+        "^#{2,6}\\s+(\\d+(?:\\.\\d+)*)\\.?\\s+(.+?)\\s*$");
+    private static final Pattern CITATION_PATTERN = Pattern.compile(
+        "§(\\d+(?:\\.\\d+)*)\\s+\\(([^)]+)\\)");
+    private static final Pattern JAVADOC_CONTINUATION = Pattern.compile("\\n\\s*\\*\\s*");
+    private static final Pattern WHITESPACE_RUN = Pattern.compile("\\s+");
+
+    @Test
+    @DisplayName("every cite resolves to a heading")
+    void everyCitationResolvesToAHeading() {
+        Set<Section> headings = readHeadings(ARCHITECTURE_DOC);
+        Set<Citation> citations = readCitations(PACKAGE_INFO_ROOT);
+
+        Set<Citation> unresolved = new TreeSet<>(Citation.BY_SOURCE_THEN_NUMBER);
+        for (Citation c : citations) {
+            if (!headings.contains(new Section(c.number(), c.name()))) {
+                unresolved.add(c);
+            }
+        }
+        assertTrue(unresolved.isEmpty(), failureMessage(unresolved));
+    }
+
+    private static String failureMessage(Set<Citation> unresolved) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(unresolved.size()).append(" package-info citation(s) do not resolve "
+            + "to a heading in ").append(ARCHITECTURE_DOC).append(":\n");
+        for (Citation c : unresolved) {
+            sb.append("  ").append(c.source()).append(": §").append(c.number())
+                .append(" (").append(c.name()).append(")\n");
+        }
+        sb.append("\nFix one of: align the citation to the heading text, align the "
+            + "heading to the citation, or update both.\nConvention: heading text is "
+            + "plain prose (no markdown decoration, no parentheticals); citations "
+            + "match byte-for-byte.\n");
+        return sb.toString();
+    }
+
+    private static Set<Section> readHeadings(Path doc) {
+        try {
+            return Files.readAllLines(doc).stream()
+                .map(HEADING_PATTERN::matcher)
+                .filter(java.util.regex.Matcher::matches)
+                .map(m -> new Section(m.group(1), m.group(2).trim()))
+                .collect(toUnmodifiableSet());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static Set<Citation> readCitations(Path root) {
+        try (Stream<Path> walk = Files.walk(root)) {
+            return walk
+                .filter(p -> p.getFileName().toString().equals("package-info.java"))
+                .flatMap(ArchitectureDocCitationTest::extractCitations)
+                .collect(toUnmodifiableSet());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static Stream<Citation> extractCitations(Path pkgInfo) {
+        try {
+            String raw = Files.readString(pkgInfo);
+            String normalised = JAVADOC_CONTINUATION.matcher(raw).replaceAll(" ");
+            String source = Paths.get("").toAbsolutePath()
+                .relativize(pkgInfo.toAbsolutePath()).toString();
+            Set<Citation> found = new LinkedHashSet<>();
+            CITATION_PATTERN.matcher(normalised).results().forEach(m -> {
+                String name = WHITESPACE_RUN.matcher(m.group(2).trim()).replaceAll(" ");
+                found.add(new Citation(m.group(1), name, source));
+            });
+            return found.stream();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private record Section(String number, String name) { }
+
+    private record Citation(String number, String name, String source) {
+        static final java.util.Comparator<Citation> BY_SOURCE_THEN_NUMBER =
+            java.util.Comparator.comparing(Citation::source).thenComparing(Citation::number);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `ArchitectureDocCitationTest` — a JUnit test that walks every `package-info.java` under `src/main/java/com/stucray/limen/`, extracts `§N.M (Name)` citations of `docs/reference/architecture.md`, and asserts that each `(number, name)` pair resolves to a real heading in the doc. Catches drift introduced when a section is renumbered, renamed, or removed without updating the citing modules.

Approach decided in a `/grill-me` session — see commit message for the design notes. Highlights:

- **Mechanical referential integrity only.** The test verifies the cited section *exists*; semantic correctness ("is this still the right section to cite for this module?") remains a human-judgement call. The cheap-to-detect failure modes (renumber, rename, delete, file-move) are the high-value ones to catch mechanically; the harder semantic question is left for human review at architecture.md edit time.
- **Strict byte-exact match** between citation `(<name>)` text and heading text after stripping `### N.M ` / `§N.M (` `)` decoration. No fuzzy matching, no normalisation other than collapsing javadoc line-wrap whitespace.
- **Day-one cleanup of two heading mismatches** to satisfy the strict matcher:
  - §4.10 heading drops backticks around `roles` — `### 4.10 Authorization — Roles, Memberships, and the JWT roles claim`
  - §4.15 heading drops trailing `(application modules)` — `### 4.15 Package structure` (the body already establishes the term)
- **Convention documented in architecture.md's preamble:** section headings are plain prose, no markdown decoration or parentheticals; citations match byte-for-byte.

## Scope

- **Only `package-info.java` files** are inspected. Per Oracle's *How to Write Doc Comments for the Javadoc Tool*: *"For large, complex packages a pointer to an external architecture document is warranted."* That pattern is canonical at the package level; method/class javadoc lives in a different category.
- `EmailSender.java`'s freeform `roadmap §6 v4` citation is **out of scope** — the roadmap section is a deliberately moving target with non-`N.M` numbering.
- `MembershipGateFilter.java`'s `RFC 6749 §4.1.2.1` is an external standard, also out of scope.

## Out of scope (deferred)

- **Impact tool.** When a PR diff edits an architecture.md heading or section body, ideally CI surfaces the package-infos that cite the affected section so the author can re-evaluate. Decided to land referential-integrity first (this PR), evaluate whether the impact tool is worth building after living with the current check for a few architecture edits.
- **Semantic-correctness verification.** Mechanically infeasible without either generating one document from the other (heavyweight) or content-hashing each section (false-positive on every prose edit).

## Verification

- Test passes on the cleaned-up state (1/1).
- Sanity-check: temporarily perturbed one citation (`§4.5 (Authentication flows)` → `§4.5 (Authentication flow)`); test failed with the expected pointer to the offending package-info file and a hint about the convention. Reverted.

## Test plan

- [ ] CI green on this PR (the test runs as part of `mvn test`, included in the existing `verify` job).
- [ ] After merge, attempt a deliberate drift in a follow-up branch (rename a heading, do not update package-info) and confirm CI fails with the expected message — then abandon that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)