### PR TITLE
fix: anchor branch-first hook regex to command boundaries

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cmd=$(jq -r '.tool_input.command // empty'); blocked=false; case \"$cmd\" in *\"git commit\"*|*\"git push\"*) blocked=true;; esac; case \"$cmd\" in *\"--dry-run\"*) blocked=false;; esac; if $blocked; then branch=$(git -C /Users/scray/dev/projects/limen rev-parse --abbrev-ref HEAD 2>/dev/null); if [ \"$branch\" = \"main\" ]; then jq -nc --arg msg \"Refusing to git commit/push on main — create a feature branch first: git checkout -b <name>\" '{hookSpecificOutput:{hookEventName:\"PreToolUse\",permissionDecision:\"deny\",permissionDecisionReason:$msg}}'; fi; fi"
+            "command": "cmd=$(jq -r '.tool_input.command // empty'); re='(^|[;&|(])[[:space:]]*git[[:space:]]+(commit|push)([[:space:]]|[;&|)`]|$)'; blocked=false; [[ \"$cmd\" =~ $re ]] && blocked=true; case \"$cmd\" in *\"--dry-run\"*) blocked=false;; esac; if $blocked; then branch=$(git -C /Users/scray/dev/projects/limen rev-parse --abbrev-ref HEAD 2>/dev/null); if [ \"$branch\" = \"main\" ]; then jq -nc --arg msg \"Refusing to commit/push on main — create a feature branch first: git checkout -b <name>\" '{hookSpecificOutput:{hookEventName:\"PreToolUse\",permissionDecision:\"deny\",permissionDecisionReason:$msg}}'; fi; fi"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- The PreToolUse hook that blocks git writes on `main` was matching on bare substrings, so a Bash tool call whose argument *mentioned* the phrases in prose (a `gh issue create --body` whose body discussed git workflows) was denied even though no git write was being attempted.
- Switch to a bash regex anchored to start-of-string or a shell command separator (`;`, `&`, `|`, `(`), with trailing-side anchoring (`)`, `` ` ``, plus other separators) so subshell forms like `$(git commit)` still match.
- On-main behaviour for real git invocations is unchanged; the false positive on prose-in-heredoc is gone.

## Test plan
- [x] 20-case regex truth table: real invocations, subshell, chained, prose-in-heredoc, quoted strings, dry-run.
- [x] End-to-end hook simulation with branch patched to `main`: BLOCKs `git commit`, `git push`, `\$(git commit)`; PASSes `git push --dry-run`, prose-only, quoted.
- [x] `jq .` re-validates `.claude/settings.json`.
- [x] This PR's own commit + push exercised the new regex on a feature branch (must not block off-main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)