### PR TITLE
feat(infra): add Ansible VPS bootstrap project

### DIFF
--- a/infra/ansible/README.md
+++ b/infra/ansible/README.md
@@ -1,0 +1,15 @@
+# Ansible
+
+Server bootstrap for the Limen VPS. The full walk-through (key generation,
+provisioning, first contact, verification) lives in
+[`docs/process/vps-bootstrap.md`](../../docs/process/vps-bootstrap.md).
+
+```sh
+# first run (deploy user doesn't exist yet)
+ansible-playbook bootstrap.yml -e ansible_user=root
+
+# every run after — expect changed=0 on a clean box
+ansible-playbook bootstrap.yml
+```
+
+Run from this directory; `ansible.cfg` points at `inventory.yml`.

--- a/infra/ansible/ansible.cfg
+++ b/infra/ansible/ansible.cfg
@@ -1,0 +1,5 @@
+[defaults]
+inventory = inventory.yml
+
+[ssh_connection]
+pipelining = True

--- a/infra/ansible/bootstrap.yml
+++ b/infra/ansible/bootstrap.yml
@@ -1,0 +1,90 @@
+---
+- name: Bootstrap VPS
+  hosts: vps
+  become: true
+  vars:
+    deploy_user: deploy
+    ssh_pubkey: "{{ lookup('file', lookup('env', 'HOME') + '/.ssh/id_ed25519_vps.pub') }}"
+
+  tasks:
+    - name: Upgrade packages
+      ansible.builtin.apt:
+        update_cache: true
+        cache_valid_time: 3600
+        upgrade: safe
+
+    - name: Install base packages
+      ansible.builtin.apt:
+        name: [ufw, fail2ban, unattended-upgrades]
+        state: present
+
+    - name: Create deploy user
+      ansible.builtin.user:
+        name: "{{ deploy_user }}"
+        groups: sudo
+        append: true
+        shell: /bin/bash
+
+    - name: Authorize SSH key for deploy user
+      ansible.posix.authorized_key:
+        user: "{{ deploy_user }}"
+        key: "{{ ssh_pubkey }}"
+
+    - name: Allow passwordless sudo for deploy user
+      ansible.builtin.copy:
+        dest: /etc/sudoers.d/90-deploy
+        content: "{{ deploy_user }} ALL=(ALL) NOPASSWD:ALL\n"
+        mode: "0440"
+        validate: /usr/sbin/visudo -cf %s
+
+    - name: Harden sshd
+      ansible.builtin.copy:
+        dest: /etc/ssh/sshd_config.d/00-hardening.conf
+        content: |
+          PermitRootLogin no
+          PasswordAuthentication no
+          KbdInteractiveAuthentication no
+          MaxAuthTries 3
+          X11Forwarding no
+        mode: "0644"
+        validate: /usr/sbin/sshd -t -f %s
+      notify: Restart ssh
+
+    - name: Configure fail2ban for sshd
+      ansible.builtin.copy:
+        dest: /etc/fail2ban/jail.local
+        content: |
+          [sshd]
+          enabled = true
+          backend = systemd
+        mode: "0644"
+      notify: Restart fail2ban
+
+    - name: Allow SSH through firewall
+      community.general.ufw:
+        rule: allow
+        name: OpenSSH
+
+    - name: Allow web traffic
+      community.general.ufw:
+        rule: allow
+        port: "{{ item }}"
+        proto: tcp
+      loop: ["80", "443"]
+
+    - name: Enable firewall, default deny incoming
+      community.general.ufw:
+        state: enabled
+        policy: deny
+        direction: incoming
+
+  handlers:
+    - name: Restart ssh
+      ansible.builtin.service:
+        name: ssh
+        state: restarted
+
+    - name: Restart fail2ban
+      ansible.builtin.service:
+        name: fail2ban
+        state: restarted

--- a/infra/ansible/inventory.yml
+++ b/infra/ansible/inventory.yml
@@ -1,0 +1,6 @@
+vps:
+  hosts:
+    limen-vps:
+      # TODO: replace with the real VPS IP (or DNS name) once provisioned
+      ansible_host: 203.0.113.10
+      ansible_user: deploy


### PR DESCRIPTION
Materialises the Ansible project from `docs/process/vps-bootstrap.md` under `infra/ansible/`:

- `ansible.cfg` — inventory pointer + SSH pipelining
- `inventory.yml` — `limen-vps` host with a TODO placeholder IP until the box is provisioned
- `bootstrap.yml` — idempotent hardening playbook (deploy user + key, NOPASSWD sudo with visudo validation, sshd `00-hardening.conf` drop-in, ufw default-deny with OpenSSH/80/443, fail2ban on the systemd backend, unattended-upgrades)
- `README.md` — run commands, links to the process doc

Not yet syntax-checked locally (Ansible not installed on this machine yet — Phase 1 of the guide); the playbook matches the doc merged in #334 verbatim.

Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)