### PR TITLE
chore: remove stale interceptor comment from ManagementWebConfig

### DIFF
--- a/src/main/java/com/stucray/limen/management/web/ManagementWebConfig.java
+++ b/src/main/java/com/stucray/limen/management/web/ManagementWebConfig.java
@@ -10,9 +10,6 @@ class ManagementWebConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        // Cross-tenant URL access is enforced by the TenantAccessFilter inside
-        // each security chain (force-logout + redirect). The interceptor is no
-        // longer needed.
         registry.addInterceptor(new PasswordChangeRequiredInterceptor())
             .addPathPatterns("/manage/t/**");
     }


### PR DESCRIPTION
## Summary
- The comment in `ManagementWebConfig::addInterceptors` described a removed cross-tenant interceptor (its job is now done by `TenantAccessFilter` in the security chain).
- But it sat directly above the still-active `PasswordChangeRequiredInterceptor` registration, making the active interceptor read as if it were the redundant one.
- Removed the comment; the `PasswordChangeRequiredInterceptor` registration is unchanged.

## Test plan
- [ ] `mvn verify` is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)