### PR TITLE
feat(infra): production compose stack + Caddy edge + compose CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,14 @@ jobs:
     uses: stucray/workflows/.github/workflows/ci-spring-boot-maven.yml@v1
     secrets:
       test_env_json: '{"LIMEN_SECURITY_KEK":"${{ secrets.LIMEN_SECURITY_KEK_TEST }}"}'
+
+  # Deploy-layer lint gate (PRD #339): the prod compose file must parse with
+  # the documented env contract. example.env carries placeholder values for
+  # every required interpolation.
+  deploy-config:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Validate production compose file
+        working-directory: infra/deploy
+        run: docker compose -f compose.prod.yaml --env-file example.env config -q

--- a/infra/deploy/Caddyfile
+++ b/infra/deploy/Caddyfile
@@ -1,0 +1,10 @@
+# Edge config for the Limen VPS. LIMEN_DOMAIN is injected by compose from the
+# deploy environment. Caddy handles ACME issuance/renewal and the HTTP->HTTPS
+# redirect for named sites automatically, and sets X-Forwarded-For/-Proto/-Host
+# on reverse_proxy. The external port is the https default (443), so Spring's
+# framework forward-headers strategy derives the right port without an explicit
+# X-Forwarded-Port.
+{$LIMEN_DOMAIN} {
+	encode gzip
+	reverse_proxy limen:8090
+}

--- a/infra/deploy/README.md
+++ b/infra/deploy/README.md
@@ -1,0 +1,16 @@
+# Production deploy stack
+
+Box-side deploy layer for the Limen VPS (PRD #339): `compose.prod.yaml` +
+`Caddyfile`, consumed by `deploy.sh` (slice #342). `example.env` documents the
+environment contract; real values are sops-encrypted in the private
+`limen-secrets` repo. Provisioning lives in [`../ansible/`](../ansible/); the
+end-to-end walk-through is
+[`docs/process/vps-bootstrap.md`](../../docs/process/vps-bootstrap.md).
+
+Validate locally without secrets:
+
+```sh
+docker compose -f compose.prod.yaml --env-file example.env config -q
+```
+
+(CI runs the same check with dummy values for the blank-in-example variables.)

--- a/infra/deploy/compose.prod.yaml
+++ b/infra/deploy/compose.prod.yaml
@@ -1,0 +1,102 @@
+# Production stack for the Limen VPS (PRD #339, slice #340).
+#
+# Standalone by design — NOT an override of the dev docker-compose.yml:
+# compose list-merge semantics can't cleanly remove a published port, and the
+# prod file should state prod intent on its own.
+#
+# Interpolation contract: every ${VAR:?} below is supplied by the decrypted
+# environment file from the limen-secrets repo, passed via
+# `docker compose --env-file` by deploy.sh (slice #342). example.env documents
+# the full set. Only Caddy publishes host ports; limen and postgres are
+# reachable solely on the internal network.
+
+services:
+  caddy:
+    # Auto-ACME TLS edge; the only internet-facing service.
+    image: caddy:2
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp" # HTTP/3
+    environment:
+      LIMEN_DOMAIN: ${LIMEN_DOMAIN:?public hostname, e.g. auth.example.com}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    networks:
+      default:
+        # Internal callers (including limen itself) resolve the public
+        # hostname to Caddy and hairpin through the proxy, getting valid TLS
+        # and correct forwarded headers — required for OIDC issuer/JWKS
+        # consistency.
+        aliases:
+          - ${LIMEN_DOMAIN:?}
+
+  limen:
+    # Paketo image published by .github/workflows/publish-image.yml; version
+    # pinned by deploy.sh from the release tag — never a moving tag.
+    image: ghcr.io/stucray/limen:${LIMEN_VERSION:?release version, e.g. 0.4.0}
+    restart: unless-stopped
+    # Above spring.lifecycle.timeout-per-shutdown-phase (default 30s) so a
+    # graceful stop finishes as SIGTERM/143, not SIGKILL/137.
+    stop_grace_period: 40s
+    # The Paketo memory calculator sizes heap from the cgroup limit minus
+    # non-heap; the 250-thread default stack reservation must come down with
+    # the cap or the app OOMs on startup. 50 threads is the validated pairing.
+    mem_limit: 768m
+    environment:
+      BPL_JVM_THREAD_COUNT: "50"
+      # Behind the TLS-terminating proxy: trust X-Forwarded-* so issuer,
+      # redirect URIs, and emailed links carry the public HTTPS origin.
+      SERVER_FORWARD_HEADERS_STRATEGY: framework
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/auth
+      SPRING_DATASOURCE_USERNAME: auth
+      SPRING_DATASOURCE_PASSWORD: ${LIMEN_DB_PASSWORD:?}
+      SPRING_PROFILES_ACTIVE: resend
+      SPRING_MAIL_PASSWORD: ${RESEND_API_KEY:?}
+      LIMEN_EMAIL_FROM: ${LIMEN_EMAIL_FROM:?verified From-address, e.g. no-reply@auth.example.com}
+      LIMEN_SECURITY_KEK: ${LIMEN_SECURITY_KEK:?}
+      LIMEN_SECURITY_KEK_PREVIOUS: ${LIMEN_SECURITY_KEK_PREVIOUS:-}
+      LIMEN_SECURITY_REMEMBERMEKEY: ${LIMEN_SECURITY_REMEMBERMEKEY:?}
+      LIMEN_BOOTSTRAP_ADMIN_EMAIL: ${LIMEN_BOOTSTRAP_ADMIN_EMAIL:?}
+      LIMEN_BOOTSTRAP_ADMIN_PASSWORD: ${LIMEN_BOOTSTRAP_ADMIN_PASSWORD:?}
+      # Observability deferred (PRD: out of scope at launch).
+      OTEL_SDK_DISABLED: "true"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      # The Paketo run image has bash but no curl/wget; a TCP connect to the
+      # server port proves the context started (Tomcat binds after context
+      # refresh). deploy.sh does the real HTTP health check through the edge.
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/127.0.0.1/8090"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      # Flyway-on-boot runs inside this window on first deploy.
+      start_period: 90s
+
+  postgres:
+    image: postgres:17
+    restart: unless-stopped
+    # No ports: — internal network only. POSTGRES_* seed credentials only on
+    # first initialisation of an empty volume; the password must be correct
+    # before the first `up`. Rotate later via ALTER USER, not env.
+    environment:
+      POSTGRES_DB: auth
+      POSTGRES_USER: auth
+      POSTGRES_PASSWORD: ${LIMEN_DB_PASSWORD:?}
+    volumes:
+      - limen_postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U auth -d auth"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  limen_postgres_data:
+  caddy_data:
+  caddy_config:

--- a/infra/deploy/example.env
+++ b/infra/deploy/example.env
@@ -1,0 +1,27 @@
+# Interpolation contract for compose.prod.yaml — every variable deploy.sh's
+# decrypted env file must provide. This file documents names and shape only;
+# real values live sops-encrypted in the private limen-secrets repo. Never put
+# a real value here. The `changeme` placeholders keep
+# `docker compose --env-file example.env config` runnable (compose's ${VAR:?}
+# rejects empty values, so blanks would fail validation).
+
+# Public hostname (Caddyfile site + internal hairpin alias)
+LIMEN_DOMAIN=auth.example.com
+# Release version to run, set by deploy.sh from the release tag (v0.4.0 -> 0.4.0)
+LIMEN_VERSION=0.0.0-example
+# Postgres password; seeds the volume on first init AND is the app's datasource
+# password — set correctly before the first `up`
+LIMEN_DB_PASSWORD=changeme
+# Resend API key (SMTP password for the resend profile)
+RESEND_API_KEY=changeme
+# From-address on a Resend-verified domain
+LIMEN_EMAIL_FROM=no-reply@auth.example.com
+# Key-encryption key for tenant signing keys (base64, see .env.example)
+LIMEN_SECURITY_KEK=changeme
+# Previous KEK during rotation; empty otherwise
+LIMEN_SECURITY_KEK_PREVIOUS=
+# Signs the remember-me cookie (limen.security.remember-me-key)
+LIMEN_SECURITY_REMEMBERMEKEY=changeme
+# First-boot admin seed
+LIMEN_BOOTSTRAP_ADMIN_EMAIL=admin@auth.example.com
+LIMEN_BOOTSTRAP_ADMIN_PASSWORD=changeme


### PR DESCRIPTION
Slice 1 of PRD #339 — the standalone production stack under `infra/deploy/`:

- `compose.prod.yaml` — Caddy as the sole internet-facing service (80/443 + HTTP/3, auto-ACME, network alias on the public hostname for the internal TLS hairpin); Limen pinned to `ghcr.io/stucray/limen:${LIMEN_VERSION}` with `SERVER_FORWARD_HEADERS_STRATEGY=framework`, `mem_limit: 768m` paired with `BPL_JVM_THREAD_COUNT=50`, `stop_grace_period: 40s` (above Spring's 30s shutdown phase), bash `/dev/tcp` healthcheck (Paketo run image has no curl/wget) and `OTEL_SDK_DISABLED=true`; Postgres 17 internal-only on a named volume with the first-init password caveat documented
- `Caddyfile` — `{$LIMEN_DOMAIN}` site, gzip, reverse proxy to 8090; ACME + HTTP→HTTPS redirect are Caddy defaults, and external port 443 is derived from the https default so no explicit X-Forwarded-Port is needed
- `example.env` — the full interpolation contract with placeholder values (compose `${VAR:?}` rejects empties, so placeholders keep validation runnable); real values will live sops-encrypted in `limen-secrets` (#341)
- CI gains a `deploy-config` job validating the compose file against `example.env` (checkout v7)
- `README.md` for the directory

Validated locally: `docker compose config -q` passes; resolved output confirms only Caddy publishes ports and the hairpin alias resolves.

Closes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)