### PR TITLE
chore: remove project-level branch-first hook (superseded by user-level)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,16 +1,3 @@
 {
-  "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "cmd=$(jq -r '.tool_input.command // empty'); re='(^|[;&|(])[[:space:]]*git[[:space:]]+(commit|push)([[:space:]]|[;&|)`]|$)'; blocked=false; [[ \"$cmd\" =~ $re ]] && blocked=true; case \"$cmd\" in *\"--dry-run\"*) blocked=false;; esac; if $blocked; then branch=$(git -C /Users/scray/dev/projects/limen rev-parse --abbrev-ref HEAD 2>/dev/null); if [ \"$branch\" = \"main\" ]; then jq -nc --arg msg \"Refusing to commit/push on main — create a feature branch first: git checkout -b <name>\" '{hookSpecificOutput:{hookEventName:\"PreToolUse\",permissionDecision:\"deny\",permissionDecisionReason:$msg}}'; fi; fi"
-          }
-        ]
-      }
-    ]
-  }
+  "$schema": "https://json.schemastore.org/claude-code-settings.json"
 }


### PR DESCRIPTION
## Summary
- Identical branch-first protection now lives at `~/.claude/settings.json` (lifted as part of the bootstrap-skills PRD phase 1, with a tightened command-boundary regex + cd-prefix awareness so the user-level hook follows `cd ~/some-repo && git push` to the actual target rather than checking the cwd repo's branch).
- The project copy hardcoded a `-C /Users/scray/dev/projects/limen` path, which fires regardless of where the git operation is targeted — it gets in the way when working across this repo and `~/.claude` in the same session.
- Two hooks doing the same job is just noise. Removing the project copy keeps a single source of truth.

## Test plan
- [x] Commit + push of this very branch exercises the user-level hook end-to-end (must not block off-main).
- [x] `jq .` validates the trimmed `.claude/settings.json`.
- [ ] After merge, future Limen commits still go through the user-level hook unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)