### PR TITLE
fix: make coverage-report idempotent on SHA-matched clean checkouts

### DIFF
--- a/scripts/coverage-report.sh
+++ b/scripts/coverage-report.sh
@@ -55,6 +55,25 @@ DATE_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 DATE_DISPLAY="$(date -u +%Y-%m-%d)"
 SHA="$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
 
+# Idempotence guard (issue #251). When --write is in effect, skip the JSONL
+# append and the markdown rewrite if HEAD is already the most recent entry
+# in the history *and* there are no uncommitted changes to source or build.
+# JaCoCo's <clinit> ordering is non-deterministic, so back-to-back `mvn
+# verify` runs on the same commit produce ~0.1–0.5 % coverage drift in
+# either direction. Without this guard every local verify leaves a phantom
+# diff in the working tree.
+#
+# Stdout mode (no --write) is intentionally unaffected — callers that pipe
+# the auto-block somewhere else still get fresh output every run.
+if [[ -n "$WRITE_PATH" && -f "$HISTORY_FILE" && -s "$HISTORY_FILE" && "$SHA" != "unknown" ]]; then
+    LAST_SHA="$(tail -n 1 "$HISTORY_FILE" | sed -nE 's/.*"sha":"([^"]+)".*/\1/p')"
+    if [[ -n "$LAST_SHA" && "$LAST_SHA" == "$SHA" ]] \
+       && git -C "$REPO_ROOT" diff --quiet -- src/ pom.xml 2>/dev/null; then
+        echo "[INFO] coverage-report: HEAD ($SHA) already snapshotted and source clean — skipping write."
+        exit 0
+    fi
+fi
+
 # Auto-compute test count if not supplied via --tests. Sums the
 # tests="N" attribute on each surefire/failsafe testsuite XML root.
 # Missing report dirs (e.g. running before any tests) leave TESTS empty,


### PR DESCRIPTION
## Summary
- Adds an early-exit guard in `scripts/coverage-report.sh`: when `--write` is in effect, skip both the JSONL append and the markdown rewrite if HEAD already matches the most recent entry in `test-coverage-history.jsonl` *and* `git diff --quiet -- src/ pom.xml` reports a clean tree.
- Stops `./mvnw verify` from producing phantom diffs on `docs/reports/test-coverage.md` + `docs/reports/test-coverage-history.jsonl` caused by JaCoCo's non-deterministic `<clinit>` ordering (~0.1–0.5 % run-to-run drift on the same commit).
- Prints a one-line `[INFO] coverage-report: HEAD (<sha>) already snapshotted and source clean — skipping write.` so the maven log shows the script ran.
- Stdout mode (no `--write`) is intentionally unaffected.

Closes #251.

## Why this shape, not a tolerance threshold
A `abs(delta) < 0.5 %` suppression was considered and rejected in the issue: it would hide real regressions that happen to be small. SHA-tracking is exact — the same commit can only have one snapshot.

## Test plan

Validated locally against the existing `target/site/jacoco/jacoco.csv` (no fresh `mvn verify` needed for the logic check):

- [x] `--write` on SHA mismatch → writes (markdown + JSONL updated, no `[INFO]`).
- [x] `--write` on SHA match + clean `src/` + clean `pom.xml` → `[INFO]` printed, files byte-identical before and after (md5 confirmed).
- [x] `--write` on SHA match + dirty `src/` (touched `LimenApplication.java`) → writes (no `[INFO]`); skip bypassed correctly.
- [x] No `--write` → 50 lines of auto-block printed to stdout; skip never fires.
- [ ] CI: `./mvnw verify` on a SHA-matched clean checkout should produce zero working-tree diff on `docs/reports/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)