### PR TITLE
feat(infra): provision Docker on the VPS via Ansible

### DIFF
--- a/infra/ansible/README.md
+++ b/infra/ansible/README.md
@@ -5,6 +5,9 @@ provisioning, first contact, verification) lives in
 [`docs/process/vps-bootstrap.md`](../../docs/process/vps-bootstrap.md).
 
 ```sh
+# once, to fetch external roles (Docker install)
+ansible-galaxy install -r requirements.yml
+
 # first run (deploy user doesn't exist yet)
 ansible-playbook bootstrap.yml -e ansible_user=root
 

--- a/infra/ansible/bootstrap.yml
+++ b/infra/ansible/bootstrap.yml
@@ -88,3 +88,13 @@
       ansible.builtin.service:
         name: fail2ban
         state: restarted
+
+# Separate play so the role runs after the deploy user exists
+# (roles listed on a play always run before its tasks).
+- name: Install Docker
+  hosts: vps
+  become: true
+  vars:
+    docker_users: [deploy]
+  roles:
+    - geerlingguy.docker

--- a/infra/ansible/requirements.yml
+++ b/infra/ansible/requirements.yml
@@ -1,0 +1,3 @@
+roles:
+  - name: geerlingguy.docker
+    version: 8.0.0


### PR DESCRIPTION
Adds Docker Engine + compose-plugin provisioning to the bootstrap playbook:

- `requirements.yml` pinning `geerlingguy.docker` at 8.0.0 (verified actively maintained — 8.0.0 released 2026-01-15)
- second `Install Docker` play in `bootstrap.yml` with `docker_users: [deploy]` — a separate play rather than a `roles:` entry on the first play because play-level roles run before tasks, and the deploy user must exist first
- README gains the `ansible-galaxy install -r requirements.yml` step

Syntax check passes with the role installed locally.

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)