### PR TITLE
feat(infra): box-side deploy.sh + shellcheck gate + deploy process doc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,6 @@ jobs:
       - name: Validate production compose file
         working-directory: infra/deploy
         run: docker compose -f compose.prod.yaml --env-file example.env config -q
+      - name: Shellcheck deploy script
+        working-directory: infra/deploy
+        run: shellcheck deploy.sh

--- a/docs/process/deploy.md
+++ b/docs/process/deploy.md
@@ -1,0 +1,77 @@
+# Deploying Limen to the VPS
+
+Operator-gated, box-side deploys (PRD #339). The release pipeline's job ends
+at "image tagged and in GHCR" ([`container.md`](container.md)); putting a
+release into production is a separate, deliberate act performed on the box.
+Provisioning the box itself is covered by
+[`vps-bootstrap.md`](vps-bootstrap.md) plus the deploy-toolchain Ansible
+tasks (slice #343).
+
+## Prerequisites (once)
+
+- Box bootstrapped and provisioned: Docker, sops + age, the `limen` and
+  `limen-secrets` clones under the deploy user, GHCR login, box age key
+  registered as a sops recipient (slices #341/#343).
+- DNS A record for the public domain pointing at the box; the domain
+  verified at Resend.
+
+## Deploy
+
+```sh
+ssh vps
+~/limen/infra/deploy/deploy.sh v0.4.0        # or --dry-run first
+```
+
+The script checks out the tag (pinning config, migrations, and image version
+from one checkout), fast-forwards the secrets clone, decrypts `prod.env` via
+sops to a mode-600 tempfile (removed on exit), pulls
+`ghcr.io/stucray/limen:<version>`, runs `docker compose up -d`, waits for the
+container healthcheck, then asserts `https://<domain>/actuator/health` is UP
+through the edge. On failure it prints the last 80 app-log lines and exits
+non-zero.
+
+**Watch the logs on any deploy that ships a migration** — Flyway runs
+in-process on startup, so a failed migration surfaces as a crash-looping
+container, and the real error is in the startup log:
+
+```sh
+docker compose -f ~/limen/infra/deploy/compose.prod.yaml logs -f limen
+```
+
+## Rollback
+
+Symmetric by design:
+
+```sh
+~/limen/infra/deploy/deploy.sh v0.3.9
+```
+
+**Schema caveat:** Flyway is forward-only. Rolling code back *under* an
+additive migration (new table, nullable column) is safe; rolling back past a
+destructive one (drop/rename) is not — old code meets a schema it doesn't
+understand. Destructive migrations therefore deserve extra release-time care;
+prefer expand/contract so the rollback property holds.
+
+## Rebuild from scratch
+
+The box is disposable; the only irreplaceable state is the Postgres volume
+(off-box backups are a follow-up PRD — until they ship, treat the box as
+precious after first real data).
+
+1. Provision a fresh box: [`vps-bootstrap.md`](vps-bootstrap.md), real IP in
+   the Ansible inventory, run the playbook.
+2. Ansible generates a new box age key — add its public half as a recipient
+   in `limen-secrets` (`sops updatekeys`), commit, push. The old box key is
+   dead; nothing to revoke beyond removing the recipient.
+3. Register the new box deploy key on the `limen-secrets` repo.
+4. `deploy.sh <current-release-tag>`.
+5. Restore the database when backups exist; until then, first boot re-seeds
+   the bootstrap admin from secrets.
+6. Update the DNS A record if the IP changed.
+
+## Verifying a graceful stop
+
+`docker compose stop limen` should exit the container with code **143**
+(SIGTERM handled, shutdown hooks ran — check for Tomcat's "Graceful shutdown
+complete" in the logs). **137** means the 40s `stop_grace_period` elapsed and
+Docker force-killed it. Exit 0 is *not* expected from a JVM container.

--- a/infra/deploy/README.md
+++ b/infra/deploy/README.md
@@ -1,10 +1,12 @@
 # Production deploy stack
 
 Box-side deploy layer for the Limen VPS (PRD #339): `compose.prod.yaml` +
-`Caddyfile`, consumed by `deploy.sh` (slice #342). `example.env` documents the
-environment contract; real values are sops-encrypted in the private
-`limen-secrets` repo. Provisioning lives in [`../ansible/`](../ansible/); the
-end-to-end walk-through is
+`Caddyfile` + `deploy.sh [--dry-run] <release-tag>`. `example.env` documents
+the environment contract; real values are sops-encrypted in the private
+`limen-secrets` repo. Provisioning lives in [`../ansible/`](../ansible/);
+operating procedures (deploy, rollback, rebuild) are in
+[`docs/process/deploy.md`](../../docs/process/deploy.md) and the box
+walk-through in
 [`docs/process/vps-bootstrap.md`](../../docs/process/vps-bootstrap.md).
 
 Validate locally without secrets:

--- a/infra/deploy/deploy.sh
+++ b/infra/deploy/deploy.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Operator-gated, box-side deploy for Limen (PRD #339, slice #342).
+#
+#   deploy.sh [--dry-run] <release-tag>     e.g. deploy.sh v0.4.0
+#
+# Checks out the release tag in this clone (pinning config, migrations, and
+# image version together), fast-forwards the secrets clone, decrypts the
+# production env via sops, pulls the pinned image, brings the stack up, and
+# waits on health. Rollback is the same command with the previous tag — but
+# mind Flyway's forward-only schema: rolling code back past a destructive
+# migration is not safe (see docs/process/deploy.md).
+#
+# Expects on the box: the limen clone (this file), the limen-secrets clone
+# (~/limen-secrets or $LIMEN_SECRETS_DIR), sops + the box age key at sops'
+# default age location, docker with the compose plugin, GHCR login.
+set -euo pipefail
+
+DRY_RUN=0
+
+usage() {
+  echo "usage: deploy.sh [--dry-run] <release-tag>   (tag form: vX.Y.Z)" >&2
+  exit 64
+}
+
+run() {
+  if ((DRY_RUN)); then
+    echo "[dry-run] $*"
+  else
+    "$@"
+  fi
+}
+
+main() {
+  local tag=""
+  while (($#)); do
+    case "$1" in
+      --dry-run) DRY_RUN=1 ;;
+      -*) usage ;;
+      *)
+        [[ -n "$tag" ]] && usage
+        tag="$1"
+        ;;
+    esac
+    shift
+  done
+  [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || usage
+  local version="${tag#v}"
+
+  local script_dir repo_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  repo_dir="$(git -C "$script_dir" rev-parse --show-toplevel)"
+  local secrets_dir="${LIMEN_SECRETS_DIR:-$HOME/limen-secrets}"
+
+  echo "==> Pinning release $tag"
+  run git -C "$repo_dir" fetch --tags origin
+  if ((!DRY_RUN)); then
+    git -C "$repo_dir" rev-parse -q --verify "refs/tags/$tag" >/dev/null \
+      || { echo "error: tag $tag not found after fetch" >&2; exit 1; }
+  fi
+  run git -C "$repo_dir" checkout -q --detach "refs/tags/$tag"
+
+  echo "==> Refreshing secrets clone"
+  run git -C "$secrets_dir" pull --ff-only
+
+  echo "==> Decrypting production env"
+  local env_file="(decrypted-env)" domain="<LIMEN_DOMAIN>"
+  if ((!DRY_RUN)); then
+    umask 077
+    env_file="$(mktemp)"
+    # shellcheck disable=SC2064 # expand env_file now, not at exit
+    trap "rm -f '$env_file'" EXIT
+    sops decrypt "$secrets_dir/prod.env" > "$env_file"
+    printf 'LIMEN_VERSION=%s\n' "$version" >> "$env_file"
+    domain="$(grep -E '^LIMEN_DOMAIN=' "$env_file" | cut -d= -f2-)"
+    [[ -n "$domain" ]] || { echo "error: LIMEN_DOMAIN missing from prod.env" >&2; exit 1; }
+  else
+    echo "[dry-run] sops decrypt $secrets_dir/prod.env; append LIMEN_VERSION=$version"
+  fi
+
+  local compose=(docker compose -f "$script_dir/compose.prod.yaml" --env-file "$env_file")
+
+  echo "==> Pulling image ghcr.io/stucray/limen:$version"
+  run "${compose[@]}" pull
+
+  echo "==> Starting stack"
+  run "${compose[@]}" up -d --remove-orphans
+
+  if ((DRY_RUN)); then
+    echo "[dry-run] wait for limen container health, then check https://$domain/actuator/health"
+    echo "[dry-run] done — no changes made"
+    return 0
+  fi
+
+  echo "==> Waiting for limen container health"
+  local cid state deadline=$((SECONDS + 180))
+  cid="$("${compose[@]}" ps -q limen)"
+  while :; do
+    state="$(docker inspect -f '{{.State.Health.Status}}' "$cid")"
+    [[ "$state" == "healthy" ]] && break
+    if ((SECONDS >= deadline)) || [[ "$state" == "unhealthy" ]]; then
+      echo "error: limen container is $state — recent logs:" >&2
+      "${compose[@]}" logs --tail=80 limen >&2
+      exit 1
+    fi
+    sleep 5
+  done
+
+  echo "==> Checking end-to-end health via the edge"
+  if ! curl -fsS --max-time 10 "https://$domain/actuator/health" | grep -q '"UP"'; then
+    echo "error: https://$domain/actuator/health not UP — recent logs:" >&2
+    "${compose[@]}" logs --tail=80 limen >&2
+    exit 1
+  fi
+
+  echo "==> Deployed $tag"
+  "${compose[@]}" ps
+}
+
+main "$@"
+# Explicit exit so a mid-run `git checkout` of this file can never affect the
+# already-running invocation past this point.
+exit


### PR DESCRIPTION
Slice 3 of PRD #339 — the operator-gated deploy path:

- `infra/deploy/deploy.sh [--dry-run] <release-tag>`: validates the tag form (usage exit 64 otherwise), fetches + checks out the tag (config/migrations/image pinned from one checkout), fast-forwards the secrets clone, sops-decrypts `prod.env` to a mode-600 tempfile removed on exit, appends the derived `LIMEN_VERSION`, `compose pull` + `up -d`, waits on the container healthcheck (bounded, 180s), then asserts `https://$LIMEN_DOMAIN/actuator/health` is UP through the edge; failures print the last 80 app-log lines and exit non-zero. `main`-wrapper + explicit `exit` guards against the checkout-while-running hazard (the script checks out the repo containing itself).
- `--dry-run` prints the full plan without side effects (demoed locally; output in the PR conversation if wanted).
- CI `deploy-config` job gains a shellcheck step; script is shellcheck-clean (0.11.0).
- `docs/process/deploy.md`: deploy, rollback with the Flyway forward-only caveat, rebuild-from-scratch, and the exit-143 graceful-stop check. README cross-links updated.

Closes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)